### PR TITLE
fix: OG preview image not rendering (0 bytes)

### DIFF
--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -25,15 +25,30 @@ export default function Image() {
             display: "flex",
             alignItems: "center",
             gap: 12,
-            marginBottom: 12,
+            marginBottom: 16,
           }}
         >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              width: 36,
+              height: 36,
+              backgroundColor: "#FF3A00",
+              border: "2px solid #0F0F0F",
+              color: "#FFFFFF",
+              fontSize: 18,
+            }}
+          >
+            V
+          </div>
           <span style={{ fontSize: 24, fontWeight: 800, color: "#FF3A00" }}>
             vibetalent.work
           </span>
         </div>
 
-        {/* Main Card */}
+        {/* Main Card — no boxShadow (unsupported by Satori), use border only */}
         <div
           style={{
             display: "flex",
@@ -42,7 +57,6 @@ export default function Image() {
             justifyContent: "center",
             backgroundColor: "#FFFFFF",
             border: "4px solid #0F0F0F",
-            boxShadow: "12px 12px 0 #0F0F0F",
             padding: 60,
           }}
         >
@@ -54,7 +68,6 @@ export default function Image() {
               marginBottom: 24,
             }}
           >
-            <span style={{ fontSize: 48 }}>⚡</span>
             <span
               style={{
                 fontSize: 56,
@@ -75,9 +88,10 @@ export default function Image() {
               color: "#0F0F0F",
               textTransform: "uppercase",
               lineHeight: 1.2,
+              display: "flex",
             }}
           >
-            Find Vibe Coders Who{" "}
+            Find Vibe Coders Who&nbsp;
             <span style={{ color: "#FF3A00" }}>Actually Ship.</span>
           </div>
 
@@ -89,8 +103,8 @@ export default function Image() {
               lineHeight: 1.5,
             }}
           >
-            A marketplace built on consistency and proof of work. No resumes.
-            Just streaks, shipped projects, and vibe scores.
+            The marketplace built on consistency and proof of work. Streaks,
+            shipped projects, and vibe scores.
           </p>
 
           {/* Stats Row */}
