### PR TITLE
fix: make report dropdown scrollable

### DIFF
--- a/src/components/ui/project-card.tsx
+++ b/src/components/ui/project-card.tsx
@@ -161,7 +161,7 @@ export function ProjectCard({ project, authorUsername, onEdit, showReport = true
                 </button>
               )}
               {reportOpen && (
-                <div className="absolute right-0 top-6 z-50 w-44 border-2 border-[#0F0F0F] bg-white shadow-[4px_4px_0_#0F0F0F]">
+                <div className="absolute right-0 top-6 z-50 w-44 max-h-48 overflow-y-auto border-2 border-[#0F0F0F] bg-white shadow-[4px_4px_0_#0F0F0F]">
                   {REPORT_REASONS.map((reason) => (
                     <button
                       key={reason}


### PR DESCRIPTION
## Summary
- Add `max-h-48` and `overflow-y-auto` to the project card report dropdown so it scrolls when content overflows

## Test plan
- [ ] Open a project card and click the report flag icon
- [ ] Verify the dropdown menu is scrollable when items exceed the max height

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved report dropdown layout to prevent excessive vertical expansion by adding a maximum height constraint with scrollable content when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->