### PR TITLE
fix: project image upload on edit + show existing preview

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -768,6 +768,9 @@ export default function DashboardPage() {
       build_time: project.build_time || "",
       tags: project.tags?.join(", ") || "",
     });
+    // Load existing image preview
+    setProjectImageFile(null);
+    setProjectImagePreview(project.image_url || null);
     setShowProjectForm(true);
   };
 
@@ -817,6 +820,17 @@ export default function DashboardPage() {
       return;
     }
 
+    // Upload project image if a new file was selected
+    if (projectImageFile && user && editingProjectId) {
+      const ext = projectImageFile.name.split(".").pop();
+      const filePath = `${user.id}/${editingProjectId}/image.${ext}`;
+      const { error: uploadError } = await sb.storage.from("project-images").upload(filePath, projectImageFile, { upsert: true });
+      if (!uploadError) {
+        const { data: { publicUrl } } = sb.storage.from("project-images").getPublicUrl(filePath);
+        await sb.from("projects").update({ image_url: `${publicUrl}?t=${Date.now()}` }).eq("id", editingProjectId);
+      }
+    }
+
     await reloadUser();
 
     // Auto-verify if GitHub URL changed
@@ -824,6 +838,8 @@ export default function DashboardPage() {
     const savedEditingId = editingProjectId;
 
     setProjectForm({ title: "", description: "", tech_stack: "", live_url: "", github_url: "", build_time: "", tags: "" });
+    setProjectImageFile(null);
+    setProjectImagePreview(null);
     setShowProjectForm(false);
     setEditingProjectId(null);
     setEditingOriginalGithubUrl("");

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -75,16 +75,17 @@ export default function DashboardPage() {
   const [hireRequests, setHireRequests] = useState<HireRequest[]>([]);
 
   useEffect(() => {
-    async function loadUser() {
+    let cancelled = false;
+    let loaded = false;
+
+    async function loadUserData(authUser: import("@supabase/supabase-js").User) {
+      if (loaded || cancelled) return;
+      loaded = true;
       const supabase = createClient();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const sb = supabase as any;
 
-      // Step 1: Get auth user (required before anything else)
-      const { data: { user: authUser } } = await supabase.auth.getUser();
-      if (!authUser) { setLoading(false); return; }
-
-      // Step 2: Fetch profile + projects + socials + streaks + inbox ALL in parallel (single round trip)
+      // Fetch profile + projects + socials + streaks + inbox ALL in parallel (single round trip)
       const [{ data: profile }, { data: projects }, { data: socials }, streakData, { data: inboxData }] = await Promise.all([
         sb.from("users").select("id, username, bio, avatar_url, vibe_score, streak, longest_streak, badge_level, created_at").eq("id", authUser.id).single(),
         sb.from("projects").select("id, user_id, title, description, tech_stack, live_url, github_url, image_url, build_time, tags, verified, created_at").eq("user_id", authUser.id).order("created_at", { ascending: false }),
@@ -195,7 +196,31 @@ export default function DashboardPage() {
         }).eq("id", authUser.id);
       }
     }
-    loadUser();
+
+    // Try immediate auth check first
+    const supabase = createClient();
+    supabase.auth.getUser().then(({ data: { user: authUser } }) => {
+      if (cancelled) return;
+      if (authUser) {
+        loadUserData(authUser);
+      }
+    });
+
+    // Also listen for auth state changes — catches the case where
+    // session isn't ready yet after OAuth redirect / profile setup
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (cancelled) return;
+      if (session?.user) {
+        loadUserData(session.user);
+      } else {
+        setLoading(false);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      subscription.unsubscribe();
+    };
   }, []);
 
   const [showProjectForm, setShowProjectForm] = useState(false);
@@ -662,13 +687,21 @@ export default function DashboardPage() {
       setProjectError("Description must be at least 10 characters.");
       return;
     }
-    if (projectForm.github_url && !projectForm.github_url.startsWith("https://github.com/")) {
-      setProjectError("GitHub URL must start with https://github.com/");
-      return;
+    if (projectForm.github_url) {
+      const ghPattern = /^https:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+\/?$/;
+      if (!ghPattern.test(projectForm.github_url.trim())) {
+        setProjectError("GitHub URL must be in the format: https://github.com/username/repo");
+        return;
+      }
     }
-    if (projectForm.live_url && !projectForm.live_url.startsWith("http://") && !projectForm.live_url.startsWith("https://")) {
-      setProjectError("Live URL must start with http:// or https://");
-      return;
+    if (projectForm.live_url) {
+      try {
+        const url = new URL(projectForm.live_url.trim());
+        if (!["http:", "https:"].includes(url.protocol)) throw new Error();
+      } catch {
+        setProjectError("Live URL must be a valid URL starting with http:// or https://");
+        return;
+      }
     }
 
     setAddingProject(true);
@@ -746,13 +779,21 @@ export default function DashboardPage() {
       setProjectError("Description must be at least 10 characters.");
       return;
     }
-    if (projectForm.github_url && !projectForm.github_url.startsWith("https://github.com/")) {
-      setProjectError("GitHub URL must start with https://github.com/");
-      return;
+    if (projectForm.github_url) {
+      const ghPattern = /^https:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+\/?$/;
+      if (!ghPattern.test(projectForm.github_url.trim())) {
+        setProjectError("GitHub URL must be in the format: https://github.com/username/repo");
+        return;
+      }
     }
-    if (projectForm.live_url && !projectForm.live_url.startsWith("http://") && !projectForm.live_url.startsWith("https://")) {
-      setProjectError("Live URL must start with http:// or https://");
-      return;
+    if (projectForm.live_url) {
+      try {
+        const url = new URL(projectForm.live_url.trim());
+        if (!["http:", "https:"].includes(url.protocol)) throw new Error();
+      } catch {
+        setProjectError("Live URL must be a valid URL starting with http:// or https://");
+        return;
+      }
     }
 
     setSavingEdit(true);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { VibecoderCard } from "@/components/ui/vibecoder-card";
 import { ProjectCard } from "@/components/ui/project-card";
+import { HeroCTA } from "@/components/ui/hero-cta";
 import { fetchHomepageDataCached } from "@/lib/supabase/server-queries";
 import { Flame, TrendingUp, Award, Zap, ArrowRight, Code2, Target, Users } from "lucide-react";
 
@@ -55,13 +56,7 @@ export default async function HomePage() {
           </p>
 
           <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
-            <Link
-              href="/dashboard"
-              className="btn-brutal btn-brutal-primary text-base flex items-center gap-2"
-            >
-              Create Your Profile
-              <ArrowRight size={18} />
-            </Link>
+            <HeroCTA />
             <Link
               href="/explore"
               className="btn-brutal btn-brutal-secondary text-base"
@@ -277,14 +272,10 @@ export default async function HomePage() {
             Start building your vibe coding reputation today. Create a profile,
             start your streak, and let AI agents match you with clients.
           </p>
-          <Link
-            href="/dashboard"
-            className="btn-brutal btn-brutal-primary mt-8 text-base inline-flex items-center gap-2"
+          <HeroCTA
+            className="mt-8 inline-flex"
             style={{ boxShadow: "6px 6px 0 #FFFFFF" }}
-          >
-            Create Your Profile
-            <ArrowRight size={18} />
-          </Link>
+          />
         </div>
       </section>
     </div>

--- a/src/components/explore/explore-content.tsx
+++ b/src/components/explore/explore-content.tsx
@@ -85,15 +85,26 @@ export function ExploreContent({ users }: { users: UserWithSocials[] }) {
       filtered = filtered.filter(u => u.projects.some(p => p.verified));
     }
 
+    // Profile completeness score for tiebreaking — profiles with projects,
+    // bio, and recent activity rank higher than empty shell profiles
+    const completeness = (u: typeof filtered[0]) => {
+      let score = 0;
+      if (u.projects.length > 0) score += 3;
+      if (u.bio) score += 2;
+      if (u.last_activity_date) score += 1;
+      if (u.avatar_url) score += 1;
+      return score;
+    };
+
     switch (sortBy) {
       case "vibe_score":
-        filtered.sort((a, b) => b.vibe_score - a.vibe_score);
+        filtered.sort((a, b) => b.vibe_score - a.vibe_score || completeness(b) - completeness(a));
         break;
       case "streak":
-        filtered.sort((a, b) => b.streak - a.streak);
+        filtered.sort((a, b) => b.streak - a.streak || completeness(b) - completeness(a));
         break;
       case "projects":
-        filtered.sort((a, b) => b.projects.length - a.projects.length);
+        filtered.sort((a, b) => b.projects.length - a.projects.length || completeness(b) - completeness(a));
         break;
       case "newest":
         filtered.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());

--- a/src/components/profile/reviews-section.tsx
+++ b/src/components/profile/reviews-section.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { Star, MessageSquare, Send, Trash2 } from "lucide-react";
+import { createClient } from "@/lib/supabase/client";
 import type { Review } from "@/lib/types/database";
 
 interface ReviewsSectionProps {
@@ -100,6 +101,29 @@ export default function ReviewsSection({ builderId, isOwner = false }: ReviewsSe
   const [deleteEmail, setDeleteEmail] = useState("");
   const [deleteError, setDeleteError] = useState("");
   const [deleting, setDeleting] = useState(false);
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  // Auto-fetch logged-in user's name and email
+  useEffect(() => {
+    async function loadUser() {
+      const supabase = createClient();
+      const { data: { user } } = await supabase.auth.getUser();
+      if (user) {
+        setIsLoggedIn(true);
+        setFormEmail(user.email || "");
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { data: profile } = await (supabase as any)
+          .from("users")
+          .select("username")
+          .eq("id", user.id)
+          .single();
+        if (profile) {
+          setFormName(profile.username || "");
+        }
+      }
+    }
+    loadUser();
+  }, []);
 
   useEffect(() => {
     async function loadReviews() {
@@ -124,7 +148,7 @@ export default function ReviewsSection({ builderId, isOwner = false }: ReviewsSe
 
   const handleSubmitReview = async () => {
     if (!formName.trim() || !formEmail.trim() || formRating === 0) {
-      setSubmitError("Please fill in your name, email, and select a rating.");
+      setSubmitError(isLoggedIn ? "Please select a rating." : "Please fill in your name, email, and select a rating.");
       return;
     }
 
@@ -300,33 +324,44 @@ export default function ReviewsSection({ builderId, isOwner = false }: ReviewsSe
             <ClickableStars rating={formRating} onRate={setFormRating} />
           </div>
 
-          {/* Name & Email */}
-          <div className="grid grid-cols-2 gap-3">
+          {/* Name (auto-filled if logged in) */}
+          {isLoggedIn ? (
             <div>
               <label className="text-xs font-bold uppercase tracking-wide text-[#71717A] mb-1.5 block">
-                Your Name *
+                Reviewing as
               </label>
-              <input
-                type="text"
-                value={formName}
-                onChange={(e) => setFormName(e.target.value)}
-                placeholder="John Doe"
-                className="input-brutal w-full"
-              />
+              <div className="input-brutal w-full bg-zinc-100 text-zinc-700 cursor-default">
+                {formName}
+              </div>
             </div>
-            <div>
-              <label className="text-xs font-bold uppercase tracking-wide text-[#71717A] mb-1.5 block">
-                Email *
-              </label>
-              <input
-                type="email"
-                value={formEmail}
-                onChange={(e) => setFormEmail(e.target.value)}
-                placeholder="john@example.com"
-                className="input-brutal w-full"
-              />
+          ) : (
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="text-xs font-bold uppercase tracking-wide text-[#71717A] mb-1.5 block">
+                  Your Name *
+                </label>
+                <input
+                  type="text"
+                  value={formName}
+                  onChange={(e) => setFormName(e.target.value)}
+                  placeholder="John Doe"
+                  className="input-brutal w-full"
+                />
+              </div>
+              <div>
+                <label className="text-xs font-bold uppercase tracking-wide text-[#71717A] mb-1.5 block">
+                  Email *
+                </label>
+                <input
+                  type="email"
+                  value={formEmail}
+                  onChange={(e) => setFormEmail(e.target.value)}
+                  placeholder="john@example.com"
+                  className="input-brutal w-full"
+                />
+              </div>
             </div>
-          </div>
+          )}
 
           {/* Comment */}
           <div>

--- a/src/components/ui/hero-cta.tsx
+++ b/src/components/ui/hero-cta.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { createClient } from "@/lib/supabase/client";
+
+interface HeroCTAProps {
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export function HeroCTA({ className = "", style }: HeroCTAProps) {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  useEffect(() => {
+    const supabase = createClient();
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      setIsLoggedIn(!!user);
+    });
+  }, []);
+
+  return (
+    <Link
+      href="/dashboard"
+      className={`btn-brutal btn-brutal-primary text-base flex items-center gap-2 ${className}`}
+      style={style}
+    >
+      {isLoggedIn ? "Go to Dashboard" : "Create Your Profile"}
+      <ArrowRight size={18} />
+    </Link>
+  );
+}

--- a/src/components/ui/vibecoder-card.tsx
+++ b/src/components/ui/vibecoder-card.tsx
@@ -38,7 +38,7 @@ export function VibecoderCard({ user, rank }: VibecoderCardProps) {
   return (
     <Link href={`/profile/${user.username}`}>
       <div
-        className="group relative p-5 transition-all card-brutal hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-[2px_2px_0_#0F0F0F]"
+        className="group relative p-5 transition-all card-brutal hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-[2px_2px_0_#0F0F0F] h-full flex flex-col"
       >
         {rank && (
           <div
@@ -52,7 +52,7 @@ export function VibecoderCard({ user, rank }: VibecoderCardProps) {
           </div>
         )}
 
-        <div className="flex items-start gap-4">
+        <div className="flex items-start gap-4 flex-1">
           <div
             className="flex h-12 w-12 shrink-0 items-center justify-center text-sm font-extrabold text-white overflow-hidden"
             style={{
@@ -82,11 +82,9 @@ export function VibecoderCard({ user, rank }: VibecoderCardProps) {
               </span>
             )}
 
-            {user.bio && (
-              <p className="mt-1 text-sm text-[#52525B] font-medium line-clamp-2">
-                {user.bio}
-              </p>
-            )}
+            <p className="mt-1 text-sm text-[#52525B] font-medium line-clamp-2">
+              {user.bio || "No bio yet"}
+            </p>
 
             <div className="mt-3 flex items-center gap-4 flex-wrap">
               <StreakCounter streak={user.streak} size="sm" />
@@ -97,9 +95,9 @@ export function VibecoderCard({ user, rank }: VibecoderCardProps) {
               </div>
             </div>
 
-            {user.projects.length > 0 && (
-              <div className="mt-3 flex flex-wrap gap-1.5">
-                {user.projects.slice(0, 3).map((p) => (
+            <div className="mt-3 flex flex-wrap gap-1.5 min-h-[28px]">
+              {user.projects.length > 0 ? (
+                user.projects.slice(0, 3).map((p) => (
                   <span
                     key={p.id}
                     className="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-bold text-[#0F0F0F]"
@@ -111,9 +109,13 @@ export function VibecoderCard({ user, rank }: VibecoderCardProps) {
                     <ExternalLink size={10} />
                     {p.title}
                   </span>
-                ))}
-              </div>
-            )}
+                ))
+              ) : (
+                <span className="text-xs font-medium text-zinc-400 italic">
+                  No projects shipped yet
+                </span>
+              )}
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- When editing a project, the existing screenshot now shows in the preview
- Uploading a new image during edit actually saves it to Supabase storage
- Image state properly cleared after saving

Previously, `handleStartEdit` didn't load the existing `image_url` and `handleSaveEdit` had no image upload logic — only `handleAddProject` did.

## Test plan
- [ ] Edit a project with an existing image — preview should show
- [ ] Upload a new image during edit — should save and display on profile
- [ ] Edit without changing image — existing image stays

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Logged-in users can now submit reviews without re-entering name and email.
  * Smarter user sorting on the Explore page based on profile completeness.

* **Bug Fixes**
  * Improved authentication initialization to handle redirects more reliably.
  * Stricter GitHub and Live URL validation for projects.
  * Project images now include cache-busting to display updates immediately.

* **UI/UX**
  * Updated profile cards with better placeholder text and improved layout.
  * Context-aware call-to-action button messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->