### PR TITLE
feat: notify builders on new reviews (in-app + email)

### DIFF
--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import { reviewLimiter, getIP, checkRateLimit } from "@/lib/rate-limit";
+import { createNotification } from "@/lib/notifications";
+import { sendReviewNotificationEmail } from "@/lib/email";
 
 const BLOCKED_DOMAINS = [
   "mailinator.com", "tempmail.com", "throwaway.email", "guerrillamail.com",
@@ -254,6 +256,36 @@ export async function POST(req: NextRequest) {
       console.error("Failed to insert review:", error);
       return NextResponse.json({ error: "Failed to submit review" }, { status: 500 });
     }
+
+    // Fire-and-forget: in-app notification for the builder
+    createNotification({
+      user_id: builder_id,
+      type: "new_review",
+      title: "New review received",
+      message: `${nameClean} left you a ${ratingNum}-star review`,
+      metadata: { review_id: data.id, reviewer_name: nameClean, rating: ratingNum },
+    }).catch(console.error);
+
+    // Fire-and-forget: email notification to the builder
+    const adminSb = getAdminSb();
+    adminSb.auth.admin.getUserById(builder_id).then(({ data: userData }) => {
+      if (userData?.user?.email) {
+        adminSb
+          .from("users")
+          .select("username")
+          .eq("id", builder_id)
+          .single()
+          .then(({ data: builderData }) => {
+            sendReviewNotificationEmail({
+              email: userData.user!.email!,
+              username: builderData?.username || "builder",
+              reviewerName: nameClean,
+              rating: ratingNum,
+              comment: commentClean,
+            }).catch(console.error);
+          });
+      }
+    }).catch(console.error);
 
     return NextResponse.json({ success: true, id: data.id });
   } catch {

--- a/src/components/ui/notification-bell.tsx
+++ b/src/components/ui/notification-bell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import { Bell, Flame, Trophy, CheckCircle, AlertTriangle, Mail } from "lucide-react";
+import { Bell, Flame, Trophy, CheckCircle, AlertTriangle, Mail, Star } from "lucide-react";
 import { useRouter } from "next/navigation";
 import type { Notification } from "@/lib/types/database";
 
@@ -12,6 +12,7 @@ const typeIcons: Record<string, typeof Bell> = {
   badge_earned: Trophy,
   project_verified: CheckCircle,
   project_flagged: AlertTriangle,
+  new_review: Star,
 };
 
 const typeColors: Record<string, string> = {
@@ -21,6 +22,7 @@ const typeColors: Record<string, string> = {
   badge_earned: "#8B5CF6",
   project_verified: "#10B981",
   project_flagged: "#EF4444",
+  new_review: "#F59E0B",
 };
 
 function timeAgo(dateStr: string): string {

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -299,3 +299,70 @@ export async function sendStreakWarningEmail({
     console.error("Failed to send streak warning email:", error);
   }
 }
+
+/**
+ * Send an email when a builder receives a new review. Fire-and-forget.
+ */
+export async function sendReviewNotificationEmail({
+  email,
+  username,
+  reviewerName,
+  rating,
+  comment,
+}: {
+  email: string;
+  username: string;
+  reviewerName: string;
+  rating: number;
+  comment: string | null;
+}): Promise<void> {
+  const client = getResend();
+  if (!client) return;
+
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://vibetalent.dev";
+  const safeReviewer = escapeHtml(reviewerName);
+  const safeComment = comment ? escapeHtml(comment.slice(0, 200)) : null;
+  const stars = "★".repeat(rating) + "☆".repeat(5 - rating);
+
+  try {
+    await client.emails.send({
+      from: "VibeTalent <notifications@vibetalent.work>",
+      to: email,
+      subject: `New ${rating}-star review from ${reviewerName} | VibeTalent`,
+      html: `
+        <div style="font-family: 'Space Grotesk', Arial, sans-serif; max-width: 600px; margin: 0 auto; border: 2px solid #0F0F0F; background: #FFFFFF;">
+          <div style="background: #0F0F0F; color: #FFFFFF; padding: 24px 32px;">
+            <h1 style="margin: 0; font-size: 20px; font-weight: 800;">⚡ VibeTalent</h1>
+          </div>
+          <div style="padding: 32px;">
+            <h2 style="color: #0F0F0F; font-size: 24px; font-weight: 700; margin: 0 0 16px;">
+              ⭐ New Review
+            </h2>
+            <p style="color: #52525B; font-size: 16px; line-height: 1.6; margin: 0 0 24px;">
+              Hey <strong>@${escapeHtml(username)}</strong>, you received a new review!
+            </p>
+            <div style="border: 2px solid #0F0F0F; padding: 20px; margin: 0 0 24px;">
+              <p style="color: #F59E0B; font-size: 20px; margin: 0 0 8px; letter-spacing: 2px;">
+                ${stars}
+              </p>
+              <p style="color: #0F0F0F; font-size: 14px; margin: 0 0 8px;">
+                <strong>From:</strong> ${safeReviewer}
+              </p>
+              ${safeComment ? `<p style="color: #52525B; font-size: 14px; line-height: 1.5; margin: 0;">"${safeComment}${(comment?.length || 0) > 200 ? "..." : ""}"</p>` : ""}
+            </div>
+            <a href="${siteUrl}/dashboard" style="display: inline-block; background: #FF3A00; color: #FFFFFF; padding: 12px 24px; text-decoration: none; font-weight: 700; font-size: 14px; border: 2px solid #0F0F0F; box-shadow: 4px 4px 0 #0F0F0F;">
+              View Dashboard
+            </a>
+          </div>
+          <div style="background: #F4F4F5; padding: 16px 32px; border-top: 2px solid #0F0F0F;">
+            <p style="color: #71717A; font-size: 12px; margin: 0;">
+              You received this because someone reviewed you on VibeTalent.
+            </p>
+          </div>
+        </div>
+      `,
+    });
+  } catch (error) {
+    console.error("Failed to send review notification email:", error);
+  }
+}

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -81,7 +81,7 @@ export interface Review {
   created_at: string;
 }
 
-export type NotificationType = "hire_request" | "streak_milestone" | "streak_warning" | "badge_earned" | "project_verified" | "project_flagged";
+export type NotificationType = "hire_request" | "streak_milestone" | "streak_warning" | "badge_earned" | "project_verified" | "project_flagged" | "new_review";
 
 export interface Notification {
   id: string;


### PR DESCRIPTION
## Summary
- Builders now receive an **in-app notification** (⭐ star icon, amber color) when someone leaves a review
- Builders also receive an **email** with the reviewer name, star rating, and comment preview
- Added `new_review` notification type to the type system and notification bell UI

## Changes
- `src/app/api/reviews/route.ts` — fire-and-forget in-app + email notification after review insert
- `src/lib/email.ts` — new `sendReviewNotificationEmail()` function with branded HTML template
- `src/lib/types/database.ts` — added `new_review` to `NotificationType`
- `src/components/ui/notification-bell.tsx` — added Star icon and amber color for review notifications

## Test plan
- [ ] Submit a review on a builder's profile
- [ ] Verify in-app notification appears in bell dropdown
- [ ] Verify email arrives with correct rating, reviewer name, and comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notifications for new reviews: Builders now receive in-app alerts and email notifications when they receive reviews.
  * Review notifications include reviewer name, rating, and comments.
  * New review notifications display with a star icon in the notification center.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->