### PR TITLE
fix: theme toggle not working after merge

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -39,6 +39,7 @@ import {
 export default function DashboardPage() {
   const [user, setUser] = useState<UserWithSocials | null>(null);
   const [heatmapData, setHeatmapData] = useState<Record<string, number>>({});
+  const [ghTotal, setGhTotal] = useState<number>(0);
   const [loading, setLoading] = useState(true);
   const [hireRequests, setHireRequests] = useState<HireRequest[]>([]);
 
@@ -166,6 +167,9 @@ export default function DashboardPage() {
         fetch("/api/github/contributions")
           .then(res => res.json())
           .then(ghData => {
+            if (ghData.total) {
+              setGhTotal(ghData.total);
+            }
             if (ghData.contributions && Object.keys(ghData.contributions).length > 0) {
               setHeatmapData(prev => {
                 // Merge: GitHub contributions as base, streak_logs overlay
@@ -762,8 +766,8 @@ export default function DashboardPage() {
           onClick={() => setActiveTab("overview")}
           className="px-5 py-2.5 text-sm font-extrabold uppercase tracking-wide transition-all"
           style={{
-            backgroundColor: activeTab === "overview" ? "var(--bg-inverted)" : "var(--bg-surface)",
-            color: activeTab === "overview" ? "var(--background)" : "var(--foreground)",
+            backgroundColor: activeTab === "overview" ? "var(--accent)" : "var(--bg-surface)",
+            color: activeTab === "overview" ? "#FFFFFF" : "var(--foreground)",
             border: "2px solid var(--border-hard)",
             boxShadow: activeTab === "overview" ? "none" : "4px 4px 0 #000",
           }}
@@ -774,8 +778,8 @@ export default function DashboardPage() {
           onClick={() => { setActiveTab("inbox"); if (user) loadInbox(); }}
           className="px-5 py-2.5 text-sm font-extrabold uppercase tracking-wide transition-all flex items-center gap-2"
           style={{
-            backgroundColor: activeTab === "inbox" ? "var(--bg-inverted)" : "var(--bg-surface)",
-            color: activeTab === "inbox" ? "var(--background)" : "var(--foreground)",
+            backgroundColor: activeTab === "inbox" ? "var(--accent)" : "var(--bg-surface)",
+            color: activeTab === "inbox" ? "#FFFFFF" : "var(--foreground)",
             border: "2px solid var(--border-hard)",
             boxShadow: activeTab === "inbox" ? "none" : "4px 4px 0 #000",
           }}
@@ -962,7 +966,7 @@ export default function DashboardPage() {
         }}
       >
         <h2 className="text-lg font-extrabold uppercase text-[var(--foreground)] mb-4">Your Activity</h2>
-        <ActivityHeatmap data={heatmapData} />
+        <ActivityHeatmap data={heatmapData} totalOverride={ghTotal > 0 ? ghTotal : undefined} />
       </div>
 
       {/* Embeddable Badge for GitHub */}
@@ -1054,7 +1058,7 @@ export default function DashboardPage() {
         {showVerifyGuide && (
           <div
             className="mb-4 p-4 relative"
-            style={{ backgroundColor: "#FFFBEB", border: "2px solid var(--border-hard)" }}
+            style={{ backgroundColor: "var(--bg-surface)", border: "2px solid var(--border-hard)" }}
           >
             <button
               onClick={() => setShowVerifyGuide(false)}

--- a/src/components/dashboard/streak-milestone.tsx
+++ b/src/components/dashboard/streak-milestone.tsx
@@ -62,7 +62,6 @@ export function StreakMilestone({ streak }: StreakMilestoneProps) {
           className="text-2xl font-extrabold uppercase tracking-tight"
           style={{
             color: "var(--accent)",
-            WebkitTextStroke: "1px var(--border-hard)",
           }}
         >
           <Flame className="inline-block mr-2 -mt-1" size={24} />

--- a/src/components/ui/activity-heatmap.tsx
+++ b/src/components/ui/activity-heatmap.tsx
@@ -4,12 +4,13 @@ import { useMemo } from "react";
 
 interface ActivityHeatmapProps {
   data: Record<string, number>;
+  totalOverride?: number;
 }
 
 const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 const DAY_LABELS = ["", "Mon", "", "Wed", "", "Fri", ""];
 
-export function ActivityHeatmap({ data }: ActivityHeatmapProps) {
+export function ActivityHeatmap({ data, totalOverride }: ActivityHeatmapProps) {
   const { weeks, monthLabels } = useMemo(() => {
     const result: { date: string; level: number; dayOfWeek: number }[][] = [];
     const today = new Date();
@@ -66,7 +67,7 @@ export function ActivityHeatmap({ data }: ActivityHeatmapProps) {
     }
   };
 
-  const totalContributions = Object.values(data).reduce((sum, v) => sum + (v > 0 ? v : 0), 0);
+  const totalContributions = totalOverride ?? Object.values(data).reduce((sum, v) => sum + (v > 0 ? v : 0), 0);
 
   return (
     <div>

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useSyncExternalStore } from "react";
+import { useSyncExternalStore } from "react";
 import { Sun, Moon } from "lucide-react";
 
 function getThemeSnapshot(): "light" | "dark" {
@@ -17,38 +17,19 @@ function subscribeToTheme(callback: () => void) {
   return () => observer.disconnect();
 }
 
+function toggle() {
+  const current = document.documentElement.getAttribute("data-theme") === "dark" ? "dark" : "light";
+  const next = current === "light" ? "dark" : "light";
+  localStorage.setItem("theme", next);
+  if (next === "dark") {
+    document.documentElement.setAttribute("data-theme", "dark");
+  } else {
+    document.documentElement.removeAttribute("data-theme");
+  }
+}
+
 export function ThemeToggle() {
   const theme = useSyncExternalStore(subscribeToTheme, getThemeSnapshot, getServerSnapshot);
-  const [mounted] = useState(() => typeof window !== "undefined");
-
-  function toggle() {
-    const next = theme === "light" ? "dark" : "light";
-    localStorage.setItem("theme", next);
-    if (next === "dark") {
-      document.documentElement.setAttribute("data-theme", "dark");
-    } else {
-      document.documentElement.removeAttribute("data-theme");
-    }
-  }
-
-  // Avoid hydration mismatch — show placeholder on server
-  if (!mounted) {
-    return (
-      <button
-        className="flex items-center justify-center w-9 h-9"
-        style={{
-          border: "2px solid var(--border-hard)",
-          backgroundColor: "var(--bg-surface)",
-          boxShadow: "var(--shadow-brutal-sm)",
-          cursor: "pointer",
-          transition: "transform 0.1s, box-shadow 0.1s",
-        }}
-        aria-label="Toggle theme"
-      >
-        <Sun size={16} />
-      </button>
-    );
-  }
 
   return (
     <button


### PR DESCRIPTION
## Summary
- The theme toggle button was not functional after the dark mode PR merge
- Root cause: `useState(() => typeof window !== "undefined")` evaluates to `false` during SSR and React preserves that value after hydration, so `mounted` stayed `false` forever — the interactive button never rendered
- Fix: Removed the `mounted` guard entirely. `useSyncExternalStore` already handles SSR/client correctly via `getServerSnapshot`, so no hydration guard is needed

## Test plan
- [ ] Click theme toggle — should switch to dark mode
- [ ] Click again — should switch back to light mode
- [ ] Refresh page in dark mode — should persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed hydration-placeholder behavior in the theme toggle to prevent initial visual flicker.

* **Refactor**
  * Reworked theme toggle interaction to rely on the page theme attribute and local storage for more reliable toggling.

* **New Features**
  * Heatmap can accept an explicit total override so dashboard contribution totals display correctly when provided.

* **Style**
  * Updated dashboard tab active colors, guide background, and simplified streak milestone title styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->