### PR TITLE
fix: always sync OAuth avatar on login

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -63,7 +63,8 @@ export async function GET(request: Request) {
         if (profile) {
           const updates: Record<string, string> = {};
 
-          if (oauthAvatar && !profile.avatar_url) {
+          // Always sync avatar from OAuth provider on login
+          if (oauthAvatar) {
             updates.avatar_url = oauthAvatar;
           }
 


### PR DESCRIPTION
## Summary
- Removed the `!profile.avatar_url` guard in the OAuth callback
- Now **always** updates `avatar_url` from GitHub/Google on every login
- Fixes: existing users who logged in via GitHub/Google still showing letter avatars instead of their profile picture

## Why it wasn't working before
The old code only set `avatar_url` if it was empty. But for existing users, the update was also silently failing due to RLS (fixed in #13). Even after #13, the condition `!profile.avatar_url` would skip users who somehow had any value set. Now it always syncs.

## Test plan
- [ ] Log in with GitHub — avatar should appear on dashboard and profile
- [ ] Log in with Google — avatar should appear on dashboard and profile
- [ ] Change GitHub profile picture, log in again — new picture should sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)