### PR TITLE
fix: correct domain to vibetalent.work in docs

### DIFF
--- a/docs/builders/getting-started.md
+++ b/docs/builders/getting-started.md
@@ -10,7 +10,7 @@ Instead of writing a resume, you build a track record that proves itself.
 
 ## Step 1: Sign Up
 
-Head to [vibetalent.dev](https://vibetalent.dev) and click **Create Profile**.
+Head to [vibetalent.work](https://vibetalent.work) and click **Create Profile**.
 
 You can sign up with:
 
@@ -25,7 +25,7 @@ Once you're in, head to your **Dashboard** and fill out your profile:
 
 | Field | Why It Matters |
 |---|---|
-| **Username** | This is your public handle — it appears in your profile URL (`vibetalent.dev/profile/you`) |
+| **Username** | This is your public handle — it appears in your profile URL (`vibetalent.work/profile/you`) |
 | **Bio** | A short description of who you are and what you build. Clients read this first. |
 | **Avatar** | A profile photo makes you look real and trustworthy |
 | **Social Links** | Connect your Twitter, GitHub, Telegram, website, and Farcaster so clients can reach you |

--- a/docs/developers/api-reference.md
+++ b/docs/developers/api-reference.md
@@ -7,7 +7,7 @@ VibeTalent exposes two sets of APIs:
 
 ## Public API (v1)
 
-Base URL: `https://vibetalent.dev/api/v1`
+Base URL: `https://vibetalent.work/api/v1`
 
 All v1 endpoints include CORS headers and return JSON. No authentication required.
 


### PR DESCRIPTION
## Summary
- Fixed 3 occurrences of `vibetalent.dev` → `vibetalent.work` in docs
- Affected files: `docs/builders/getting-started.md`, `docs/developers/api-reference.md`

## Test plan
- [x] Grep confirms no remaining `vibetalent.dev` references in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation references to use the new `vibetalent.work` domain for API endpoints and profile URLs, replacing `vibetalent.dev`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->