### PR TITLE
fix: OAuth login, avatar fetch, review delete & dedup

### DIFF
--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -33,7 +33,7 @@ export async function GET(req: NextRequest) {
     const sb = getSb();
     const { data, error } = await sb
       .from("reviews")
-      .select("id, builder_id, reviewer_name, rating, comment, created_at")
+      .select("id, builder_id, reviewer_name, reviewer_email, rating, comment, created_at")
       .eq("builder_id", builderId)
       .order("created_at", { ascending: false });
 
@@ -55,6 +55,60 @@ export async function GET(req: NextRequest) {
     });
   } catch {
     return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { review_id, reviewer_email } = body;
+
+    if (!review_id || !reviewer_email) {
+      return NextResponse.json(
+        { error: "review_id and reviewer_email are required" },
+        { status: 400 }
+      );
+    }
+
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!uuidRegex.test(review_id)) {
+      return NextResponse.json({ error: "Invalid review_id" }, { status: 400 });
+    }
+
+    const emailClean = String(reviewer_email).trim().toLowerCase();
+    const sb = getSb();
+
+    // Verify the review exists and belongs to this email
+    const { data: review, error: fetchErr } = await sb
+      .from("reviews")
+      .select("id, reviewer_email")
+      .eq("id", review_id)
+      .single();
+
+    if (fetchErr || !review) {
+      return NextResponse.json({ error: "Review not found" }, { status: 404 });
+    }
+
+    if (review.reviewer_email !== emailClean) {
+      return NextResponse.json(
+        { error: "Email does not match. You can only delete your own review." },
+        { status: 403 }
+      );
+    }
+
+    const { error: deleteErr } = await sb
+      .from("reviews")
+      .delete()
+      .eq("id", review_id);
+
+    if (deleteErr) {
+      console.error("Failed to delete review:", deleteErr);
+      return NextResponse.json({ error: "Failed to delete review" }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
   }
 }
 
@@ -122,6 +176,21 @@ export async function POST(req: NextRequest) {
     }
 
     const sb = getSb();
+
+    // Prevent duplicate reviews: one review per email per builder
+    const { data: existingByEmail } = await sb
+      .from("reviews")
+      .select("id")
+      .eq("builder_id", builder_id)
+      .eq("reviewer_email", emailClean)
+      .maybeSingle();
+
+    if (existingByEmail) {
+      return NextResponse.json(
+        { error: "You have already reviewed this builder. Delete your existing review first to submit a new one." },
+        { status: 409 }
+      );
+    }
 
     // Validate hire_request_id if provided
     if (hire_request_id) {

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,5 +1,6 @@
+import { createServerClient } from "@supabase/ssr";
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { cookies } from "next/headers";
 
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
@@ -7,7 +8,30 @@ export async function GET(request: Request) {
   const next = searchParams.get("next") ?? "/dashboard";
 
   if (code) {
-    const supabase = await createServerSupabaseClient();
+    const cookieStore = await cookies();
+
+    // Build the redirect response first so cookies can be forwarded onto it
+    const redirectTo = `${origin}${next}`;
+    const forwardedResponse = NextResponse.redirect(redirectTo);
+
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          getAll() {
+            return cookieStore.getAll();
+          },
+          setAll(cookiesToSet) {
+            cookiesToSet.forEach(({ name, value, options }) => {
+              cookieStore.set(name, value, options);
+              forwardedResponse.cookies.set(name, value, options);
+            });
+          },
+        },
+      }
+    );
+
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
       // Pull avatar from OAuth provider if user doesn't have one
@@ -18,8 +42,6 @@ export async function GET(request: Request) {
           user.user_metadata?.picture ||
           null;
 
-        // Extract GitHub username from OAuth metadata
-        // GitHub provides this as user_name or preferred_username
         const githubUsername =
           user.user_metadata?.user_name ||
           user.user_metadata?.preferred_username ||
@@ -33,16 +55,12 @@ export async function GET(request: Request) {
           .single();
 
         if (profile) {
-          // Build update object with fields that need updating
           const updates: Record<string, string> = {};
 
           if (oauthAvatar && !(profile as Record<string, unknown>).avatar_url) {
             updates.avatar_url = oauthAvatar;
           }
 
-          // Always update github_username from OAuth metadata on login
-          // NOTE: If the `github_username` column doesn't exist yet, run:
-          // ALTER TABLE users ADD COLUMN IF NOT EXISTS github_username TEXT;
           if (githubUsername) {
             updates.github_username = githubUsername;
           }
@@ -57,7 +75,7 @@ export async function GET(request: Request) {
         }
       }
 
-      return NextResponse.redirect(`${origin}${next}`);
+      return forwardedResponse;
     }
   }
 

--- a/src/app/auth/profile-setup/page.tsx
+++ b/src/app/auth/profile-setup/page.tsx
@@ -49,6 +49,7 @@ export default function ProfileSetupPage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [userId, setUserId] = useState<string | null>(null);
+  const [oauthAvatarUrl, setOauthAvatarUrl] = useState<string | null>(null);
   const [streakLogged, setStreakLogged] = useState(false);
 
   // Step 1
@@ -86,6 +87,12 @@ export default function ProfileSetupPage() {
         return;
       }
       setUserId(user.id);
+      // Grab OAuth avatar from provider metadata
+      const avatar =
+        user.user_metadata?.avatar_url ||
+        user.user_metadata?.picture ||
+        null;
+      setOauthAvatarUrl(avatar);
     };
     checkAuth();
   }, [router]);
@@ -120,6 +127,7 @@ export default function ProfileSetupPage() {
           id: userId,
           username: profile.username,
           bio: profile.bio || null,
+          ...(oauthAvatarUrl ? { avatar_url: oauthAvatarUrl } : {}),
         },
         { onConflict: "id" }
       );

