### PR TITLE
fix: use verified domain for Resend emails

### DIFF
--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -50,7 +50,7 @@ export async function sendHireNotification({
 
   try {
     await client.emails.send({
-      from: "VibeTalent <notifications@vibetalent.dev>",
+      from: "VibeTalent <notifications@vibetalent.work>",
       to: builderEmail,
       subject: `New hire request from ${senderName} | VibeTalent`,
       html: `
@@ -112,7 +112,7 @@ export async function sendStreakMilestoneEmail({
 
   try {
     await client.emails.send({
-      from: "VibeTalent <notifications@vibetalent.dev>",
+      from: "VibeTalent <notifications@vibetalent.work>",
       to: email,
       subject: `You hit a ${streakDays}-day streak! | VibeTalent`,
       html: `
@@ -164,7 +164,7 @@ export async function sendBadgeEarnedEmail({
 
   try {
     await client.emails.send({
-      from: "VibeTalent <notifications@vibetalent.dev>",
+      from: "VibeTalent <notifications@vibetalent.work>",
       to: email,
       subject: `You earned a ${badgeLevel} badge! | VibeTalent`,
       html: `
@@ -215,7 +215,7 @@ export async function sendProjectVerifiedEmail({
 
   try {
     await client.emails.send({
-      from: "VibeTalent <notifications@vibetalent.dev>",
+      from: "VibeTalent <notifications@vibetalent.work>",
       to: email,
       subject: `Your project "${projectTitle}" is verified! | VibeTalent`,
       html: `
@@ -268,7 +268,7 @@ export async function sendStreakWarningEmail({
 
   try {
     await client.emails.send({
-      from: "VibeTalent <notifications@vibetalent.dev>",
+      from: "VibeTalent <notifications@vibetalent.work>",
       to: email,
       subject: `Your ${streakDays}-day streak is about to end! | VibeTalent`,
       html: `


### PR DESCRIPTION
## Summary
- All 5 email functions (`sendHireNotification`, `sendStreakMilestoneEmail`, `sendBadgeEarnedEmail`, `sendProjectVerifiedEmail`, `sendStreakWarningEmail`) were sending from `@vibetalent.dev` but only `vibetalent.work` is verified in Resend
- Every email silently failed with a 403 error — the fire-and-forget pattern hid the failures
- Updated all `from` addresses to `notifications@vibetalent.work`

## Test plan
- [x] Verified domain status via Resend API — `vibetalent.work` is verified
- [x] Sent test email to `cryptoabhi234@gmail.com` — delivered successfully
- [x] Confirmed `last_event: "delivered"` via Resend email status API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated the sender address for notification emails — all automated notifications (hire, streak milestones/warnings, badge earned, project verification) will now come from notifications@vibetalent.work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->