### PR TITLE
fix: use service role key for review delete and avatar update

### DIFF
--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -16,6 +16,13 @@ function getSb() {
   );
 }
 
+function getAdminSb() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  );
+}
+
 export async function GET(req: NextRequest) {
   try {
     const { searchParams } = new URL(req.url);
@@ -33,7 +40,7 @@ export async function GET(req: NextRequest) {
     const sb = getSb();
     const { data, error } = await sb
       .from("reviews")
-      .select("id, builder_id, reviewer_name, reviewer_email, rating, comment, created_at")
+      .select("id, builder_id, reviewer_name, rating, comment, created_at")
       .eq("builder_id", builderId)
       .order("created_at", { ascending: false });
 
@@ -76,7 +83,7 @@ export async function DELETE(req: NextRequest) {
     }
 
     const emailClean = String(reviewer_email).trim().toLowerCase();
-    const sb = getSb();
+    const sb = getAdminSb();
 
     // Verify the review exists and belongs to this email
     const { data: review, error: fetchErr } = await sb

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,4 +1,5 @@
 import { createServerClient } from "@supabase/ssr";
+import { createClient } from "@supabase/supabase-js";
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 
@@ -47,8 +48,13 @@ export async function GET(request: Request) {
           user.user_metadata?.preferred_username ||
           null;
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const { data: profile } = await (supabase as any)
+        // Use service role client for DB operations to bypass RLS
+        const adminSb = createClient(
+          process.env.NEXT_PUBLIC_SUPABASE_URL!,
+          process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+        );
+
+        const { data: profile } = await adminSb
           .from("users")
           .select("avatar_url, github_username")
           .eq("id", user.id)
@@ -57,7 +63,7 @@ export async function GET(request: Request) {
         if (profile) {
           const updates: Record<string, string> = {};
 
-          if (oauthAvatar && !(profile as Record<string, unknown>).avatar_url) {
+          if (oauthAvatar && !profile.avatar_url) {
             updates.avatar_url = oauthAvatar;
           }
 
@@ -66,8 +72,7 @@ export async function GET(request: Request) {
           }
 
           if (Object.keys(updates).length > 0) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            await (supabase as any)
+            await adminSb
               .from("users")
               .update(updates)
               .eq("id", user.id);


### PR DESCRIPTION
## Summary
- **Review delete silently failing**: RLS has no DELETE policy on `reviews` table — anon key can't delete. Now uses service role client after email ownership verification.
- **Avatar update failing for existing users**: Callback was using anon key for DB update which couldn't reliably bypass RLS. Now uses service role client.
- **Removed `reviewer_email` from GET response** to stop leaking PII to all visitors.

## Required
Add `SUPABASE_SERVICE_ROLE_KEY` to environment variables (Vercel + local .env.local). Find it in Supabase Dashboard > Settings > API > service_role (secret).

## Test plan
- [ ] Add service role key to env, then test deleting an existing review
- [ ] Log in with GitHub as existing avatarless user — avatar should appear
- [x] Verified no console errors on all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced security for review operations and authentication callbacks
  * Refined data returned from reviews endpoint to improve privacy
  * Strengthened database access controls for administrative operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->