### PR TITLE
feat: live platform stats on admin metrics tab

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { createClient } from "@/lib/supabase/client";
-import { Shield, Plus, Trash2, Rocket, Target, BarChart3, Calendar, TrendingUp, Users, Code2, Flame, Award, RefreshCw } from "lucide-react";
+import { Shield, Plus, Trash2, Rocket, Target, BarChart3, Calendar, TrendingUp, Users, Code2, Flame, RefreshCw } from "lucide-react";
 
 const ADMIN_USERS = ["unknownking07", "stuart5915"];
 
@@ -35,6 +35,7 @@ export default function AdminPage() {
   const dataLoaded = useRef(false);
   const [liveStats, setLiveStats] = useState<LiveStats>(null);
   const [statsLoading, setStatsLoading] = useState(false);
+  const statsFetched = useRef(false);
 
   const stored = loadStoredData();
   const [initiatives, setInitiatives] = useState<Initiative[]>(stored?.initiatives ?? SEED_INITIATIVES);
@@ -51,18 +52,23 @@ export default function AdminPage() {
     });
   }, []);
 
-  const fetchLiveStats = async () => {
+  const fetchLiveStats = useCallback(async () => {
     setStatsLoading(true);
     try {
       const res = await fetch("/api/admin-stats");
       if (res.ok) { const data = await res.json(); setLiveStats(data); }
     } catch { /* ignore */ }
     setStatsLoading(false);
-  };
+  }, []);
 
