### PR TITLE
fix: Discord OG image preview not loading

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,7 +18,7 @@ const jetbrainsMono = JetBrains_Mono({
   subsets: ["latin"],
 });
 
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://vibetalent.work";
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://www.vibetalent.work";
 
 export const metadata: Metadata = {
   title: {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,20 +37,20 @@ export default async function HomePage() {
               {
                 "@type": "WebSite",
                 name: "VibeTalent",
-                url: "https://vibetalent.work",
+                url: "https://www.vibetalent.work",
                 description:
                   "The marketplace for vibe coders who ship consistently. Find developers based on streaks, shipped projects, and vibe scores.",
                 potentialAction: {
                   "@type": "SearchAction",
-                  target: "https://vibetalent.work/explore?q={search_term_string}",
+                  target: "https://www.vibetalent.work/explore?q={search_term_string}",
                   "query-input": "required name=search_term_string",
                 },
               },
               {
                 "@type": "Organization",
                 name: "VibeTalent",
-                url: "https://vibetalent.work",
-                logo: "https://vibetalent.work/opengraph-image",
+                url: "https://www.vibetalent.work",
+                logo: "https://www.vibetalent.work/opengraph-image",
                 sameAs: [],
               },
             ],

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://vibetalent.work";
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://www.vibetalent.work";
 const siteName = "VibeTalent";
 
 export function createMetadata(options: {


### PR DESCRIPTION
## Summary
- Discord crawlers don't follow 307 redirects when fetching OG images
- Vercel redirects `vibetalent.work` → `www.vibetalent.work` with a 307
- Updated all `siteUrl` fallbacks and structured data URLs to use `www.vibetalent.work` so crawlers fetch the image directly

## Files changed
- `src/app/layout.tsx` — siteUrl fallback
- `src/lib/seo.ts` — siteUrl fallback  
- `src/app/page.tsx` — structured data URLs

## Test plan
- [ ] Share `https://vibetalent.work` on Discord → image preview loads
- [ ] Verify `og:image` meta tag points to `https://www.vibetalent.work/opengraph-image`

🤖 Generated with [Claude Code](https://claude.com/claude-code)