### PR TITLE
fix: consistent contribution count between dashboard and profile

### DIFF
--- a/src/components/profile/profile-heatmap.tsx
+++ b/src/components/profile/profile-heatmap.tsx
@@ -90,9 +90,8 @@ export function ProfileHeatmap({ data, githubUsername }: ProfileHeatmapProps) {
     return { weeks: result, monthLabels: labels };
   }, [mergedData]);
 
-  // Use GitHub's actual total when available; fall back to counting active days from streak_logs
-  const streakTotal = Object.values(data).reduce((sum, v) => sum + (v > 0 ? v : 0), 0);
-  const total = ghTotal > 0 ? ghTotal + streakTotal : streakTotal;
+  // Use GitHub's actual total when available; fall back to counting active days
+  const total = ghTotal > 0 ? ghTotal : Object.values(mergedData).reduce((sum, v) => sum + (v > 0 ? v : 0), 0);
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- Profile heatmap was calculating `ghTotal + streakTotal` which double-counted days that exist in both GitHub data and streak logs
- Dashboard was using just `ghTotal` — causing a mismatch (e.g., 479 on profile vs 467 on dashboard)
- Now both use GitHub's actual total directly when available, falling back to counting active days from merged data

## Test plan
- [ ] Check profile page heatmap shows same contribution count as dashboard heatmap
- [ ] Verify count matches GitHub's public contributions page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the "last year contributions" total displayed in user profiles to accurately calculate the daily maximum contributions from all tracked sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->