-  useEffect(() => {
-    if (authorized && tab === "metrics") fetchLiveStats();
-  }, [authorized, tab]);
+  // Fetch stats when switching to metrics tab (via onClick, not useEffect)
+  const handleTabClick = useCallback((t: "initiatives" | "roadmap" | "metrics") => {
+    setTab(t);
+    if (t === "metrics" && authorized && !statsFetched.current) {
+      statsFetched.current = true;
+      fetchLiveStats();
+    }
+  }, [authorized, fetchLiveStats]);
 
   useEffect(() => {
     if (!authorized || !dataLoaded.current) { dataLoaded.current = true; return; }
@@ -98,7 +104,7 @@ export default function AdminPage() {
         </div>
         <div style={{ display: "flex", gap: 4, background: "var(--bg-surface)", border: "2px solid var(--border-hard)", borderRadius: 10, padding: 4, boxShadow: "var(--shadow-brutal-sm)" }}>
           {(["initiatives", "roadmap", "metrics"] as const).map(t => (
-            <button key={t} onClick={() => setTab(t)} style={{ padding: "8px 16px", borderRadius: 6, border: "none", cursor: "pointer", fontWeight: 700, fontSize: "0.82rem", textTransform: "capitalize", background: tab === t ? "var(--accent)" : "transparent", color: tab === t ? "white" : "var(--text-muted)" }}>{t}</button>
+            <button key={t} onClick={() => handleTabClick(t)} style={{ padding: "8px 16px", borderRadius: 6, border: "none", cursor: "pointer", fontWeight: 700, fontSize: "0.82rem", textTransform: "capitalize", background: tab === t ? "var(--accent)" : "transparent", color: tab === t ? "white" : "var(--text-muted)" }}>{t}</button>
           ))}
         </div>
       </div>
@@ -147,67 +153,38 @@ export default function AdminPage() {
       {tab === "metrics" && <div>
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 16 }}>
           <h2 style={{ fontSize: "1.1rem", fontWeight: 800, display: "flex", alignItems: "center", gap: 8 }}><BarChart3 size={18} /> Live Platform Stats</h2>
-          <button onClick={fetchLiveStats} style={{ ...btn, background: statsLoading ? "var(--text-muted)" : "var(--accent)" }} disabled={statsLoading}>
+          <button onClick={() => fetchLiveStats()} style={{ ...btn, background: statsLoading ? "var(--text-muted)" : "var(--accent)" }} disabled={statsLoading}>
             <RefreshCw size={14} style={{ animation: statsLoading ? "spin 1s linear infinite" : "none" }} /> Refresh
           </button>
         </div>
 
         {liveStats ? <>
-          {/* Top stats grid */}
           <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 8, marginBottom: 16 }}>
-            <div style={statCard}>
-              <Users size={18} style={{ color: "var(--accent)", margin: "0 auto 6px" }} />
-              <div style={statNum}>{liveStats.builders}</div>
-              <div style={statLabel}>Total Builders</div>
-            </div>
-            <div style={statCard}>
-              <Code2 size={18} style={{ color: "var(--accent)", margin: "0 auto 6px" }} />
-              <div style={statNum}>{liveStats.projects}</div>
-              <div style={statLabel}>Projects Shipped</div>
-            </div>
-            <div style={statCard}>
-              <Flame size={18} style={{ color: "var(--accent)", margin: "0 auto 6px" }} />
-              <div style={statNum}>{liveStats.activeStreaks}</div>
-              <div style={statLabel}>Active Streaks</div>
-            </div>
-            <div style={statCard}>
-              <TrendingUp size={18} style={{ color: liveStats.growth.pct >= 0 ? "#16a34a" : "#EF4444", margin: "0 auto 6px" }} />
-              <div style={{ ...statNum, color: liveStats.growth.pct >= 0 ? "#16a34a" : "#EF4444" }}>
-                {liveStats.growth.pct >= 0 ? "+" : ""}{liveStats.growth.pct}%
-              </div>
-              <div style={statLabel}>Growth (7d)</div>
-            </div>
+            <div style={statCard}><Users size={18} style={{ color: "var(--accent)", margin: "0 auto 6px" }} /><div style={statNum}>{liveStats.builders}</div><div style={statLabel}>Total Builders</div></div>
+            <div style={statCard}><Code2 size={18} style={{ color: "var(--accent)", margin: "0 auto 6px" }} /><div style={statNum}>{liveStats.projects}</div><div style={statLabel}>Projects Shipped</div></div>
+            <div style={statCard}><Flame size={18} style={{ color: "var(--accent)", margin: "0 auto 6px" }} /><div style={statNum}>{liveStats.activeStreaks}</div><div style={statLabel}>Active Streaks</div></div>
+            <div style={statCard}><TrendingUp size={18} style={{ color: liveStats.growth.pct >= 0 ? "#16a34a" : "#EF4444", margin: "0 auto 6px" }} /><div style={{ ...statNum, color: liveStats.growth.pct >= 0 ? "#16a34a" : "#EF4444" }}>{liveStats.growth.pct >= 0 ? "+" : ""}{liveStats.growth.pct}%</div><div style={statLabel}>Growth (7d)</div></div>
           </div>
-
-          {/* Detail stats */}
           <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8, marginBottom: 16 }}>
             <div style={card}>
               <div style={{ fontSize: "0.75rem", fontWeight: 700, color: "var(--text-muted)", marginBottom: 12, textTransform: "uppercase", letterSpacing: "0.05em" }}>Streak Stats</div>