@@ -102,10 +116,10 @@ export default function Image() {
             }}
           >
             {[
-              { icon: "🔥", label: "Streaks" },
-              { icon: "📦", label: "Projects" },
-              { icon: "🏆", label: "Badges" },
-              { icon: "⚡", label: "Vibe Score" },
+              { label: "Streaks", color: "#FF3A00" },
+              { label: "Projects", color: "#0F0F0F" },
+              { label: "Badges", color: "#CA8A04" },
+              { label: "Vibe Score", color: "#FF3A00" },
             ].map((item) => (
               <div
                 key={item.label}
@@ -118,7 +132,14 @@ export default function Image() {
                   border: "3px solid #0F0F0F",
                 }}
               >
-                <span style={{ fontSize: 20 }}>{item.icon}</span>
+                <div
+                  style={{
+                    width: 10,
+                    height: 10,
+                    backgroundColor: item.color,
+                    borderRadius: "50%",
+                  }}
+                />
                 <span
                   style={{
                     fontSize: 16,

--- a/src/app/profile/[username]/opengraph-image.tsx
+++ b/src/app/profile/[username]/opengraph-image.tsx
@@ -37,15 +37,15 @@ export default async function Image({
     );
   }
 
-  const badgeEmoji =
+  const badgeLabel =
     user.badge_level === "diamond"
-      ? "💎"
+      ? "DIAMOND"
       : user.badge_level === "gold"
-        ? "🥇"
+        ? "GOLD"
         : user.badge_level === "silver"
-          ? "🥈"
+          ? "SILVER"
           : user.badge_level === "bronze"
-            ? "🥉"
+            ? "BRONZE"
             : "";
 
   return new ImageResponse(
@@ -66,23 +66,38 @@ export default async function Image({
           style={{
             display: "flex",
             alignItems: "center",
-            gap: 16,
-            marginBottom: 12,
+            gap: 12,
+            marginBottom: 16,
           }}
         >
-          <span style={{ fontSize: 28, fontWeight: 800, color: "#FF3A00" }}>
-            ⚡ VibeTalent
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              width: 32,
+              height: 32,
+              backgroundColor: "#FF3A00",
+              border: "2px solid #0F0F0F",
+              color: "#FFFFFF",
+              fontSize: 16,
+              fontWeight: 800,
+            }}
+          >
+            V
+          </div>
+          <span style={{ fontSize: 24, fontWeight: 800, color: "#FF3A00" }}>
+            VibeTalent
           </span>
         </div>
 
-        {/* Main Card */}
+        {/* Main Card — no boxShadow (unsupported by Satori) */}
         <div
           style={{
             display: "flex",
             flex: 1,
             backgroundColor: "#FFFFFF",
             border: "4px solid #0F0F0F",
-            boxShadow: "12px 12px 0 #0F0F0F",
             padding: 48,
             gap: 48,
           }}
@@ -126,8 +141,20 @@ export default async function Image({
               >
                 @{user.username}
               </span>
-              {badgeEmoji && (
-                <span style={{ fontSize: 36 }}>{badgeEmoji}</span>
+              {badgeLabel && (
+                <span
+                  style={{
+                    fontSize: 16,
+                    fontWeight: 800,
+                    color: "#CA8A04",
+                    backgroundColor: "#FFF7ED",
+                    border: "2px solid #0F0F0F",
+                    padding: "4px 12px",
+                    textTransform: "uppercase",
+                  }}
+                >
+                  {badgeLabel}
+                </span>
               )}
             </div>
 
@@ -137,7 +164,6 @@ export default async function Image({
                   fontSize: 22,
                   color: "#52525B",
                   marginTop: 8,
-                  lineClamp: 2,
                 }}
               >
                 {user.bio.slice(0, 100)}
@@ -165,7 +191,7 @@ export default async function Image({
                 <span
                   style={{ fontSize: 36, fontWeight: 800, color: "#FF3A00" }}
                 >
-                  🔥 {user.streak}
+                  {user.streak}
                 </span>
                 <span
                   style={{
@@ -191,7 +217,7 @@ export default async function Image({
                 <span
                   style={{ fontSize: 36, fontWeight: 800, color: "#FF3A00" }}
                 >
-                  ⚡ {user.vibe_score}
+                  {user.vibe_score}
                 </span>
                 <span
                   style={{
@@ -217,7 +243,7 @@ export default async function Image({
                 <span
                   style={{ fontSize: 36, fontWeight: 800, color: "#0F0F0F" }}
                 >
-                  📦 {user.projects.length}
+                  {user.projects.length}
                 </span>
                 <span
                   style={{


### PR DESCRIPTION
## Summary
The OG image endpoint was returning **0 bytes** — a valid HTTP 200 with `content-type: image/png` but an empty body. This is why Discord/WhatsApp/Telegram showed the title and description but no preview image.

**Root cause**: `boxShadow` CSS property is **not supported by Satori** (the renderer behind `next/og` ImageResponse). Using it causes the renderer to silently crash and return an empty PNG.

**Fixes**:
- Removed `boxShadow` from homepage and profile OG images
- Removed emoji characters (can cause edge runtime font issues)  
- Replaced emojis with text labels and colored visual indicators
- Removed `lineClamp` (also unsupported by Satori)

## Test plan
- [ ] After deploy, visit `https://www.vibetalent.work/opengraph-image` — should show an actual image
- [ ] Share `https://www.vibetalent.work/?v=4` in Discord — should show preview with image
- [ ] Share a profile URL in WhatsApp/Telegram — should show profile OG card

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced social sharing preview images with improved visual design, including updated badge styling with text labels, new avatar branding, refined statistics display, and removed shadow effects for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->