### PR TITLE
feat: simplify dashboard, settings page, profile avatar dropdown

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -230,7 +230,6 @@ export default function DashboardPage() {
   const [githubSyncResult, setGithubSyncResult] = useState<string | null>(null);
   const [lastSyncLabel, setLastSyncLabel] = useState<string | null>(null);
 
-  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     const ts = localStorage.getItem("last_github_sync");
     if (ts) {
@@ -245,7 +244,6 @@ export default function DashboardPage() {
       }
     }
   }, []);
-  /* eslint-enable react-hooks/set-state-in-effect */
 
   const reloadUser = useCallback(async () => {
     const supabase = createClient();

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -10,7 +10,6 @@ import { StreakCounter } from "@/components/ui/streak-counter";
 import { ActivityHeatmap } from "@/components/ui/activity-heatmap";
 import { ProjectCard } from "@/components/ui/project-card";
 import { ProfileViewsWidget } from "@/components/dashboard/profile-views-widget";
-import { EmailPreferences } from "@/components/dashboard/email-preferences";
 import type { HireRequest, HireMessage } from "@/lib/types/database";
 import {
   Plus,
@@ -34,49 +33,13 @@ import {
   Trash2,
   ShieldCheck,
   Zap,
-  Users,
 } from "lucide-react";
-
-/**
- * Extract a bare username from a value that might be a full URL or @-prefixed handle.
- * For twitter/github/telegram: strips common URL prefixes and leading @.
- * Returns just the username portion.
- */
-function extractUsername(value: string, platform: "twitter" | "github" | "telegram"): string {
-  let v = value.trim();
-  if (!v) return "";
-
-  // Remove trailing slashes
-  v = v.replace(/\/+$/, "");
-
-  // Strip known URL prefixes
-  const patterns: Record<string, RegExp[]> = {
-    twitter: [/^https?:\/\/(www\.)?(twitter|x)\.com\//i],
-    github: [/^https?:\/\/(www\.)?github\.com\//i],
-    telegram: [/^https?:\/\/(www\.)?(t\.me|telegram\.me)\//i],
-  };
-
-  for (const re of patterns[platform]) {
-    v = v.replace(re, "");
-  }
-
-  // Remove leading @
-  v = v.replace(/^@/, "");
-
-  // Drop query/hash and take only first segment
-  v = v.split(/[?#]/)[0];
-  v = v.split("/")[0];
-  v = v.trim();
-
-  return v;
-}
 
 export default function DashboardPage() {
   const [user, setUser] = useState<UserWithSocials | null>(null);
   const [heatmapData, setHeatmapData] = useState<Record<string, number>>({});
   const [loading, setLoading] = useState(true);
   const [hireRequests, setHireRequests] = useState<HireRequest[]>([]);
-  const [referralCopied, setReferralCopied] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -239,36 +202,9 @@ export default function DashboardPage() {
     tags: "",
   });
 
-  const [profileForm, setProfileForm] = useState({
-    username: "",
-    bio: "",
-    twitter: "",
-    github: "",
-    telegram: "",
-    website: "",
-    ide: "",
-  });
-
-  /* eslint-disable react-hooks/set-state-in-effect */
-  useEffect(() => {
-    if (user) {
-      setProfileForm({
-        username: user.username,
-        bio: user.bio || "",
-        twitter: user.social_links?.twitter || "",
-        github: user.social_links?.github || "",
-        telegram: user.social_links?.telegram || "",
-        website: user.social_links?.website || "",
-        ide: user.social_links?.farcaster || "",
-      });
-    }
-  }, [user]);
-  /* eslint-enable react-hooks/set-state-in-effect */
-
   const [todayLogged, setTodayLogged] = useState(false);
   const [logging, setLogging] = useState(false);
   const [countdown, setCountdown] = useState("");
-  const [saving, setSaving] = useState(false);
   const [addingProject, setAddingProject] = useState(false);
   const [editingProjectId, setEditingProjectId] = useState<string | null>(null);
   const [editingOriginalGithubUrl, setEditingOriginalGithubUrl] = useState<string>("");
@@ -284,8 +220,6 @@ export default function DashboardPage() {
   const chatEndRef = useRef<HTMLDivElement>(null);
   const chatPollRef = useRef<NodeJS.Timeout | null>(null);
   const [badgeCopied, setBadgeCopied] = useState<string | null>(null);
-  const [uploadingAvatar, setUploadingAvatar] = useState(false);
-  const avatarInputRef = useRef<HTMLInputElement>(null);
   const [verifyingProjectId, setVerifyingProjectId] = useState<string | null>(null);
   const [verifyMessage, setVerifyMessage] = useState<{ projectId: string; success: boolean; text: string } | null>(null);
   const [showVerifyGuide, setShowVerifyGuide] = useState(true);
@@ -350,55 +284,6 @@ export default function DashboardPage() {
       setVerifyMessage({ projectId, success: false, text: "Verification request failed." });
     }
     setVerifyingProjectId(null);
-  };
-
-  const handleAvatarUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file || !user) return;
-
-    // Validate file type
-    const allowedTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
-    if (!allowedTypes.includes(file.type)) {
-      alert('Only JPG, PNG, WebP, and GIF images are allowed');
-      return;
-    }
-
-    // Validate file size (2MB max)
-    if (file.size > 2 * 1024 * 1024) {
-      alert('Image must be under 2MB');
-      return;
-    }
-
-    setUploadingAvatar(true);
-    const supabase = createClient();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const sb = supabase as any;
-    const ext = file.name.split(".").pop();
-    const filePath = `${user.id}/avatar.${ext}`;
-
-    // Upload to storage
-    const { error: uploadError } = await sb.storage
-      .from("avatars")
-      .upload(filePath, file, { upsert: true });
-
-    if (uploadError) {
-      console.error("Upload failed:", uploadError);
-      setUploadingAvatar(false);
-      return;
-    }
-
-    // Get public URL
-    const { data: { publicUrl } } = sb.storage
-      .from("avatars")
-      .getPublicUrl(filePath);
-
-    // Add cache-busting timestamp
-    const avatarUrl = `${publicUrl}?t=${Date.now()}`;
-
-    // Update user record
-    await sb.from("users").update({ avatar_url: avatarUrl }).eq("id", user.id);
-    setUser({ ...user, avatar_url: avatarUrl });
-    setUploadingAvatar(false);
   };
 
   const handleProjectImageSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -643,45 +528,6 @@ export default function DashboardPage() {
       streak: newStreak,
       longest_streak: newLongest,
     }).eq("id", user.id);
-  };
-
-  const handleSaveProfile = async () => {
-    if (!user || saving) return;
-    setSaving(true);
-    const supabase = createClient();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const sb = supabase as any;
-
-    await sb
-      .from("users")
-      .update({ username: profileForm.username, bio: profileForm.bio })
-      .eq("id", user.id);
-
-    // Upsert social links (farcaster column stores IDE choice)
-    await sb.from("social_links").upsert({
-      user_id: user.id,
-      twitter: profileForm.twitter || null,
-      github: profileForm.github || null,
-      telegram: profileForm.telegram || null,
-      website: profileForm.website || null,
-      farcaster: profileForm.ide || null,
-    }, { onConflict: "user_id" });
-
-    setUser({
-      ...user,
-      username: profileForm.username,
-      bio: profileForm.bio,
-      social_links: {
-        id: user.social_links?.id || "",
-        user_id: user.id,
-        twitter: profileForm.twitter || null,
-        github: profileForm.github || null,
-        telegram: profileForm.telegram || null,
-        website: profileForm.website || null,
-        farcaster: profileForm.ide || null,
-      },
-    });
-    setSaving(false);
   };
 
   const handleAddProject = async () => {
@@ -1085,52 +931,7 @@ export default function DashboardPage() {
         <ActivityHeatmap data={heatmapData} />
       </div>
 
-      {/* Referral */}
-      <div
-        className="p-6 mb-8"
-        style={{
-          backgroundColor: "#FFFFFF",
-          border: "2px solid #0F0F0F",
-          boxShadow: "var(--shadow-brutal)",
-        }}
-      >
-        <h2 className="text-lg font-extrabold uppercase flex items-center gap-2 text-[#0F0F0F] mb-2">
-          <Users size={20} className="text-[var(--accent)]" />
-          Invite Builders
-        </h2>
-        <p className="text-sm text-[#52525B] font-medium mb-4">
-          Share your referral link. When someone signs up, you get a bonus streak day!
-        </p>
-        <div className="flex gap-2">
-          <input
-            type="text"
-            readOnly
-            value={`${typeof window !== "undefined" ? window.location.origin : "https://vibetalent.work"}/auth/signup?ref=${user.username}`}
-            className="input-brutal flex-1 text-sm font-mono"
-          />
-          <button
-            onClick={() => {
-              navigator.clipboard.writeText(`${window.location.origin}/auth/signup?ref=${user.username}`);
-              setReferralCopied(true);
-              setTimeout(() => setReferralCopied(false), 2000);
-            }}
-            className="btn-brutal text-sm px-4"
-            style={{
-              backgroundColor: referralCopied ? "#D1FAE5" : "var(--accent)",
-              color: referralCopied ? "#065F46" : "#FFFFFF",
-            }}
-          >
-            {referralCopied ? "Copied!" : "Copy"}
-          </button>
-        </div>
-        {(user.referral_count ?? 0) > 0 && (
-          <p className="text-sm font-bold text-[#0F0F0F] mt-3">
-            You&apos;ve referred {user.referral_count} builder{user.referral_count !== 1 ? "s" : ""}!
-          </p>
-        )}
-      </div>
-
-      {/* Embeddable Badge */}
+      {/* Embeddable Badge for GitHub */}
       <div
         className="p-5 mb-8"
         style={{
@@ -1141,7 +942,7 @@ export default function DashboardPage() {
       >
         <h2 className="text-base font-extrabold uppercase flex items-center gap-2 text-[#0F0F0F] mb-3">
           <ExternalLink size={16} className="text-[var(--accent)]" />
-          Embeddable Badge
+          Embeddable Badge for GitHub
         </h2>
 
         <div className="flex items-center gap-4 p-3 bg-zinc-50 border-2 border-zinc-200 mb-3">
@@ -1189,336 +990,183 @@ export default function DashboardPage() {
         </div>
       </div>
 
-      {/* Profile Views + Email Preferences */}
-      <div className="grid lg:grid-cols-2 gap-8 mb-8">
+      {/* Profile Views */}
+      <div className="mb-8">
         <ProfileViewsWidget />
-        <EmailPreferences />
       </div>
 
-      <div className="grid lg:grid-cols-2 gap-8">
-        {/* Edit Profile */}
-        <div
-          className="p-6"
-          style={{
-            backgroundColor: "#FFFFFF",
-            border: "2px solid #0F0F0F",
-            boxShadow: "var(--shadow-brutal)",
-          }}
-        >
-          <h2 className="text-lg font-extrabold uppercase text-[#0F0F0F] mb-4">Edit Profile</h2>
-          <div className="space-y-4">
-            {/* Avatar Upload */}
-            <div className="flex items-center gap-4">
-              <div
-                className="relative w-20 h-20 flex items-center justify-center text-2xl font-extrabold text-white cursor-pointer group"
-                style={{ backgroundColor: "#0F0F0F", border: "2px solid #0F0F0F" }}
-                onClick={() => avatarInputRef.current?.click()}
-              >
-                {user.avatar_url ? (
-                  <Image src={user.avatar_url} alt={user.username} width={80} height={80} className="w-full h-full object-cover" />
-                ) : (
-                  user.username.slice(0, 2).toUpperCase()
-                )}
-                <div className="absolute inset-0 bg-black/50 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
-                  <Camera size={20} className="text-white" />
-                </div>
-              </div>
-              <div>
-                <button
-                  onClick={() => avatarInputRef.current?.click()}
-                  disabled={uploadingAvatar}
-                  className="text-sm font-bold text-[var(--accent)] hover:underline"
-                >
-                  {uploadingAvatar ? "Uploading..." : "Change Avatar"}
-                </button>
-                <p className="text-xs text-[#71717A] mt-1">JPG, PNG. Max 2MB.</p>
-              </div>
-              <input
-                ref={avatarInputRef}
-                type="file"
-                accept="image/*"
-                onChange={handleAvatarUpload}
-                className="hidden"
-              />
-            </div>
-            <div>
-              <label className="text-xs font-bold uppercase tracking-wide text-[#71717A] mb-1.5 block">Username</label>
-              <input
-                type="text"
-                value={profileForm.username}
-                onChange={(e) => setProfileForm({ ...profileForm, username: e.target.value })}
-                className="input-brutal"
-              />
-            </div>
-            <div>
-              <label className="text-xs font-bold uppercase tracking-wide text-[#71717A] mb-1.5 block">Bio</label>
-              <textarea
-                value={profileForm.bio}
-                onChange={(e) => setProfileForm({ ...profileForm, bio: e.target.value })}
-                rows={3}
-                className="input-brutal resize-none"
-              />
-            </div>
-            <div className="grid grid-cols-2 gap-3">
-              <div>
-                <label className="text-xs font-bold uppercase tracking-wide text-[#71717A] mb-1.5 block">X (Twitter)</label>
-                <div className="relative">
-                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[#A1A1AA] font-bold text-sm select-none">@</span>
-                  <input
-                    type="text"
-                    value={profileForm.twitter}
-                    onChange={(e) => setProfileForm({ ...profileForm, twitter: extractUsername(e.target.value, "twitter") })}
-                    placeholder="username"
-                    className="input-brutal"
-                    style={{ paddingLeft: "1.75rem" }}
-                  />
-                </div>
-              </div>
-              <div>
-                <label className="text-xs font-bold uppercase tracking-wide text-[#71717A] mb-1.5 block">GitHub</label>
-                <div className="relative">
-                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[#A1A1AA] font-bold text-sm select-none">@</span>
-                  <input
-                    type="text"
-                    value={profileForm.github}
-                    onChange={(e) => setProfileForm({ ...profileForm, github: extractUsername(e.target.value, "github") })}
-                    placeholder="username"
-                    className="input-brutal"
-                    style={{ paddingLeft: "1.75rem" }}
-                  />
-                </div>
-              </div>
-              <div>
-                <label className="text-xs font-bold uppercase tracking-wide text-[#71717A] mb-1.5 block">Telegram</label>
-                <div className="relative">
-                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[#A1A1AA] font-bold text-sm select-none">@</span>
-                  <input
-                    type="text"
-                    value={profileForm.telegram}
-                    onChange={(e) => setProfileForm({ ...profileForm, telegram: extractUsername(e.target.value, "telegram") })}
-                    placeholder="username"
-                    className="input-brutal"
-                    style={{ paddingLeft: "1.75rem" }}
-                  />
-                </div>
-              </div>
-              <div>
-                <label className="text-xs font-bold uppercase tracking-wide text-[#71717A] mb-1.5 block">Portfolio</label>
-                <input
-                  type="text"
-                  value={profileForm.website}
-                  onChange={(e) => setProfileForm({ ...profileForm, website: e.target.value })}
-                  placeholder="https://..."
-                  className="input-brutal"
-                />
-              </div>
-            </div>
-            <div>
-              <label className="text-xs font-bold uppercase tracking-wide text-[#71717A] mb-1.5 block">Vibe Coding IDE</label>
-              <select
-                value={profileForm.ide}
-                onChange={(e) => setProfileForm({ ...profileForm, ide: e.target.value })}
-                className="input-brutal"
-              >
-                <option value="">Select your IDE...</option>
-                <option value="Claude Code (Pro)">Claude Code (Pro)</option>
-                <option value="Claude Code (Max 5x)">Claude Code (Max 5x)</option>
-                <option value="Claude Code (Max 20x)">Claude Code (Max 20x)</option>
-                <option value="Cursor">Cursor</option>
-                <option value="Windsurf">Windsurf</option>
-                <option value="Antigravity">Antigravity</option>
-                <option value="Bolt">Bolt</option>
-                <option value="Lovable">Lovable</option>
-                <option value="Replit Agent">Replit Agent</option>
-                <option value="GitHub Copilot">GitHub Copilot</option>
-                <option value="VS Code + AI">VS Code + AI</option>
-                <option value="Other">Other</option>
-              </select>
-            </div>
-            <button
-              onClick={handleSaveProfile}
-              disabled={saving}
-              className="btn-brutal btn-brutal-primary text-sm flex items-center gap-2"
-            >
-              <Save size={16} />
-              {saving ? "Saving..." : "Save Profile"}
-            </button>
-          </div>
+      {/* Your Projects */}
+      <div>
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-extrabold uppercase text-[#0F0F0F]">Your Projects</h2>
+          <button
+            onClick={() => {
+              if (showProjectForm) {
+                setShowProjectForm(false);
+                setEditingProjectId(null);
+                setProjectForm({ title: "", description: "", tech_stack: "", live_url: "", github_url: "", build_time: "", tags: "" });
+              } else {
+                setShowProjectForm(true);
+              }
+            }}
+            className="btn-brutal btn-brutal-secondary text-sm flex items-center gap-2 py-2 px-4"
+          >
+            {showProjectForm ? <X size={16} /> : <Plus size={16} />}
+            {showProjectForm ? "Cancel" : "Add Project"}
+          </button>
         </div>
 
-        {/* Projects */}
-        <div>
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-extrabold uppercase text-[#0F0F0F]">Your Projects</h2>
+        {/* Verification Guide */}
+        {showVerifyGuide && (
+          <div
+            className="mb-4 p-4 relative"
+            style={{ backgroundColor: "#FFFBEB", border: "2px solid #0F0F0F" }}
+          >
             <button
-              onClick={() => {
-                if (showProjectForm) {
-                  setShowProjectForm(false);
-                  setEditingProjectId(null);
-                  setProjectForm({ title: "", description: "", tech_stack: "", live_url: "", github_url: "", build_time: "", tags: "" });
-                } else {
-                  setShowProjectForm(true);
-                }
-              }}
-              className="btn-brutal btn-brutal-secondary text-sm flex items-center gap-2 py-2 px-4"
+              onClick={() => setShowVerifyGuide(false)}
+              className="absolute top-3 right-3 text-[#A1A1AA] hover:text-[#0F0F0F] transition-colors"
+              title="Dismiss"
             >
-              {showProjectForm ? <X size={16} /> : <Plus size={16} />}
-              {showProjectForm ? "Cancel" : "Add Project"}
+              <X size={14} />
             </button>
+            <h3 className="text-sm font-extrabold uppercase text-[#0F0F0F] flex items-center gap-2 mb-2">
+              <ShieldCheck size={16} className="text-green-600" />
+              How to Verify Your Projects
+            </h3>
+            <p className="text-xs text-[#52525B] font-medium leading-relaxed">
+              Verified projects show a green badge, proving you own the code. There are two ways to verify:
+            </p>
+            <ol className="text-xs text-[#52525B] font-medium mt-2 space-y-1.5 list-decimal list-inside leading-relaxed">
+              <li>
+                <strong className="text-[#0F0F0F]">Owner Match (automatic):</strong> If the GitHub repo URL belongs to your GitHub account (the one you signed in with), it verifies instantly.
+              </li>
+              <li>
+                <strong className="text-[#0F0F0F]">Verification File (for collaborators):</strong> Add a file named <code className="bg-white px-1.5 py-0.5 border border-[#E4E4E7] font-mono text-[10px]">.vibetalent</code> to the root of the repo containing your GitHub username. Then click the <strong>Verify</strong> button on the project card below.
+              </li>
+            </ol>
           </div>
+        )}
 
-          {/* Verification Guide */}
-          {showVerifyGuide && (
-            <div
-              className="mb-4 p-4 relative"
-              style={{ backgroundColor: "#FFFBEB", border: "2px solid #0F0F0F" }}
-            >
+        {showProjectForm && (
+          <div
+            className="p-5 mb-4"
+            style={{
+              backgroundColor: "#FFFFFF",
+              border: "2px solid #0F0F0F",
+              boxShadow: "var(--shadow-brutal-sm)",
+            }}
+          >
+            <h3 className="text-sm font-extrabold uppercase text-[#0F0F0F] mb-3">{editingProjectId ? "Edit Project" : "New Project"}</h3>
+            {projectError && (
+              <div className="p-3 mb-3 text-sm font-bold text-[#991B1B]" style={{ backgroundColor: "#FEE2E2", border: "2px solid #0F0F0F" }}>
+                {projectError}
+              </div>
+            )}
+            <div className="space-y-3">
+              <input
+                type="text"
+                placeholder="Project name"
+                value={projectForm.title}
+                onChange={(e) => setProjectForm({ ...projectForm, title: e.target.value })}
+                className="input-brutal"
+              />
+              <textarea
+                placeholder="Description"
+                value={projectForm.description}
+                onChange={(e) => setProjectForm({ ...projectForm, description: e.target.value })}
+                rows={2}
+                className="input-brutal resize-none"
+              />
+              <input
+                type="text"
+                placeholder="Tech stack (comma separated)"
+                value={projectForm.tech_stack}
+                onChange={(e) => setProjectForm({ ...projectForm, tech_stack: e.target.value })}
+                className="input-brutal"
+              />
+              <div className="grid grid-cols-2 gap-3">
+                <input
+                  type="text"
+                  placeholder="Live URL"
+                  value={projectForm.live_url}
+                  onChange={(e) => setProjectForm({ ...projectForm, live_url: e.target.value })}
+                  className="input-brutal"
+                />
+                <input
+                  type="text"
+                  placeholder="GitHub URL"
+                  value={projectForm.github_url}
+                  onChange={(e) => setProjectForm({ ...projectForm, github_url: e.target.value })}
+                  className="input-brutal"
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <input
+                  type="text"
+                  placeholder="Build time (e.g., 2 days)"
+                  value={projectForm.build_time}
+                  onChange={(e) => setProjectForm({ ...projectForm, build_time: e.target.value })}
+                  className="input-brutal"
+                />
+                <input
+                  type="text"
+                  placeholder="Tags (comma separated)"
+                  value={projectForm.tags}
+                  onChange={(e) => setProjectForm({ ...projectForm, tags: e.target.value })}
+                  className="input-brutal"
+                />
+              </div>
+              <div>
+                <label className="text-xs font-bold uppercase tracking-wide text-[#71717A] mb-1.5 block">Project Screenshot</label>
+                <div className="flex items-center gap-4">
+                  {projectImagePreview && (
+                    <div className="relative w-24 h-16 border-2 border-[#0F0F0F]">
+                      <Image src={projectImagePreview} alt="Preview" fill className="object-cover" />
+                      <button onClick={() => { setProjectImageFile(null); setProjectImagePreview(null); }} className="absolute -top-2 -right-2 w-5 h-5 bg-[#0F0F0F] text-white rounded-full flex items-center justify-center text-xs">&times;</button>
+                    </div>
+                  )}
+                  <button type="button" onClick={() => projectImageInputRef.current?.click()} className="btn-brutal btn-brutal-secondary text-xs py-1.5 px-3">
+                    <Camera size={14} className="mr-1 inline" /> {projectImagePreview ? "Change" : "Add Image"}
+                  </button>
+                  <input ref={projectImageInputRef} type="file" accept="image/jpeg,image/png,image/webp,image/gif" onChange={handleProjectImageSelect} className="hidden" />
+                </div>
+                <p className="text-xs text-[#71717A] mt-1">Recommended: 1280×720px (16:9). Max 5MB. JPG, PNG, WebP, GIF.</p>
+              </div>
               <button
-                onClick={() => setShowVerifyGuide(false)}
-                className="absolute top-3 right-3 text-[#A1A1AA] hover:text-[#0F0F0F] transition-colors"
-                title="Dismiss"
+                onClick={editingProjectId ? handleSaveEdit : handleAddProject}
+                disabled={(editingProjectId ? savingEdit : addingProject) || !projectForm.title || !projectForm.description}
+                className="btn-brutal btn-brutal-primary text-sm flex items-center gap-2 disabled:opacity-50"
               >
-                <X size={14} />
+                {editingProjectId ? <Save size={16} /> : <Plus size={16} />}
+                {editingProjectId
+                  ? (savingEdit ? "Saving..." : "Save Changes")
+                  : (addingProject ? "Adding..." : "Add Project")}
               </button>
-              <h3 className="text-sm font-extrabold uppercase text-[#0F0F0F] flex items-center gap-2 mb-2">
-                <ShieldCheck size={16} className="text-green-600" />
-                How to Verify Your Projects
-              </h3>
-              <p className="text-xs text-[#52525B] font-medium leading-relaxed">
-                Verified projects show a green badge, proving you own the code. There are two ways to verify:
-              </p>
-              <ol className="text-xs text-[#52525B] font-medium mt-2 space-y-1.5 list-decimal list-inside leading-relaxed">
-                <li>
-                  <strong className="text-[#0F0F0F]">Owner Match (automatic):</strong> If the GitHub repo URL belongs to your GitHub account (the one you signed in with), it verifies instantly.
-                </li>
-                <li>
-                  <strong className="text-[#0F0F0F]">Verification File (for collaborators):</strong> Add a file named <code className="bg-white px-1.5 py-0.5 border border-[#E4E4E7] font-mono text-[10px]">.vibetalent</code> to the root of the repo containing your GitHub username. Then click the <strong>Verify</strong> button on the project card below.
-                </li>
-              </ol>
             </div>
-          )}
+          </div>
+        )}
 
-          {showProjectForm && (
-            <div
-              className="p-5 mb-4"
-              style={{
-                backgroundColor: "#FFFFFF",
-                border: "2px solid #0F0F0F",
-                boxShadow: "var(--shadow-brutal-sm)",
-              }}
-            >
-              <h3 className="text-sm font-extrabold uppercase text-[#0F0F0F] mb-3">{editingProjectId ? "Edit Project" : "New Project"}</h3>
-              {projectError && (
-                <div className="p-3 mb-3 text-sm font-bold text-[#991B1B]" style={{ backgroundColor: "#FEE2E2", border: "2px solid #0F0F0F" }}>
-                  {projectError}
+        <div className="space-y-4">
+          {user.projects.map((project) => (
+            <div key={project.id}>
+              <ProjectCard
+                project={project}
+                onEdit={handleStartEdit}
+                verified={!!project.verified}
+                onVerify={verifyProject}
+              />
+              {verifyingProjectId === project.id && (
+                <div className="mt-1 px-5 py-2 text-xs font-bold text-[#71717A] uppercase">
+                  Verifying...
                 </div>
               )}
-              <div className="space-y-3">
-                <input
-                  type="text"
-                  placeholder="Project name"
-                  value={projectForm.title}
-                  onChange={(e) => setProjectForm({ ...projectForm, title: e.target.value })}
-                  className="input-brutal"
-                />
-                <textarea
-                  placeholder="Description"
-                  value={projectForm.description}
-                  onChange={(e) => setProjectForm({ ...projectForm, description: e.target.value })}
-                  rows={2}
-                  className="input-brutal resize-none"
-                />
-                <input
-                  type="text"
-                  placeholder="Tech stack (comma separated)"
-                  value={projectForm.tech_stack}
-                  onChange={(e) => setProjectForm({ ...projectForm, tech_stack: e.target.value })}
-                  className="input-brutal"
-                />
-                <div className="grid grid-cols-2 gap-3">
-                  <input
-                    type="text"
-                    placeholder="Live URL"
-                    value={projectForm.live_url}
-                    onChange={(e) => setProjectForm({ ...projectForm, live_url: e.target.value })}
-                    className="input-brutal"
-                  />
-                  <input
-                    type="text"
-                    placeholder="GitHub URL"
-                    value={projectForm.github_url}
-                    onChange={(e) => setProjectForm({ ...projectForm, github_url: e.target.value })}
-                    className="input-brutal"
-                  />
+              {verifyMessage && verifyMessage.projectId === project.id && (
+                <div className={`mt-1 px-5 py-2 text-xs font-bold uppercase ${verifyMessage.success ? "text-green-600" : "text-orange-600"}`}>
+                  {verifyMessage.text}
                 </div>
-                <div className="grid grid-cols-2 gap-3">
-                  <input
-                    type="text"
-                    placeholder="Build time (e.g., 2 days)"
-                    value={projectForm.build_time}
-                    onChange={(e) => setProjectForm({ ...projectForm, build_time: e.target.value })}
-                    className="input-brutal"
-                  />
-                  <input
-                    type="text"
-                    placeholder="Tags (comma separated)"
-                    value={projectForm.tags}
-                    onChange={(e) => setProjectForm({ ...projectForm, tags: e.target.value })}
-                    className="input-brutal"
-                  />
-                </div>
-                <div>
-                  <label className="text-xs font-bold uppercase tracking-wide text-[#71717A] mb-1.5 block">Project Screenshot</label>
-                  <div className="flex items-center gap-4">
-                    {projectImagePreview && (
-                      <div className="relative w-24 h-16 border-2 border-[#0F0F0F]">
-                        <Image src={projectImagePreview} alt="Preview" fill className="object-cover" />
-                        <button onClick={() => { setProjectImageFile(null); setProjectImagePreview(null); }} className="absolute -top-2 -right-2 w-5 h-5 bg-[#0F0F0F] text-white rounded-full flex items-center justify-center text-xs">&times;</button>
-                      </div>
-                    )}
-                    <button type="button" onClick={() => projectImageInputRef.current?.click()} className="btn-brutal btn-brutal-secondary text-xs py-1.5 px-3">
-                      <Camera size={14} className="mr-1 inline" /> {projectImagePreview ? "Change" : "Add Image"}
-                    </button>
-                    <input ref={projectImageInputRef} type="file" accept="image/jpeg,image/png,image/webp,image/gif" onChange={handleProjectImageSelect} className="hidden" />
-                  </div>
-                  <p className="text-xs text-[#71717A] mt-1">Recommended: 1280×720px (16:9). Max 5MB. JPG, PNG, WebP, GIF.</p>
-                </div>
-                <button
-                  onClick={editingProjectId ? handleSaveEdit : handleAddProject}
-                  disabled={(editingProjectId ? savingEdit : addingProject) || !projectForm.title || !projectForm.description}
-                  className="btn-brutal btn-brutal-primary text-sm flex items-center gap-2 disabled:opacity-50"
-                >
-                  {editingProjectId ? <Save size={16} /> : <Plus size={16} />}
-                  {editingProjectId
-                    ? (savingEdit ? "Saving..." : "Save Changes")
-                    : (addingProject ? "Adding..." : "Add Project")}
-                </button>
-              </div>
+              )}
             </div>
-          )}
-
-          <div className="space-y-4">
-            {user.projects.map((project) => (
-              <div key={project.id}>
-                <ProjectCard
-                  project={project}
-                  onEdit={handleStartEdit}
-                  verified={!!project.verified}
-                  onVerify={verifyProject}
-                />
-                {verifyingProjectId === project.id && (
-                  <div className="mt-1 px-5 py-2 text-xs font-bold text-[#71717A] uppercase">
-                    Verifying...
-                  </div>
-                )}
-                {verifyMessage && verifyMessage.projectId === project.id && (
-                  <div className={`mt-1 px-5 py-2 text-xs font-bold uppercase ${verifyMessage.success ? "text-green-600" : "text-orange-600"}`}>
-                    {verifyMessage.text}
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
+          ))}
         </div>
       </div>
       </>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -106,6 +106,7 @@ export default function SettingsPage() {
   }, []);
 
   // Populate form when user loads
+  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     if (user) {
       setProfileForm({
@@ -119,6 +120,7 @@ export default function SettingsPage() {
       });
     }
   }, [user]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   const handleAvatarUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,483 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import Image from "next/image";
+import { createClient } from "@/lib/supabase/client";
+import type { UserWithSocials } from "@/lib/types/database";
+import { EmailPreferences } from "@/components/dashboard/email-preferences";
+import {
+  Save,
+  Camera,
+  Users,
+  ExternalLink,
+} from "lucide-react";
+
+/**
+ * Extract a bare username from a value that might be a full URL or @-prefixed handle.
+ */
+function extractUsername(value: string, platform: "twitter" | "github" | "telegram"): string {
+  let v = value.trim();
+  if (!v) return "";
+  v = v.replace(/\/+$/, "");
+  const patterns: Record<string, RegExp[]> = {
+    twitter: [/^https?:\/\/(www\.)?(twitter|x)\.com\//i],
+    github: [/^https?:\/\/(www\.)?github\.com\//i],
+    telegram: [/^https?:\/\/(www\.)?(t\.me|telegram\.me)\//i],
+  };
+  for (const re of patterns[platform]) {
+    v = v.replace(re, "");
+  }
+  v = v.replace(/^@/, "");
+  v = v.split(/[?#]/)[0];
+  v = v.split("/")[0];
+  v = v.trim();
+  return v;
+}
+
+export default function SettingsPage() {
+  const [user, setUser] = useState<UserWithSocials | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [uploadingAvatar, setUploadingAvatar] = useState(false);
+  const [referralCopied, setReferralCopied] = useState(false);
+  const avatarInputRef = useRef<HTMLInputElement>(null);
+
+  const [profileForm, setProfileForm] = useState({
+    username: "",
+    bio: "",
+    twitter: "",
+    github: "",
+    telegram: "",
+    website: "",
+    ide: "",
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    let loaded = false;
+
+    async function loadUserData(authUser: import("@supabase/supabase-js").User) {
+      if (loaded || cancelled) return;
+      loaded = true;
+      const supabase = createClient();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const sb = supabase as any;
+
+      const [{ data: profile }, { data: projects }, { data: socials }] = await Promise.all([
+        sb.from("users").select("id, username, bio, avatar_url, vibe_score, streak, longest_streak, badge_level, streak_freezes_remaining, streak_freezes_used, referral_count, created_at").eq("id", authUser.id).single(),
+        sb.from("projects").select("id, user_id, title, description, tech_stack, live_url, github_url, image_url, build_time, tags, verified, created_at").eq("user_id", authUser.id).order("created_at", { ascending: false }),
+        sb.from("social_links").select("id, user_id, twitter, telegram, github, website, farcaster").eq("user_id", authUser.id).single(),
+      ]);
+
+      if (!profile) {
+        window.location.href = "/auth/profile-setup";
+        return;
+      }
+
+      setUser({
+        ...profile,
+        projects: projects || [],
+        social_links: socials || null,
+      });
+      setLoading(false);
+    }
+
+    const supabase = createClient();
+    supabase.auth.getUser().then(({ data: { user: authUser } }) => {
+      if (cancelled) return;
+      if (authUser) {
+        loadUserData(authUser);
+      }
+    });
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (cancelled) return;
+      if (session?.user) {
+        loadUserData(session.user);
+      } else {
+        setLoading(false);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  // Populate form when user loads
+  useEffect(() => {
+    if (user) {
+      setProfileForm({
+        username: user.username,
+        bio: user.bio || "",
+        twitter: user.social_links?.twitter || "",
+        github: user.social_links?.github || "",
+        telegram: user.social_links?.telegram || "",
+        website: user.social_links?.website || "",
+        ide: user.social_links?.farcaster || "",
+      });
+    }
+  }, [user]);
+
+  const handleAvatarUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file || !user) return;
+
+    const allowedTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+    if (!allowedTypes.includes(file.type)) {
+      alert('Only JPG, PNG, WebP, and GIF images are allowed');
+      return;
+    }
+
+    if (file.size > 2 * 1024 * 1024) {
+      alert('Image must be under 2MB');
+      return;
+    }
+
+    setUploadingAvatar(true);
+    const supabase = createClient();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sb = supabase as any;
+    const ext = file.name.split(".").pop();
+    const filePath = `${user.id}/avatar.${ext}`;
+
+    const { error: uploadError } = await sb.storage
+      .from("avatars")
+      .upload(filePath, file, { upsert: true });
+
+    if (uploadError) {
+      console.error("Upload failed:", uploadError);
+      setUploadingAvatar(false);
+      return;
+    }
+
+    const { data: { publicUrl } } = sb.storage
+      .from("avatars")
+      .getPublicUrl(filePath);
+
+    const avatarUrl = `${publicUrl}?t=${Date.now()}`;
+
+    await sb.from("users").update({ avatar_url: avatarUrl }).eq("id", user.id);
+    setUser({ ...user, avatar_url: avatarUrl });
+    setUploadingAvatar(false);
+  };
+
+  const handleSaveProfile = async () => {
+    if (!user || saving) return;
+    setSaving(true);
+    const supabase = createClient();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sb = supabase as any;
+
+    await sb
+      .from("users")
+      .update({ username: profileForm.username, bio: profileForm.bio })
+      .eq("id", user.id);
+
+    await sb.from("social_links").upsert({
+      user_id: user.id,
+      twitter: profileForm.twitter || null,
+      github: profileForm.github || null,
+      telegram: profileForm.telegram || null,
+      website: profileForm.website || null,
+      farcaster: profileForm.ide || null,
+    }, { onConflict: "user_id" });
+
+    setUser({
+      ...user,
+      username: profileForm.username,
+      bio: profileForm.bio,
+      social_links: {
+        id: user.social_links?.id || "",
+        user_id: user.id,
+        twitter: profileForm.twitter || null,
+        github: profileForm.github || null,
+        telegram: profileForm.telegram || null,
+        website: profileForm.website || null,
+        farcaster: profileForm.ide || null,
+      },
+    });
+    setSaving(false);
+  };
+
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 sm:px-6 py-12">
+        <h1 className="text-3xl font-extrabold uppercase text-[#0F0F0F] mb-8">Settings</h1>
+        <div className="space-y-6">
+          {[1, 2, 3].map((i) => <div key={i} className="skeleton h-32" />)}
+        </div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 sm:px-6 py-12 text-center">
+        <h1 className="text-3xl font-extrabold uppercase text-[#0F0F0F] mb-4">Settings</h1>
+        <p className="text-[#52525B] font-medium">Please sign in to view your settings.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 sm:px-6 py-12">
+      <h1 className="text-3xl font-extrabold uppercase text-[#0F0F0F] mb-8">Settings</h1>
+
+      {/* Edit Profile */}
+      <div
+        className="p-6 mb-8"
+        style={{
+          backgroundColor: "#FFFFFF",
+          border: "2px solid #0F0F0F",
+          boxShadow: "var(--shadow-brutal)",
+        }}
+      >
+        <h2 className="text-lg font-extrabold uppercase text-[#0F0F0F] mb-4">Edit Profile</h2>
+        <div className="space-y-4">
+          {/* Avatar Upload */}
+          <div className="flex items-center gap-4">
+            <div
+              className="relative w-20 h-20 flex items-center justify-center text-2xl font-extrabold text-white cursor-pointer group"
+              style={{ backgroundColor: "#0F0F0F", border: "2px solid #0F0F0F" }}
+              onClick={() => avatarInputRef.current?.click()}
+            >
+              {user.avatar_url ? (
+                <Image src={user.avatar_url} alt={user.username} width={80} height={80} className="w-full h-full object-cover" />
+              ) : (
+                user.username.slice(0, 2).toUpperCase()
+              )}
+              <div className="absolute inset-0 bg-black/50 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
+                <Camera size={20} className="text-white" />
+              </div>
+            </div>
+            <div>
+              <button
+                onClick={() => avatarInputRef.current?.click()}
+                disabled={uploadingAvatar}
+                className="text-sm font-bold text-[var(--accent)] hover:underline"
+              >
+                {uploadingAvatar ? "Uploading..." : "Change Avatar"}
+              </button>
+              <p className="text-xs text-[#71717A] mt-1">JPG, PNG. Max 2MB.</p>
+            </div>
+            <input
+              ref={avatarInputRef}
+              type="file"
+              accept="image/*"
+              onChange={handleAvatarUpload}
+              className="hidden"
+            />
+          </div>
+          <div>
+            <label className="text-xs font-bold uppercase tracking-wide text-[#71717A] mb-1.5 block">Username</label>
+            <input
+              type="text"
+              value={profileForm.username}
+              onChange={(e) => setProfileForm({ ...profileForm, username: e.target.value })}
+              className="input-brutal"
+            />
+          </div>
+          <div>
+            <label className="text-xs font-bold uppercase tracking-wide text-[#71717A] mb-1.5 block">Bio</label>
+            <textarea
+              value={profileForm.bio}
+              onChange={(e) => setProfileForm({ ...profileForm, bio: e.target.value })}
+              rows={3}
+              className="input-brutal resize-none"
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="text-xs font-bold uppercase tracking-wide text-[#71717A] mb-1.5 block">X (Twitter)</label>
+              <div className="relative">
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[#A1A1AA] font-bold text-sm select-none">@</span>
+                <input
+                  type="text"
+                  value={profileForm.twitter}
+                  onChange={(e) => setProfileForm({ ...profileForm, twitter: extractUsername(e.target.value, "twitter") })}
+                  placeholder="username"
+                  className="input-brutal"
+                  style={{ paddingLeft: "1.75rem" }}
+                />
+              </div>
+            </div>
+            <div>
+              <label className="text-xs font-bold uppercase tracking-wide text-[#71717A] mb-1.5 block">GitHub</label>
+              <div className="relative">
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[#A1A1AA] font-bold text-sm select-none">@</span>
+                <input
+                  type="text"
+                  value={profileForm.github}
+                  onChange={(e) => setProfileForm({ ...profileForm, github: extractUsername(e.target.value, "github") })}
+                  placeholder="username"
+                  className="input-brutal"
+                  style={{ paddingLeft: "1.75rem" }}
+                />
+              </div>
+            </div>
+            <div>
+              <label className="text-xs font-bold uppercase tracking-wide text-[#71717A] mb-1.5 block">Telegram</label>
+              <div className="relative">
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[#A1A1AA] font-bold text-sm select-none">@</span>
+                <input
+                  type="text"
+                  value={profileForm.telegram}
+                  onChange={(e) => setProfileForm({ ...profileForm, telegram: extractUsername(e.target.value, "telegram") })}
+                  placeholder="username"
+                  className="input-brutal"
+                  style={{ paddingLeft: "1.75rem" }}
+                />
+              </div>
+            </div>
+            <div>
+              <label className="text-xs font-bold uppercase tracking-wide text-[#71717A] mb-1.5 block">Portfolio</label>
+              <input
+                type="text"
+                value={profileForm.website}
+                onChange={(e) => setProfileForm({ ...profileForm, website: e.target.value })}
+                placeholder="https://..."
+                className="input-brutal"
+              />
+            </div>
+          </div>
+          <div>
+            <label className="text-xs font-bold uppercase tracking-wide text-[#71717A] mb-1.5 block">Vibe Coding IDE</label>
+            <select
+              value={profileForm.ide}
+              onChange={(e) => setProfileForm({ ...profileForm, ide: e.target.value })}
+              className="input-brutal"
+            >
+              <option value="">Select your IDE...</option>
+              <option value="Claude Code (Pro)">Claude Code (Pro)</option>
+              <option value="Claude Code (Max 5x)">Claude Code (Max 5x)</option>
+              <option value="Claude Code (Max 20x)">Claude Code (Max 20x)</option>
+              <option value="Cursor">Cursor</option>
+              <option value="Windsurf">Windsurf</option>
+              <option value="Antigravity">Antigravity</option>
+              <option value="Bolt">Bolt</option>
+              <option value="Lovable">Lovable</option>
+              <option value="Replit Agent">Replit Agent</option>
+              <option value="GitHub Copilot">GitHub Copilot</option>
+              <option value="VS Code + AI">VS Code + AI</option>
+              <option value="Other">Other</option>
+            </select>
+          </div>
+          <button
+            onClick={handleSaveProfile}
+            disabled={saving}
+            className="btn-brutal btn-brutal-primary text-sm flex items-center gap-2"
+          >
+            <Save size={16} />
+            {saving ? "Saving..." : "Save Profile"}
+          </button>
+        </div>
+      </div>
+
+      {/* Email Notifications */}
+      <div className="mb-8">
+        <EmailPreferences />
+      </div>
+
+      {/* Referral */}
+      <div
+        id="referral"
+        className="p-6 mb-8"
+        style={{
+          backgroundColor: "#FFFFFF",
+          border: "2px solid #0F0F0F",
+          boxShadow: "var(--shadow-brutal)",
+        }}
+      >
+        <h2 className="text-lg font-extrabold uppercase flex items-center gap-2 text-[#0F0F0F] mb-2">
+          <Users size={20} className="text-[var(--accent)]" />
+          Invite Builders
+        </h2>
+        <p className="text-sm text-[#52525B] font-medium mb-4">
+          Share your referral link. When someone signs up, you get a bonus streak day!
+        </p>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            readOnly
+            value={`${typeof window !== "undefined" ? window.location.origin : "https://vibetalent.work"}/auth/signup?ref=${user.username}`}
+            className="input-brutal flex-1 text-sm font-mono"
+          />
+          <button
+            onClick={() => {
+              navigator.clipboard.writeText(`${window.location.origin}/auth/signup?ref=${user.username}`);
+              setReferralCopied(true);
+              setTimeout(() => setReferralCopied(false), 2000);
+            }}
+            className="btn-brutal text-sm px-4"
+            style={{
+              backgroundColor: referralCopied ? "#D1FAE5" : "var(--accent)",
+              color: referralCopied ? "#065F46" : "#FFFFFF",
+            }}
+          >
+            {referralCopied ? "Copied!" : "Copy"}
+          </button>
+        </div>
+        {(user.referral_count ?? 0) > 0 && (
+          <p className="text-sm font-bold text-[#0F0F0F] mt-3">
+            You&apos;ve referred {user.referral_count} builder{user.referral_count !== 1 ? "s" : ""}!
+          </p>
+        )}
+      </div>
+
+      {/* Embeddable Badge for GitHub */}
+      <div
+        className="p-5 mb-8"
+        style={{
+          backgroundColor: "#FFFFFF",
+          border: "2px solid #0F0F0F",
+          boxShadow: "var(--shadow-brutal)",
+        }}
+      >
+        <h2 className="text-base font-extrabold uppercase flex items-center gap-2 text-[#0F0F0F] mb-3">
+          <ExternalLink size={16} className="text-[var(--accent)]" />
+          Embeddable Badge for GitHub
+        </h2>
+
+        <div className="flex items-center gap-4 p-3 bg-zinc-50 border-2 border-zinc-200 mb-3">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={`/api/badge/${user.username}`}
+            alt={`${user.username}'s VibeTalent badge`}
+            height={28}
+          />
+        </div>
+
+        <div className="flex gap-2">
+          {(() => {
+            const siteUrl = "https://vibetalent.work";
+            const encodedName = encodeURIComponent(user.username);
+            const badgeImgUrl = `${siteUrl}/api/badge/${encodedName}`;
+            const profileUrl = `${siteUrl}/profile/${encodedName}`;
+            return (
+              <>
+                <button
+                  onClick={() => {
+                    navigator.clipboard.writeText(`[![VibeTalent](${badgeImgUrl})](${profileUrl})`);
+                  }}
+                  className="btn-brutal flex-1 flex items-center justify-center gap-1.5 text-xs py-2"
+                >
+                  Copy Markdown
+                </button>
+                <button
+                  onClick={() => {
+                    navigator.clipboard.writeText(`<a href="${profileUrl}"><img src="${badgeImgUrl}" alt="VibeTalent Badge" /></a>`);
+                  }}
+                  className="btn-brutal flex-1 flex items-center justify-center gap-1.5 text-xs py-2"
+                >
+                  Copy HTML
+                </button>
+              </>
+            );
+          })()}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import Link from "next/link";
+import Image from "next/image";
 import { usePathname, useRouter } from "next/navigation";
-import { Flame, Menu, X, LogOut } from "lucide-react";
-import { useState, useEffect } from "react";
+import { Flame, Menu, X, LogOut, Settings, User, Users } from "lucide-react";
+import { useState, useEffect, useRef } from "react";
 import { createClient } from "@/lib/supabase/client";
 import { NotificationBell } from "@/components/ui/notification-bell";
 
@@ -21,27 +22,73 @@ export function Navbar() {
   const router = useRouter();
   const [mobileOpen, setMobileOpen] = useState(false);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [profileDropdownOpen, setProfileDropdownOpen] = useState(false);
+  const [userProfile, setUserProfile] = useState<{ username: string; avatar_url: string | null } | null>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const supabase = createClient();
     // Check auth once on mount, then listen for changes
-    supabase.auth.getUser().then(({ data: { user } }) => {
+    supabase.auth.getUser().then(async ({ data: { user } }) => {
       setIsLoggedIn(!!user);
+      if (user) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { data: profile } = await (supabase as any)
+          .from("users")
+          .select("username, avatar_url")
+          .eq("id", user.id)
+          .single();
+        if (profile) {
+          setUserProfile({ username: profile.username, avatar_url: profile.avatar_url });
+        }
+      }
     });
 
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+    const { data: { subscription } } = supabase.auth.onAuthStateChange(async (_event, session) => {
       setIsLoggedIn(!!session?.user);
+      if (session?.user) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { data: profile } = await (supabase as any)
+          .from("users")
+          .select("username, avatar_url")
+          .eq("id", session.user.id)
+          .single();
+        if (profile) {
+          setUserProfile({ username: profile.username, avatar_url: profile.avatar_url });
+        }
+      } else {
+        setUserProfile(null);
+      }
     });
 
     return () => subscription.unsubscribe();
   }, []);
 
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setProfileDropdownOpen(false);
+      }
+    }
+    if (profileDropdownOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [profileDropdownOpen]);
+
   const handleLogout = async () => {
     const supabase = createClient();
     await supabase.auth.signOut();
     setIsLoggedIn(false);
+    setUserProfile(null);
+    setProfileDropdownOpen(false);
     router.push("/");
   };
+
+  const initials = userProfile?.username
+    ? userProfile.username.slice(0, 2).toUpperCase()
+    : "??";
 
   return (
     <nav
@@ -102,19 +149,77 @@ export function Navbar() {
             <div className="ml-3">
               <NotificationBell />
             </div>
-            <button
-              onClick={handleLogout}
-              className="btn-brutal ml-3 text-sm py-2 px-5 flex items-center gap-2"
-              style={{
-                backgroundColor: "#0F0F0F",
-                color: "#FFFFFF",
-                border: "2px solid #0F0F0F",
-                boxShadow: "var(--shadow-brutal-sm)",
-              }}
-            >
-              <LogOut size={14} />
-              Logout
-            </button>
+            {/* Profile Avatar Dropdown */}
+            <div className="relative ml-3" ref={dropdownRef}>
+              <button
+                onClick={() => setProfileDropdownOpen(!profileDropdownOpen)}
+                className="flex items-center justify-center overflow-hidden"
+                style={{
+                  width: 40,
+                  height: 40,
+                  borderRadius: "50%",
+                  border: "2px solid #0F0F0F",
+                  backgroundColor: "#0F0F0F",
+                  cursor: "pointer",
+                }}
+              >
+                {userProfile?.avatar_url ? (
+                  <Image
+                    src={userProfile.avatar_url}
+                    alt={userProfile.username}
+                    width={40}
+                    height={40}
+                    className="w-full h-full object-cover"
+                    style={{ borderRadius: "50%" }}
+                  />
+                ) : (
+                  <span className="text-sm font-extrabold text-white">{initials}</span>
+                )}
+              </button>
+              {profileDropdownOpen && (
+                <div
+                  className="absolute right-0 top-12 z-50 w-48"
+                  style={{
+                    backgroundColor: "#FFFFFF",
+                    border: "2px solid #0F0F0F",
+                    boxShadow: "var(--shadow-brutal-sm)",
+                  }}
+                >
+                  <Link
+                    href={`/profile/${userProfile?.username || ""}`}
+                    onClick={() => setProfileDropdownOpen(false)}
+                    className="flex items-center gap-2 px-4 py-3 text-sm font-bold uppercase tracking-wide text-[#0F0F0F] hover:bg-[#F4F4F5] transition-colors"
+                  >
+                    <User size={16} />
+                    My Profile
+                  </Link>
+                  <Link
+                    href="/settings"
+                    onClick={() => setProfileDropdownOpen(false)}
+                    className="flex items-center gap-2 px-4 py-3 text-sm font-bold uppercase tracking-wide text-[#0F0F0F] hover:bg-[#F4F4F5] transition-colors"
+                  >
+                    <Settings size={16} />
+                    Settings
+                  </Link>
+                  <Link
+                    href="/settings#referral"
+                    onClick={() => setProfileDropdownOpen(false)}
+                    className="flex items-center gap-2 px-4 py-3 text-sm font-bold uppercase tracking-wide text-[#0F0F0F] hover:bg-[#F4F4F5] transition-colors"
+                  >
+                    <Users size={16} />
+                    Referral
+                  </Link>
+                  <div style={{ borderTop: "2px solid #0F0F0F" }} />
+                  <button
+                    onClick={handleLogout}
+                    className="flex items-center gap-2 px-4 py-3 text-sm font-bold uppercase tracking-wide text-[#0F0F0F] hover:bg-[#F4F4F5] transition-colors w-full text-left"
+                  >
+                    <LogOut size={16} />
+                    Log out
+                  </button>
+                </div>
+              )}
+            </div>
             </>
           ) : (
             <Link
@@ -144,6 +249,36 @@ export function Navbar() {
             backgroundColor: "#FFFFFF",
           }}
         >
+          {/* Mobile: Show avatar + username at top if logged in */}
+          {isLoggedIn && userProfile && (
+            <div className="flex items-center gap-3 py-3 mb-1" style={{ borderBottom: "1px solid #E4E4E7" }}>
+              <div
+                className="flex items-center justify-center overflow-hidden"
+                style={{
+                  width: 36,
+                  height: 36,
+                  borderRadius: "50%",
+                  border: "2px solid #0F0F0F",
+                  backgroundColor: "#0F0F0F",
+                }}
+              >
+                {userProfile.avatar_url ? (
+                  <Image
+                    src={userProfile.avatar_url}
+                    alt={userProfile.username}
+                    width={36}
+                    height={36}
+                    className="w-full h-full object-cover"
+                    style={{ borderRadius: "50%" }}
+                  />
+                ) : (
+                  <span className="text-xs font-extrabold text-white">{initials}</span>
+                )}
+              </div>
+              <span className="text-sm font-extrabold text-[#0F0F0F]">{userProfile.username}</span>
+            </div>
+          )}
+
           {navLinks.map((link) => (
             <Link
               key={link.href}
@@ -173,6 +308,31 @@ export function Navbar() {
               <NotificationBell />
               <span className="text-sm font-bold uppercase tracking-wide text-[#0F0F0F]">Notifications</span>
             </div>
+            {userProfile && (
+              <>
+                <Link
+                  href={`/profile/${userProfile.username}`}
+                  onClick={() => setMobileOpen(false)}
+                  className="block px-4 py-3 mt-1 text-sm font-bold uppercase tracking-wide text-[#0F0F0F]"
+                >
+                  My Profile
+                </Link>
+                <Link
+                  href="/settings"
+                  onClick={() => setMobileOpen(false)}
+                  className="block px-4 py-3 text-sm font-bold uppercase tracking-wide text-[#0F0F0F]"
+                >
+                  Settings
+                </Link>
+                <Link
+                  href="/settings#referral"
+                  onClick={() => setMobileOpen(false)}
+                  className="block px-4 py-3 text-sm font-bold uppercase tracking-wide text-[#0F0F0F]"
+                >
+                  Referral
+                </Link>
+              </>
+            )}
             <button
               onClick={() => { handleLogout(); setMobileOpen(false); }}
               className="btn-brutal mt-2 w-full justify-center text-sm py-2.5 flex items-center gap-2"
@@ -183,7 +343,7 @@ export function Navbar() {
               }}
             >
               <LogOut size={14} />
-              Logout
+              Log out
             </button>
             </>
           ) : (


### PR DESCRIPTION
## Summary
- **Navbar**: Replaced logout button with circular profile avatar that opens dropdown (My Profile, Settings, Referral, Log out). Works on both desktop and mobile.
- **Dashboard simplified**: Now only shows Stats, Log Activity, Activity Heatmap, Embeddable Badge for GitHub (renamed), Profile Views, Your Projects, and Inbox
- **New /settings page**: Contains Edit Profile (avatar, username, bio, social links, IDE), Email Preferences, and Referral — all moved from dashboard

## Changes
- `src/components/layout/navbar.tsx` — Profile avatar dropdown with user data fetch, click-outside-to-close
- `src/app/dashboard/page.tsx` — Removed Edit Profile, Referral, Email Preferences sections; renamed badge section
- `src/app/settings/page.tsx` — New settings page with all moved sections

## Test plan
- [ ] Log in → navbar shows avatar circle instead of logout button
- [ ] Click avatar → dropdown with My Profile, Settings, Referral, Log out
- [ ] Click outside dropdown → closes
- [ ] Dashboard shows only: stats, activity, heatmap, badge, profile views, projects, inbox
- [ ] /settings page loads with Edit Profile, Email Preferences, Referral
- [ ] Save profile from settings works
- [ ] Mobile nav shows avatar + links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Settings page to edit profile, upload avatar, manage social links, email preferences, referral link, and embeddable GitHub badge.
  * New user profile menu in the navigation bar with quick access to My Profile, Settings, Referral, and Log out.

* **Improvements**
  * Simplified dashboard layout: Profile edit and invite panels removed from the overview for a cleaner flow.
  * Consistent profile display across desktop and mobile; embeddable badge heading clarified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->