-              <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                <div style={{ display: "flex", justifyContent: "space-between" }}><span style={{ fontSize: "0.82rem", color: "var(--text-muted)" }}>Avg Streak</span><span style={{ fontWeight: 700, fontFamily: "var(--font-jetbrains-mono)" }}>{liveStats.avgStreak} days</span></div>
-                <div style={{ display: "flex", justifyContent: "space-between" }}><span style={{ fontSize: "0.82rem", color: "var(--text-muted)" }}>Longest Streak</span><span style={{ fontWeight: 700, fontFamily: "var(--font-jetbrains-mono)" }}>{liveStats.maxStreak} days</span></div>
-                <div style={{ display: "flex", justifyContent: "space-between" }}><span style={{ fontSize: "0.82rem", color: "var(--text-muted)" }}>Avg Vibe Score</span><span style={{ fontWeight: 700, fontFamily: "var(--font-jetbrains-mono)" }}>{liveStats.avgVibeScore}</span></div>
-                <div style={{ display: "flex", justifyContent: "space-between" }}><span style={{ fontSize: "0.82rem", color: "var(--text-muted)" }}>Hire Requests</span><span style={{ fontWeight: 700, fontFamily: "var(--font-jetbrains-mono)" }}>{liveStats.hires}</span></div>
-                <div style={{ display: "flex", justifyContent: "space-between" }}><span style={{ fontSize: "0.82rem", color: "var(--text-muted)" }}>Endorsements</span><span style={{ fontWeight: 700, fontFamily: "var(--font-jetbrains-mono)" }}>{liveStats.endorsements}</span></div>
-              </div>
+              {[["Avg Streak", `${liveStats.avgStreak} days`], ["Longest Streak", `${liveStats.maxStreak} days`], ["Avg Vibe Score", `${liveStats.avgVibeScore}`], ["Hire Requests", `${liveStats.hires}`], ["Endorsements", `${liveStats.endorsements}`]].map(([l, v]) => (
+                <div key={l} style={{ display: "flex", justifyContent: "space-between", marginBottom: 6 }}><span style={{ fontSize: "0.82rem", color: "var(--text-muted)" }}>{l}</span><span style={{ fontWeight: 700, fontFamily: "var(--font-jetbrains-mono)" }}>{v}</span></div>
+              ))}
             </div>
             <div style={card}>
               <div style={{ fontSize: "0.75rem", fontWeight: 700, color: "var(--text-muted)", marginBottom: 12, textTransform: "uppercase", letterSpacing: "0.05em" }}>Badge Distribution</div>
-              <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                {Object.entries(liveStats.badges).map(([level, count]) => (
-                  <div key={level} style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-                    <span style={{ fontSize: "0.82rem", color: "var(--text-muted)", textTransform: "capitalize" }}>{level === "none" ? "No badge" : level}</span>
-                    <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                      <div style={{ width: Math.max(4, (count / liveStats.builders) * 120), height: 8, borderRadius: 4, background: level === "diamond" ? "#0891B2" : level === "gold" ? "#CA8A04" : level === "silver" ? "#71717A" : level === "bronze" ? "#D97706" : "var(--border-subtle)" }} />
-                      <span style={{ fontWeight: 700, fontFamily: "var(--font-jetbrains-mono)", fontSize: "0.82rem", minWidth: 24, textAlign: "right" }}>{count}</span>
-                    </div>
+              {Object.entries(liveStats.badges).map(([level, count]) => (
+                <div key={level} style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 6 }}>
+                  <span style={{ fontSize: "0.82rem", color: "var(--text-muted)", textTransform: "capitalize" }}>{level === "none" ? "No badge" : level}</span>
+                  <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                    <div style={{ width: Math.max(4, (count / Math.max(liveStats.builders, 1)) * 120), height: 8, borderRadius: 4, background: level === "diamond" ? "#0891B2" : level === "gold" ? "#CA8A04" : level === "silver" ? "#71717A" : level === "bronze" ? "#D97706" : "var(--border-subtle)" }} />
+                    <span style={{ fontWeight: 700, fontFamily: "var(--font-jetbrains-mono)", fontSize: "0.82rem", minWidth: 24, textAlign: "right" }}>{count}</span>
                   </div>
-                ))}
-              </div>
+                </div>
+              ))}
             </div>
           </div>
-
-          {/* Growth detail */}
           <div style={card}>
             <div style={{ fontSize: "0.75rem", fontWeight: 700, color: "var(--text-muted)", marginBottom: 8, textTransform: "uppercase", letterSpacing: "0.05em" }}>Weekly Signups</div>
             <div style={{ display: "flex", gap: 24 }}>