--- a/src/components/profile/reviews-section.tsx
+++ b/src/components/profile/reviews-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Star, MessageSquare, Send } from "lucide-react";
+import { Star, MessageSquare, Send, Trash2 } from "lucide-react";
 import type { Review } from "@/lib/types/database";
 
 interface ReviewsSectionProps {
@@ -96,6 +96,10 @@ export default function ReviewsSection({ builderId, isOwner = false }: ReviewsSe
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState("");
   const [submitSuccess, setSubmitSuccess] = useState(false);
+  const [deleteId, setDeleteId] = useState<string | null>(null);
+  const [deleteEmail, setDeleteEmail] = useState("");
+  const [deleteError, setDeleteError] = useState("");
+  const [deleting, setDeleting] = useState(false);
 
   useEffect(() => {
     async function loadReviews() {
@@ -165,6 +169,47 @@ export default function ReviewsSection({ builderId, isOwner = false }: ReviewsSe
       setSubmitError("Failed to submit review. Please try again.");
     } finally {
       setSubmitting(false);
+    }
+  };
+
+  const handleDeleteReview = async () => {
+    if (!deleteId || !deleteEmail.trim()) {
+      setDeleteError("Please enter your email to confirm deletion.");
+      return;
+    }
+
+    setDeleteError("");
+    setDeleting(true);
+
+    try {
+      const res = await fetch("/api/reviews", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          review_id: deleteId,
+          reviewer_email: deleteEmail.trim(),
+        }),
+      });
+
+      if (res.ok) {
+        setDeleteId(null);
+        setDeleteEmail("");
+
+        // Reload reviews
+        const reviewsRes = await fetch(`/api/reviews?builder_id=${builderId}`);
+        if (reviewsRes.ok) {
+          const data = await reviewsRes.json();
+          setReviews(data.reviews || []);
+          setAvgRating(data.average_rating || 0);
+        }
+      } else {
+        const data = await res.json();
+        setDeleteError(data.error || "Failed to delete review.");
+      }
+    } catch {
+      setDeleteError("Failed to delete review. Please try again.");
+    } finally {
+      setDeleting(false);
     }
   };
 
@@ -337,14 +382,60 @@ export default function ReviewsSection({ builderId, isOwner = false }: ReviewsSe
                   </span>
                   <StarRating rating={review.rating} size={14} />
                 </div>
-                <span className="text-zinc-400 text-xs font-mono">
-                  {timeAgo(review.created_at)}
-                </span>
+                <div className="flex items-center gap-2">
+                  <span className="text-zinc-400 text-xs font-mono">
+                    {timeAgo(review.created_at)}
+                  </span>
+                  {!isOwner && (
+                    <button
+                      onClick={() => { setDeleteId(review.id); setDeleteEmail(""); setDeleteError(""); }}
+                      className="text-zinc-400 hover:text-red-500 transition-colors"
+                      title="Delete your review"
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                  )}
+                </div>
               </div>
               {review.comment && (
                 <p className="text-zinc-600 text-sm leading-relaxed">
                   {review.comment}
                 </p>
+              )}
+              {deleteId === review.id && (
+                <div
+                  className="mt-3 p-3 space-y-2"
+                  style={{ backgroundColor: "#FEF2F2", border: "2px solid #0F0F0F" }}
+                >
+                  <p className="text-xs font-bold text-zinc-700">
+                    Enter the email you used when writing this review to confirm deletion:
+                  </p>
+                  <input
+                    type="email"
+                    value={deleteEmail}
+                    onChange={(e) => setDeleteEmail(e.target.value)}
+                    placeholder="your@email.com"
+                    className="input-brutal w-full text-sm"
+                  />
+                  {deleteError && (
+                    <p className="text-xs font-bold text-red-600">{deleteError}</p>
+                  )}
+                  <div className="flex gap-2">
+                    <button
+                      onClick={handleDeleteReview}
+                      disabled={deleting}
+                      className="btn-brutal text-xs py-1.5 px-3 bg-red-500 text-white hover:bg-red-600"
+                    >
+                      {deleting ? "Deleting..." : "Confirm Delete"}
+                    </button>
+                    <button
+                      onClick={() => { setDeleteId(null); setDeleteError(""); }}
+                      className="btn-brutal text-xs py-1.5 px-3"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
               )}
             </div>
           ))}


### PR DESCRIPTION
## Summary
- **Fix OAuth login race condition**: Callback route now forwards session cookies onto the redirect response, fixing "login failed but worked on refresh"
- **Fix GitHub avatar not loading**: Profile setup now pulls `avatar_url` from OAuth metadata and includes it in the user upsert
- **Review delete**: Users can delete their own reviews by confirming with the email they used
- **One review per user per builder**: Prevents duplicate reviews (checks by email + builder_id, returns 409 if already reviewed)

## Files changed
- `src/app/auth/callback/route.ts` — Rewrote to create Supabase client inline with cookie forwarding
- `src/app/auth/profile-setup/page.tsx` — Fetch OAuth avatar and include in user upsert
- `src/app/api/reviews/route.ts` — Added DELETE endpoint + duplicate check by email
- `src/components/profile/reviews-section.tsx` — Added delete button with email confirmation UI

## Test plan
- [x] Verified all pages load without console errors (explore, leaderboard, login, dashboard)
- [ ] Test GitHub OAuth login flow end-to-end (avatar should appear immediately)
- [ ] Test submitting a review, then trying to submit again (should get 409)
- [ ] Test deleting a review with correct and incorrect email

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Delete reviews with email verification confirmation
  * Prevent duplicate reviews from the same reviewer per builder
  * OAuth provider avatars now captured during profile setup

* **Refactor**
  * Improved authentication session handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->