### PR TITLE
feat: add OAuth consent modal for GitHub & Google login

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -4,12 +4,14 @@ import { useState } from "react";
 import { createClient } from "@/lib/supabase/client";
 import Link from "next/link";
 import { Flame, Github, Mail, Lock } from "lucide-react";
+import OAuthConsentModal from "@/components/auth/oauth-consent-modal";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const [consentProvider, setConsentProvider] = useState<"github" | "google" | null>(null);
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -73,7 +75,7 @@ export default function LoginPage() {
       >
         <div className="space-y-3">
           <button
-            onClick={handleGitHubLogin}
+            onClick={() => setConsentProvider("github")}
             className="w-full flex items-center justify-center gap-2 px-5 py-3 text-sm font-extrabold uppercase tracking-wide text-white cursor-pointer transition-colors hover:bg-[#2a2a2a]"
             style={{
               backgroundColor: "#0F0F0F",
@@ -85,7 +87,7 @@ export default function LoginPage() {
           </button>
 
           <button
-            onClick={handleGoogleLogin}
+            onClick={() => setConsentProvider("google")}
             className="w-full flex items-center justify-center gap-2 px-5 py-3 text-sm font-extrabold uppercase tracking-wide text-[#0F0F0F] cursor-pointer transition-colors hover:bg-[#F5F5F5]"
             style={{
               backgroundColor: "#FFFFFF",
@@ -170,6 +172,18 @@ export default function LoginPage() {
           Sign Up
         </Link>
       </p>
+
+      {consentProvider && (
+        <OAuthConsentModal
+          provider={consentProvider}
+          onConfirm={() => {
+            if (consentProvider === "github") handleGitHubLogin();
+            else handleGoogleLogin();
+            setConsentProvider(null);
+          }}
+          onCancel={() => setConsentProvider(null)}
+        />
+      )}
     </div>
   );
 }

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { createClient } from "@/lib/supabase/client";
 import Link from "next/link";
 import { Flame, Github, Mail, Lock, User, Check } from "lucide-react";
+import OAuthConsentModal from "@/components/auth/oauth-consent-modal";
 
 export default function SignUpPage() {
   const [username, setUsername] = useState("");
@@ -12,6 +13,7 @@ export default function SignUpPage() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [success, setSuccess] = useState(false);
+  const [consentProvider, setConsentProvider] = useState<"github" | "google" | null>(null);
 
   const handleSignUp = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -114,7 +116,7 @@ export default function SignUpPage() {
       >
         <div className="space-y-3">
           <button
-            onClick={handleGitHubSignUp}
+            onClick={() => setConsentProvider("github")}
             className="w-full flex items-center justify-center gap-2 px-5 py-3 text-sm font-extrabold uppercase tracking-wide text-white cursor-pointer transition-colors hover:bg-[#2a2a2a]"
             style={{
               backgroundColor: "#0F0F0F",
@@ -126,7 +128,7 @@ export default function SignUpPage() {
           </button>
 
           <button
-            onClick={handleGoogleSignUp}
+            onClick={() => setConsentProvider("google")}
             className="w-full flex items-center justify-center gap-2 px-5 py-3 text-sm font-extrabold uppercase tracking-wide text-[#0F0F0F] cursor-pointer transition-colors hover:bg-[#F5F5F5]"
             style={{
               backgroundColor: "#FFFFFF",
@@ -229,6 +231,18 @@ export default function SignUpPage() {
           Sign In
         </Link>
       </p>
+
+      {consentProvider && (
+        <OAuthConsentModal
+          provider={consentProvider}
+          onConfirm={() => {
+            if (consentProvider === "github") handleGitHubSignUp();
+            else handleGoogleSignUp();
+            setConsentProvider(null);
+          }}
+          onCancel={() => setConsentProvider(null)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/auth/oauth-consent-modal.tsx
+++ b/src/components/auth/oauth-consent-modal.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { Github, Shield, User, Mail, BookOpen, X } from "lucide-react";
+
+type Provider = "github" | "google";
+
+interface OAuthConsentModalProps {
+  provider: Provider;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const providerConfig = {
+  github: {
+    name: "GitHub",
+    icon: <Github size={24} />,
+    color: "#0F0F0F",
+    permissions: [
+      { icon: <User size={18} />, label: "Profile information", detail: "Your name, username, and avatar" },
+      { icon: <Mail size={18} />, label: "Email address", detail: "Your primary email on GitHub" },
+      { icon: <BookOpen size={18} />, label: "Public repositories", detail: "Read-only access to your public repos" },
+    ],
+    privacyNote: "VibeTalent will never push code, create repos, or modify your GitHub account.",
+  },
+  google: {
+    name: "Google",
+    icon: (
+      <svg width="24" height="24" viewBox="0 0 24 24">
+        <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/>
+        <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+        <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
+        <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+      </svg>
+    ),
+    color: "#4285F4",
+    permissions: [
+      { icon: <User size={18} />, label: "Name and profile picture", detail: "Your display name and avatar" },
+      { icon: <Mail size={18} />, label: "Email address", detail: "Your Google email address" },
+    ],
+    privacyNote: "VibeTalent will never access your contacts, drive, or any other Google services.",
+  },
+};
+
+export default function OAuthConsentModal({ provider, onConfirm, onCancel }: OAuthConsentModalProps) {
+  const config = providerConfig[provider];
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/50" onClick={onCancel} />
+
+      {/* Modal */}
+      <div
+        className="relative w-full max-w-sm"
+        style={{
+          backgroundColor: "#FFFFFF",
+          border: "2px solid #0F0F0F",
+          boxShadow: "6px 6px 0px #0F0F0F",
+        }}
+      >
+        {/* Close button */}
+        <button
+          onClick={onCancel}
+          className="absolute top-3 right-3 p-1 text-[#71717A] hover:text-[#0F0F0F] cursor-pointer"
+        >
+          <X size={18} />
+        </button>
+
+        {/* Header */}
+        <div className="p-6 pb-4 text-center">
+          <div
+            className="inline-flex items-center justify-center w-12 h-12 mb-3"
+            style={{
+              backgroundColor: config.color,
+              border: "2px solid #0F0F0F",
+              boxShadow: "3px 3px 0px #0F0F0F",
+              color: "#FFFFFF",
+            }}
+          >
+            {config.icon}
+          </div>
+          <h2 className="text-lg font-extrabold uppercase text-[#0F0F0F]">
+            Sign in with {config.name}
+          </h2>
+          <p className="mt-1 text-xs font-medium text-[#71717A]">
+            VibeTalent will access the following from your {config.name} account
+          </p>
+        </div>
+
+        {/* Permissions list */}
+        <div className="px-6 space-y-0">
+          {config.permissions.map((perm, i) => (
+            <div
+              key={i}
+              className="flex items-start gap-3 py-3"
+              style={{ borderTop: i === 0 ? "2px solid #E4E4E7" : "1px solid #E4E4E7" }}
+            >
+              <div className="mt-0.5 text-[#52525B]">{perm.icon}</div>
+              <div>
+                <p className="text-sm font-bold text-[#0F0F0F]">{perm.label}</p>
+                <p className="text-xs text-[#71717A]">{perm.detail}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Privacy note */}
+        <div
+          className="mx-6 mt-4 p-3 flex items-start gap-2"
+          style={{
+            backgroundColor: "#F0FDF4",
+            border: "2px solid #0F0F0F",
+          }}
+        >
+          <Shield size={16} className="mt-0.5 text-[#16A34A] shrink-0" />
+          <p className="text-xs font-medium text-[#166534]">{config.privacyNote}</p>
+        </div>
+
+        {/* Actions */}
+        <div className="p-6 space-y-2">
+          <button
+            onClick={onConfirm}
+            className="w-full flex items-center justify-center px-5 py-3 text-sm font-extrabold uppercase tracking-wide text-white cursor-pointer transition-colors hover:opacity-90"
+            style={{
+              backgroundColor: config.color,
+              border: "2px solid #0F0F0F",
+            }}
+          >
+            Continue with {config.name}
+          </button>
+          <button
+            onClick={onCancel}
+            className="w-full flex items-center justify-center px-5 py-2.5 text-xs font-bold uppercase tracking-wide text-[#71717A] cursor-pointer hover:text-[#0F0F0F] transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/__tests__/agent-scoring.test.ts
+++ b/src/lib/__tests__/agent-scoring.test.ts
@@ -113,6 +113,42 @@ describe("evaluateUser", () => {
     expect(manyResult.dimensions.project_quality).toBeGreaterThan(fewResult.dimensions.project_quality);
   });
 
+  it("flags unverified projects as a risk", () => {
+    const user = createMockUser({
+      projects: [
+        {
+          id: "p-1", user_id: "user-1", title: "Fake", description: "Unverified project",
+          tech_stack: ["React"], live_url: null, github_url: null, image_url: null,
+          build_time: null, tags: [], verified: false, created_at: "2025-01-01T00:00:00Z",
+        },
+      ],
+    });
+    const result = evaluateUser(user);
+    expect(result.risks.some(r => r.includes("unverified") || r.includes("ownership"))).toBe(true);
+  });
+
+  it("gives higher project quality score to verified projects", () => {
+    const verifiedUser = createMockUser({
+      projects: Array.from({ length: 3 }, (_, i) => ({
+        id: `p-${i}`, user_id: "user-1", title: `Proj ${i}`,
+        description: "A well-documented project with comprehensive features",
+        tech_stack: ["React"], live_url: `https://p${i}.dev`, github_url: `https://github.com/t/p${i}`,
+        image_url: null, build_time: null, tags: [], verified: true, created_at: "2025-01-01T00:00:00Z",
+      })),
+    });
+    const unverifiedUser = createMockUser({
+      projects: Array.from({ length: 3 }, (_, i) => ({
+        id: `p-${i}`, user_id: "user-1", title: `Proj ${i}`,
+        description: "A well-documented project with comprehensive features",
+        tech_stack: ["React"], live_url: `https://p${i}.dev`, github_url: `https://github.com/t/p${i}`,
+        image_url: null, build_time: null, tags: [], verified: false, created_at: "2025-01-01T00:00:00Z",
+      })),
+    });
+    const vResult = evaluateUser(verifiedUser);
+    const uResult = evaluateUser(unverifiedUser);
+    expect(vResult.dimensions.project_quality).toBeGreaterThan(uResult.dimensions.project_quality);
+  });
+
   it("returns max 5 strengths and max 4 risks", () => {
     const user = createMockUser({
       streak: 200,

--- a/src/lib/__tests__/streak.test.ts
+++ b/src/lib/__tests__/streak.test.ts
@@ -134,9 +134,22 @@ describe("calculateVibeScore", () => {
     expect(calculateVibeScore(0, 0, "diamond")).toBe(40);
   });
 
-  it("combines all factors correctly", () => {
+  it("combines all factors correctly (backward compatible)", () => {
+    // Without verifiedCount: treats all as verified
     // 10*2 + 3*5 + 20 = 20 + 15 + 20 = 55
     expect(calculateVibeScore(10, 3, "silver")).toBe(55);
+  });
+
+  it("gives full points only to verified projects", () => {
+    // 0*2 + (2 verified * 5) + (1 unverified * 1) + 0 = 11
+    expect(calculateVibeScore(0, 3, "none", 2)).toBe(11);
+  });
+
+  it("penalizes all-unverified projects", () => {
+    // 0*2 + (0 verified * 5) + (5 unverified * 1) + 0 = 5
+    expect(calculateVibeScore(0, 5, "none", 0)).toBe(5);
+    // vs all verified: 0*2 + 5*5 + 0 = 25
+    expect(calculateVibeScore(0, 5, "none", 5)).toBe(25);
   });
 });
 

--- a/src/lib/agent-scoring.ts
+++ b/src/lib/agent-scoring.ts
@@ -11,15 +11,17 @@ function evaluateDimensions(user: UserWithSocials): EvaluationDimensions {
     (user.streak * 0.6 + user.longest_streak * 0.4) / 3.65 * 10
   );
 
-  // Project Quality: count, URLs, description length
-  const projCount = user.projects.length;
-  const withLiveUrl = user.projects.filter(p => p.live_url).length;
-  const withGithub = user.projects.filter(p => p.github_url).length;
-  const avgDescLen = projCount > 0
-    ? user.projects.reduce((sum, p) => sum + p.description.length, 0) / projCount
+  // Project Quality: verified projects weighted heavily, unverified penalized
+  const verifiedProjects = user.projects.filter(p => p.verified);
+  const unverifiedProjects = user.projects.filter(p => !p.verified);
+  const withLiveUrl = verifiedProjects.filter(p => p.live_url).length;
+  const withGithub = verifiedProjects.filter(p => p.github_url).length;
+  const avgDescLen = verifiedProjects.length > 0
+    ? verifiedProjects.reduce((sum, p) => sum + p.description.length, 0) / verifiedProjects.length
     : 0;
   const project_quality = clamp(0, 100,
-    projCount * 15 + withLiveUrl * 10 + withGithub * 5 + (avgDescLen > 50 ? 10 : 0)
+    verifiedProjects.length * 15 + unverifiedProjects.length * 2 +
+    withLiveUrl * 10 + withGithub * 5 + (avgDescLen > 50 ? 10 : 0)
   );
 
   // Tech Breadth: unique technologies
@@ -77,7 +79,9 @@ function extractStrengths(user: UserWithSocials, dims: EvaluationDimensions): st
   else if (user.streak > 30) strengths.push(`${user.streak}-day streak shows dedication`);
   if (user.badge_level === "diamond") strengths.push("Diamond badge holder — top tier");
   else if (user.badge_level === "gold") strengths.push("Gold badge — proven consistency");
-  if (user.projects.length >= 3) strengths.push(`${user.projects.length} shipped projects`);
+  const verifiedProjCount = user.projects.filter(p => p.verified).length;
+  if (verifiedProjCount >= 3) strengths.push(`${verifiedProjCount} verified shipped projects`);
+  else if (user.projects.length >= 3) strengths.push(`${user.projects.length} shipped projects`);
   if (dims.tech_breadth > 60) strengths.push("Diverse tech stack");
   if (user.projects.some(p => p.live_url)) strengths.push("Has live deployed projects");
   if (user.projects.some(p => p.github_url)) strengths.push("Open source contributor");
@@ -87,6 +91,10 @@ function extractStrengths(user: UserWithSocials, dims: EvaluationDimensions): st
 
 function extractRisks(user: UserWithSocials, dims: EvaluationDimensions): string[] {
   const risks: string[] = [];
+  const unverifiedCount = user.projects.filter(p => !p.verified).length;
+  const verifiedCount = user.projects.filter(p => p.verified).length;
+  if (unverifiedCount > 0 && verifiedCount === 0) risks.push("No verified projects — ownership unconfirmed");
+  else if (unverifiedCount > verifiedCount) risks.push(`${unverifiedCount} of ${user.projects.length} projects are unverified`);
   if (user.streak === 0) risks.push("Currently inactive — no active streak");
   if (user.projects.length < 2) risks.push("Limited project portfolio");
   if (!user.social_links?.telegram) risks.push("No Telegram for quick communication");

--- a/src/lib/streak.ts
+++ b/src/lib/streak.ts
@@ -63,15 +63,21 @@ export function calculateStreak(activityDates: string[]): {
 
 /**
  * Calculate vibe score based on streak and projects.
- * Formula: (Current Streak × 2) + (Projects Built × 5) + (Badge Bonus)
+ * Formula: (Current Streak × 2) + (Verified Projects × 5) + (Unverified × 1) + (Badge Bonus)
+ * Only verified projects get full points to prevent gaming with fake repos.
  */
 export function calculateVibeScore(
   currentStreak: number,
   projectCount: number,
-  badgeLevel: BadgeLevel
+  badgeLevel: BadgeLevel,
+  verifiedCount?: number
 ): number {
   const streakPoints = currentStreak * 2;
-  const projectPoints = projectCount * 5;
+
+  // Verified projects get full 5 points, unverified only get 1 point
+  const verified = verifiedCount ?? projectCount;
+  const unverified = projectCount - verified;
+  const projectPoints = verified * 5 + unverified * 1;
 
   const badgeBonusMap: Record<BadgeLevel, number> = {
     none: 0,


### PR DESCRIPTION
## Summary
- Adds a consent/permissions modal that appears when users click "Continue with GitHub" or "Continue with Google"
- Shows exactly what data VibeTalent will access (profile info, email, public repos)
- Includes a green security note reassuring users their accounts won't be modified
- Works on both login and signup pages

## Test plan
- [ ] Click "Continue with GitHub" on login page — verify consent modal appears
- [ ] Click "Continue with Google" on login page — verify consent modal appears
- [ ] Click "Cancel" — verify modal closes without redirecting
- [ ] Click "Continue" — verify OAuth flow proceeds normally
- [ ] Test same flows on signup page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OAuth consent modal for GitHub/Google sign-in and sign-up so users can review requested permissions before proceeding.
  * OAuth buttons now open the consent modal and start authentication only after confirmation.

* **Chores**
  * Updated scoring to weight verified projects more heavily and penalize unverified ones, affecting displayed project/risk summaries and overall vibe scores.

* **Tests**
  * Added unit tests covering verification-aware scoring and vibe calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->