@@ -216,9 +193,8 @@ export default function AdminPage() {
             </div>
             <div style={{ fontSize: "0.7rem", color: "var(--text-muted)", marginTop: 6 }}>Updated: {new Date(liveStats.timestamp).toLocaleString()}</div>
           </div>
-        </> : <div style={{ textAlign: "center", padding: 40, color: "var(--text-muted)" }}>{statsLoading ? "Loading stats..." : "Failed to load stats. Click Refresh."}</div>}
+        </> : <div style={{ textAlign: "center", padding: 40, color: "var(--text-muted)" }}>{statsLoading ? "Loading stats..." : "Click Refresh to load live stats."}</div>}
 
-        {/* Manual log section */}
         <div style={{ marginTop: 24 }}>
           <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 16 }}>
             <h3 style={{ fontSize: "0.95rem", fontWeight: 800, display: "flex", alignItems: "center", gap: 8 }}><Calendar size={16} /> Manual Notes</h3>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -2,13 +2,14 @@
 
 import { useState, useEffect, useRef } from "react";
 import { createClient } from "@/lib/supabase/client";
-import { Shield, Plus, Trash2, Rocket, Target, BarChart3, Calendar } from "lucide-react";
+import { Shield, Plus, Trash2, Rocket, Target, BarChart3, Calendar, TrendingUp, Users, Code2, Flame, Award, RefreshCw } from "lucide-react";
 
 const ADMIN_USERS = ["unknownking07", "stuart5915"];
 
 type Initiative = { id: string; title: string; status: "active" | "planned" | "done" | "paused"; owner: string; notes: string; deadline: string };
 type RoadmapItem = { id: string; title: string; priority: "high" | "medium" | "low"; status: "todo" | "in-progress" | "done"; notes: string };
 type MetricEntry = { id: string; date: string; builders: number; projects: number; hires: number; visits: number; notes: string };
+type LiveStats = { builders: number; projects: number; hires: number; endorsements: number; avgStreak: number; maxStreak: number; activeStreaks: number; avgVibeScore: number; badges: Record<string, number>; growth: { thisWeek: number; lastWeek: number; pct: number }; timestamp: string } | null;
 
 const SC: Record<string, string> = { active: "#16a34a", planned: "#FF3A00", done: "#71717A", paused: "#d97706", todo: "#71717A", "in-progress": "#FF3A00", high: "#EF4444", medium: "#FF3A00", low: "#71717A" };
 
@@ -22,10 +23,7 @@ const SEED_INITIATIVES: Initiative[] = [
 
 function loadStoredData() {
   if (typeof window === "undefined") return null;
-  try {
-    const stored = localStorage.getItem("vt-admin-data");
-    if (stored) return JSON.parse(stored);
-  } catch { /* ignore */ }
+  try { const s = localStorage.getItem("vt-admin-data"); if (s) return JSON.parse(s); } catch { /* ignore */ }
   return null;
 }
 
@@ -35,6 +33,8 @@ export default function AdminPage() {
   const [authorized, setAuthorized] = useState(false);
   const [tab, setTab] = useState<"initiatives" | "roadmap" | "metrics">("initiatives");
   const dataLoaded = useRef(false);
+  const [liveStats, setLiveStats] = useState<LiveStats>(null);
+  const [statsLoading, setStatsLoading] = useState(false);
 
   const stored = loadStoredData();
   const [initiatives, setInitiatives] = useState<Initiative[]>(stored?.initiatives ?? SEED_INITIATIVES);
@@ -50,6 +50,19 @@ export default function AdminPage() {
       setLoading(false);
     });
   }, []);
