### PR TITLE
fix: match dashboard project card width to profile page

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1155,7 +1155,7 @@ export default function DashboardPage() {
           </div>
         )}
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-4">
           {user.projects.map((project) => (
             <div key={project.id}>
               <ProjectCard


### PR DESCRIPTION
## Summary
- Dashboard project cards were too wide (fixed 2-column = ~600px each)
- Changed to `repeat(auto-fill, minmax(300px, 1fr))` grid — same as profile page
- Cards now cap at ~300px wide and auto-fill into 3+ columns on larger screens

## Test plan
- [ ] Check dashboard project cards match profile page card width
- [ ] Cards should be ~300px wide, wrapping into multiple columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)