+
+  const fetchLiveStats = async () => {
+    setStatsLoading(true);
+    try {
+      const res = await fetch("/api/admin-stats");
+      if (res.ok) { const data = await res.json(); setLiveStats(data); }
+    } catch { /* ignore */ }
+    setStatsLoading(false);
+  };
+
+  useEffect(() => {
+    if (authorized && tab === "metrics") fetchLiveStats();
+  }, [authorized, tab]);
 
   useEffect(() => {
     if (!authorized || !dataLoaded.current) { dataLoaded.current = true; return; }
@@ -72,6 +85,9 @@ export default function AdminPage() {
   const sel = (c: string): React.CSSProperties => ({ padding: "4px 8px", borderRadius: 6, border: "2px solid var(--border-subtle)", fontSize: "0.72rem", fontWeight: 700, textTransform: "uppercase", color: c, background: "var(--bg-surface)", cursor: "pointer" });
   const del: React.CSSProperties = { background: "none", border: "none", cursor: "pointer", color: "var(--text-muted)", padding: 4 };
   const tit: React.CSSProperties = { flex: 1, minWidth: 200, fontSize: "0.95rem", fontWeight: 700, background: "transparent", border: "none", color: "var(--foreground)", outline: "none" };
+  const statCard: React.CSSProperties = { ...card, textAlign: "center", padding: "20px 16px" };
+  const statNum: React.CSSProperties = { fontSize: "1.6rem", fontWeight: 900, fontFamily: "var(--font-jetbrains-mono)", color: "var(--foreground)" };
+  const statLabel: React.CSSProperties = { fontSize: "0.65rem", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em", color: "var(--text-muted)", marginTop: 4 };
 
   return (
     <div style={{ maxWidth: 1000, margin: "0 auto", padding: "24px 16px 80px" }}>
@@ -130,25 +146,93 @@ export default function AdminPage() {
 
       {tab === "metrics" && <div>
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 16 }}>
-          <h2 style={{ fontSize: "1.1rem", fontWeight: 800, display: "flex", alignItems: "center", gap: 8 }}><BarChart3 size={18} /> Weekly Metrics</h2>
-          <button onClick={() => setMetrics(p => [{ id: Date.now().toString(), date: new Date().toISOString().slice(0, 10), builders: 0, projects: 0, hires: 0, visits: 0, notes: "" }, ...p])} style={btn}><Plus size={14} /> Log Week</button>
+          <h2 style={{ fontSize: "1.1rem", fontWeight: 800, display: "flex", alignItems: "center", gap: 8 }}><BarChart3 size={18} /> Live Platform Stats</h2>
+          <button onClick={fetchLiveStats} style={{ ...btn, background: statsLoading ? "var(--text-muted)" : "var(--accent)" }} disabled={statsLoading}>
+            <RefreshCw size={14} style={{ animation: statsLoading ? "spin 1s linear infinite" : "none" }} /> Refresh
+          </button>
         </div>
-        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-          {metrics.map(e => <div key={e.id} style={card}>
-            <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 10, flexWrap: "wrap" }}>
-              <Calendar size={14} style={{ color: "var(--text-muted)" }} />
-              <input type="date" value={e.date} onChange={ev => setMetrics(p => p.map(x => x.id === e.id ? { ...x, date: ev.target.value } : x))} style={inp} />
-              <button onClick={() => setMetrics(p => p.filter(x => x.id !== e.id))} style={{ ...del, marginLeft: "auto" }}><Trash2 size={14} /></button>
+
+        {liveStats ? <>
+          {/* Top stats grid */}
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 8, marginBottom: 16 }}>
+            <div style={statCard}>
+              <Users size={18} style={{ color: "var(--accent)", margin: "0 auto 6px" }} />
+              <div style={statNum}>{liveStats.builders}</div>
+              <div style={statLabel}>Total Builders</div>
             </div>
-            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(120px, 1fr))", gap: 8 }}>
-              {(["builders", "projects", "hires", "visits"] as const).map(f => <div key={f} style={{ display: "flex", flexDirection: "column", gap: 2 }}>
-                <label style={{ fontSize: "0.65rem", fontWeight: 700, textTransform: "uppercase", color: "var(--text-muted)", letterSpacing: "0.05em" }}>{f}</label>
-                <input type="number" value={e[f]} onChange={ev => setMetrics(p => p.map(x => x.id === e.id ? { ...x, [f]: parseInt(ev.target.value) || 0 } : x))} style={{ ...inp, fontWeight: 700 }} />
-              </div>)}
+            <div style={statCard}>
+              <Code2 size={18} style={{ color: "var(--accent)", margin: "0 auto 6px" }} />
+              <div style={statNum}>{liveStats.projects}</div>
+              <div style={statLabel}>Projects Shipped</div>
             </div>
-            <input value={e.notes} onChange={ev => setMetrics(p => p.map(x => x.id === e.id ? { ...x, notes: ev.target.value } : x))} placeholder="What happened this week..." style={{ ...inp, width: "100%", marginTop: 8 }} />
-          </div>)}
-          {!metrics.length && <div style={{ textAlign: "center", padding: 40, color: "var(--text-muted)", fontSize: "0.85rem" }}>No metrics yet. Click + Log Week to start tracking.</div>}
+            <div style={statCard}>
+              <Flame size={18} style={{ color: "var(--accent)", margin: "0 auto 6px" }} />
+              <div style={statNum}>{liveStats.activeStreaks}</div>
+              <div style={statLabel}>Active Streaks</div>
+            </div>
+            <div style={statCard}>
+              <TrendingUp size={18} style={{ color: liveStats.growth.pct >= 0 ? "#16a34a" : "#EF4444", margin: "0 auto 6px" }} />
+              <div style={{ ...statNum, color: liveStats.growth.pct >= 0 ? "#16a34a" : "#EF4444" }}>
+                {liveStats.growth.pct >= 0 ? "+" : ""}{liveStats.growth.pct}%
+              </div>
+              <div style={statLabel}>Growth (7d)</div>
+            </div>
+          </div>
+
+          {/* Detail stats */}
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8, marginBottom: 16 }}>
+            <div style={card}>
+              <div style={{ fontSize: "0.75rem", fontWeight: 700, color: "var(--text-muted)", marginBottom: 12, textTransform: "uppercase", letterSpacing: "0.05em" }}>Streak Stats</div>
+              <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <div style={{ display: "flex", justifyContent: "space-between" }}><span style={{ fontSize: "0.82rem", color: "var(--text-muted)" }}>Avg Streak</span><span style={{ fontWeight: 700, fontFamily: "var(--font-jetbrains-mono)" }}>{liveStats.avgStreak} days</span></div>
+                <div style={{ display: "flex", justifyContent: "space-between" }}><span style={{ fontSize: "0.82rem", color: "var(--text-muted)" }}>Longest Streak</span><span style={{ fontWeight: 700, fontFamily: "var(--font-jetbrains-mono)" }}>{liveStats.maxStreak} days</span></div>
+                <div style={{ display: "flex", justifyContent: "space-between" }}><span style={{ fontSize: "0.82rem", color: "var(--text-muted)" }}>Avg Vibe Score</span><span style={{ fontWeight: 700, fontFamily: "var(--font-jetbrains-mono)" }}>{liveStats.avgVibeScore}</span></div>
+                <div style={{ display: "flex", justifyContent: "space-between" }}><span style={{ fontSize: "0.82rem", color: "var(--text-muted)" }}>Hire Requests</span><span style={{ fontWeight: 700, fontFamily: "var(--font-jetbrains-mono)" }}>{liveStats.hires}</span></div>
+                <div style={{ display: "flex", justifyContent: "space-between" }}><span style={{ fontSize: "0.82rem", color: "var(--text-muted)" }}>Endorsements</span><span style={{ fontWeight: 700, fontFamily: "var(--font-jetbrains-mono)" }}>{liveStats.endorsements}</span></div>
+              </div>
+            </div>
+            <div style={card}>
+              <div style={{ fontSize: "0.75rem", fontWeight: 700, color: "var(--text-muted)", marginBottom: 12, textTransform: "uppercase", letterSpacing: "0.05em" }}>Badge Distribution</div>
+              <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                {Object.entries(liveStats.badges).map(([level, count]) => (
+                  <div key={level} style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                    <span style={{ fontSize: "0.82rem", color: "var(--text-muted)", textTransform: "capitalize" }}>{level === "none" ? "No badge" : level}</span>
+                    <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                      <div style={{ width: Math.max(4, (count / liveStats.builders) * 120), height: 8, borderRadius: 4, background: level === "diamond" ? "#0891B2" : level === "gold" ? "#CA8A04" : level === "silver" ? "#71717A" : level === "bronze" ? "#D97706" : "var(--border-subtle)" }} />
+                      <span style={{ fontWeight: 700, fontFamily: "var(--font-jetbrains-mono)", fontSize: "0.82rem", minWidth: 24, textAlign: "right" }}>{count}</span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Growth detail */}
+          <div style={card}>
+            <div style={{ fontSize: "0.75rem", fontWeight: 700, color: "var(--text-muted)", marginBottom: 8, textTransform: "uppercase", letterSpacing: "0.05em" }}>Weekly Signups</div>
+            <div style={{ display: "flex", gap: 24 }}>
+              <div><span style={{ fontFamily: "var(--font-jetbrains-mono)", fontWeight: 700, fontSize: "1.1rem" }}>{liveStats.growth.thisWeek}</span> <span style={{ fontSize: "0.78rem", color: "var(--text-muted)" }}>this week</span></div>
+              <div><span style={{ fontFamily: "var(--font-jetbrains-mono)", fontWeight: 700, fontSize: "1.1rem" }}>{liveStats.growth.lastWeek}</span> <span style={{ fontSize: "0.78rem", color: "var(--text-muted)" }}>last week</span></div>
+            </div>
+            <div style={{ fontSize: "0.7rem", color: "var(--text-muted)", marginTop: 6 }}>Updated: {new Date(liveStats.timestamp).toLocaleString()}</div>
+          </div>
+        </> : <div style={{ textAlign: "center", padding: 40, color: "var(--text-muted)" }}>{statsLoading ? "Loading stats..." : "Failed to load stats. Click Refresh."}</div>}
+
+        {/* Manual log section */}
+        <div style={{ marginTop: 24 }}>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 16 }}>
+            <h3 style={{ fontSize: "0.95rem", fontWeight: 800, display: "flex", alignItems: "center", gap: 8 }}><Calendar size={16} /> Manual Notes</h3>
+            <button onClick={() => setMetrics(p => [{ id: Date.now().toString(), date: new Date().toISOString().slice(0, 10), builders: 0, projects: 0, hires: 0, visits: 0, notes: "" }, ...p])} style={{ ...btn, fontSize: "0.75rem", padding: "6px 12px" }}><Plus size={12} /> Add Note</button>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {metrics.map(e => <div key={e.id} style={card}>
+              <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+                <input type="date" value={e.date} onChange={ev => setMetrics(p => p.map(x => x.id === e.id ? { ...x, date: ev.target.value } : x))} style={inp} />
+                <input value={e.notes} onChange={ev => setMetrics(p => p.map(x => x.id === e.id ? { ...x, notes: ev.target.value } : x))} placeholder="What happened..." style={{ ...inp, flex: 1, minWidth: 200 }} />
+                <button onClick={() => setMetrics(p => p.filter(x => x.id !== e.id))} style={del}><Trash2 size={14} /></button>
+              </div>
+            </div>)}
+          </div>
         </div>
       </div>}
     </div>

--- a/src/app/api/admin-stats/route.ts
+++ b/src/app/api/admin-stats/route.ts
@@ -1,0 +1,94 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+
+function getAdminClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  );
+}
+
+export async function GET() {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sb = getAdminClient() as any;
+
+    const [
+      { count: totalBuilders },
+      { count: totalProjects },
+      { data: streakData },
+      { data: badgeData },
+      { count: totalHires },
+      { count: totalEndorsements },
+      { data: recentUsers },
+      { data: activeStreaks },
+    ] = await Promise.all([
+      sb.from("users").select("id", { count: "exact", head: true }),
+      sb.from("projects").select("id", { count: "exact", head: true }),
+      sb.from("users").select("streak, longest_streak, vibe_score"),
+      sb.from("users").select("badge_level").not("badge_level", "is", null),
+      sb.from("hire_requests").select("id", { count: "exact", head: true }),
+      sb.from("endorsements").select("id", { count: "exact", head: true }),
+      sb.from("users").select("created_at").order("created_at", { ascending: false }).limit(100),
+      sb.from("users").select("streak").gt("streak", 0),
+    ]);
+
+    // Compute stats
+    const builders = totalBuilders || 0;
+    const projects = totalProjects || 0;
+    const hires = totalHires || 0;
+    const endorsements = totalEndorsements || 0;
+
+    // Streak stats
+    const streaks = streakData || [];
+    const avgStreak = streaks.length > 0
+      ? Math.round(streaks.reduce((a: number, u: { streak: number }) => a + u.streak, 0) / streaks.length)
+      : 0;
+    const maxStreak = streaks.length > 0
+      ? Math.max(...streaks.map((u: { longest_streak: number }) => u.longest_streak || 0))
+      : 0;
+    const activeStreakCount = (activeStreaks || []).length;
+    const totalVibeScore = streaks.reduce((a: number, u: { vibe_score: number }) => a + (u.vibe_score || 0), 0);
+    const avgVibeScore = streaks.length > 0 ? Math.round(totalVibeScore / streaks.length) : 0;
+
+    // Badge distribution
+    const badges: Record<string, number> = { none: 0, bronze: 0, silver: 0, gold: 0, diamond: 0 };
+    for (const u of (badgeData || [])) {
+      const level = (u.badge_level || "none").toLowerCase();
+      badges[level] = (badges[level] || 0) + 1;
+    }
+    badges.none = builders - Object.values(badges).reduce((a, b) => a + b, 0) + badges.none;
+
+    // Growth: users joined in last 7 days vs previous 7 days
+    const now = new Date();
+    const weekAgo = new Date(now.getTime() - 7 * 86400000);
+    const twoWeeksAgo = new Date(now.getTime() - 14 * 86400000);
+    const recent = (recentUsers || []) as { created_at: string }[];
+    const thisWeek = recent.filter(u => new Date(u.created_at) >= weekAgo).length;
+    const lastWeek = recent.filter(u => new Date(u.created_at) >= twoWeeksAgo && new Date(u.created_at) < weekAgo).length;
+    const growthPct = lastWeek > 0 ? Math.round(((thisWeek - lastWeek) / lastWeek) * 100) : thisWeek > 0 ? 100 : 0;
+
+    return NextResponse.json({
+      builders,
+      projects,
+      hires,
+      endorsements,
+      avgStreak,
+      maxStreak,
+      activeStreaks: activeStreakCount,
+      avgVibeScore,
+      badges,
+      growth: {
+        thisWeek,
+        lastWeek,
+        pct: growthPct,
+      },
+      timestamp: new Date().toISOString(),
+    }, {
+      headers: { "Cache-Control": "public, s-maxage=120, stale-while-revalidate=300" },
+    });
+  } catch (err) {
+    console.error("Admin stats error:", err);
+    return NextResponse.json({ error: "Failed to fetch stats" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- New `/api/admin-stats` endpoint — aggregates real Supabase data
- Metrics tab now shows live dashboard: total builders, projects, active streaks, hire requests, endorsements, badge distribution, avg vibe score, 7-day growth
- Manual notes section below for tracking events/decisions
- Refresh button to pull latest stats

## Stats shown:
- Total Builders, Projects Shipped, Active Streaks, 7d Growth %
- Streak stats: avg, longest, avg vibe score, hires, endorsements  
- Badge distribution: none/bronze/silver/gold/diamond with bars
- Weekly signups: this week vs last week

## Test plan
- [ ] Visit /admin → metrics tab → verify live stats load
- [ ] Click Refresh → verify updated timestamp
- [ ] Verify badge distribution bars render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)