### PR TITLE
feat: add Feed page — live builder activity stream

### DIFF
--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+
+function getPublicClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  );
+}
+
+type FeedItem = {
+  id: string;
+  type: "streak" | "project";
+  username: string;
+  avatar_url: string | null;
+  badge_level: string;
+  streak: number;
+  date: string;
+  project_title?: string;
+  project_description?: string;
+  tech_stack?: string[];
+  live_url?: string;
+  github_url?: string;
+};
+
+export async function GET(request: NextRequest) {
+  const rawLimit = parseInt(request.nextUrl.searchParams.get("limit") || "50");
+  const limit = Math.min(Math.max(isNaN(rawLimit) ? 50 : rawLimit, 1), 100);
+
+  try {
+    const supabase = getPublicClient();
+
+    const { data: streakLogs, error: streakError } = await supabase
+      .from("streak_logs")
+      .select("id, activity_date, user_id, users!inner(username, avatar_url, badge_level, streak)")
+      .order("activity_date", { ascending: false })
+      .limit(100);
+
+    if (streakError) console.error("Feed: streak_logs fetch error:", streakError);
+
+    const { data: projects, error: projectError } = await supabase
+      .from("projects")
+      .select("id, title, description, tech_stack, live_url, github_url, created_at, user_id, users!inner(username, avatar_url, badge_level, streak)")
+      .eq("flagged", false)
+      .order("created_at", { ascending: false })
+      .limit(20);
+
+    if (projectError) console.error("Feed: projects fetch error:", projectError);
+
+    const feed: FeedItem[] = [];
+
+    if (streakLogs) {
+      for (const log of streakLogs) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const user = log.users as any;
+        if (!user?.username) continue;
+        feed.push({
+          id: `streak-${log.id}`,
+          type: "streak",
+          username: user.username,
+          avatar_url: user.avatar_url || null,
+          badge_level: user.badge_level || "none",
+          streak: user.streak || 0,
+          date: log.activity_date,
+        });
+      }
+    }
+
+    if (projects) {
+      for (const project of projects) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const user = project.users as any;
+        if (!user?.username) continue;
+        feed.push({
+          id: `project-${project.id}`,
+          type: "project",
+          username: user.username,
+          avatar_url: user.avatar_url || null,
+          badge_level: user.badge_level || "none",
+          streak: user.streak || 0,
+          date: project.created_at,
+          project_title: project.title,
+          project_description: project.description,
+          tech_stack: project.tech_stack || [],
+          live_url: project.live_url || undefined,
+          github_url: project.github_url || undefined,
+        });
+      }
+    }
+
+    feed.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+
+    return NextResponse.json(
+      { feed: feed.slice(0, limit) },
+      { headers: { "Cache-Control": "public, s-maxage=60, stale-while-revalidate=120" } }
+    );
+  } catch (err) {
+    console.error("Feed API error:", err);
+    return NextResponse.json({ feed: [] });
+  }
+}

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { Activity, Rocket, Flame, ExternalLink, Github, Loader2 } from "lucide-react";
+
+type FeedItem = {
+  id: string;
+  type: "streak" | "project";
+  username: string;
+  avatar_url: string | null;
+  badge_level: string;
+  streak: number;
+  date: string;
+  project_title?: string;
+  project_description?: string;
+  tech_stack?: string[];
+  live_url?: string;
+  github_url?: string;
+};
+
+function relativeTime(dateStr: string): string {
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  const diff = now - then;
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  return `${Math.floor(days / 30)}mo ago`;
+}
+
+export default function FeedPage() {
+  const [feed, setFeed] = useState<FeedItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    fetch("/api/feed?limit=50")
+      .then((res) => { if (!res.ok) throw new Error(); return res.json(); })
+      .then((data) => setFeed(data.feed || []))
+      .catch(() => setError(true))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return (
+    <div style={{ minHeight: "80vh", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 12 }}>
+      <Loader2 size={28} style={{ color: "var(--accent)", animation: "spin 1s linear infinite" }} />
+      <span style={{ color: "var(--text-muted)", fontFamily: "var(--font-jetbrains-mono)", fontSize: "0.85rem" }}>Loading feed...</span>
+      <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+    </div>
+  );
+
+  return (
+    <div style={{ maxWidth: 680, margin: "0 auto", padding: "32px 16px 80px" }}>
+      <div style={{ marginBottom: 32 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 6 }}>
+          <Activity size={22} style={{ color: "var(--accent)" }} />
+          <h1 style={{ fontSize: "1.75rem", fontWeight: 900, textTransform: "uppercase", letterSpacing: "-0.02em", color: "var(--foreground)", fontFamily: "var(--font-space-grotesk)", margin: 0 }}>Feed</h1>
+        </div>
+        <p style={{ color: "var(--text-muted)", fontSize: "0.9rem", fontWeight: 500, margin: 0 }}>See what builders are shipping and who&apos;s keeping their streak alive.</p>
+      </div>
+
+      {error && <div style={{ textAlign: "center", padding: "40px 24px", color: "var(--text-muted)", fontSize: "0.85rem", background: "var(--bg-surface)", border: "2px solid var(--border-hard)", borderRadius: 12, boxShadow: "var(--shadow-brutal-sm)" }}>Failed to load feed. Try refreshing.</div>}
+
+      {!error && feed.length === 0 && (
+        <div style={{ textAlign: "center", padding: "60px 24px", color: "var(--text-muted)", fontSize: "0.9rem", background: "var(--bg-surface)", border: "2px solid var(--border-hard)", borderRadius: 12, boxShadow: "var(--shadow-brutal-sm)" }}>
+          <Activity size={32} style={{ color: "var(--border-hard)", marginBottom: 12 }} />
+          <p style={{ fontWeight: 700, marginBottom: 4, color: "var(--foreground)" }}>No activity yet</p>
+          <p>Be the first to log a streak or ship a project.</p>
+        </div>
+      )}
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        {feed.map((item) => (
+          <div key={item.id} style={{ background: "var(--bg-surface)", border: "2px solid var(--border-hard)", borderRadius: 12, padding: 16, boxShadow: "var(--shadow-brutal-sm)" }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: item.type === "project" ? 12 : 0 }}>
+              <Link href={`/profile/${item.username}`} style={{ flexShrink: 0, textDecoration: "none" }}>
+                <div style={{ width: 40, height: 40, borderRadius: "50%", border: "2px solid var(--border-hard)", overflow: "hidden", backgroundColor: "var(--bg-inverted)", display: "flex", alignItems: "center", justifyContent: "center" }}>
+                  {item.avatar_url ? (
+                    <Image src={item.avatar_url} alt={item.username} width={40} height={40} style={{ width: "100%", height: "100%", objectFit: "cover", borderRadius: "50%" }} />
+                  ) : (
+                    <span style={{ color: "var(--text-on-inverted)", fontWeight: 800, fontSize: "0.75rem" }}>{item.username.slice(0, 2).toUpperCase()}</span>
+                  )}
+                </div>
+              </Link>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                {item.type === "streak" ? (
+                  <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
+                    <Flame size={16} style={{ color: "var(--accent)", flexShrink: 0 }} />
+                    <Link href={`/profile/${item.username}`} style={{ fontWeight: 800, fontSize: "0.88rem", color: "var(--foreground)", textDecoration: "none" }}>{item.username}</Link>
+                    <span style={{ color: "var(--text-muted)", fontSize: "0.82rem" }}>logged a coding day</span>
+                    {item.streak > 1 && <span style={{ fontSize: "0.72rem", fontWeight: 700, fontFamily: "var(--font-jetbrains-mono)", color: "var(--accent)", background: "rgba(255,58,0,0.08)", padding: "2px 8px", borderRadius: 6, border: "1px solid rgba(255,58,0,0.2)", whiteSpace: "nowrap" }}>{item.streak} day streak</span>}
+                  </div>
+                ) : (
+                  <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
+                    <Rocket size={16} style={{ color: "var(--accent)", flexShrink: 0 }} />
+                    <Link href={`/profile/${item.username}`} style={{ fontWeight: 800, fontSize: "0.88rem", color: "var(--foreground)", textDecoration: "none" }}>{item.username}</Link>
+                    <span style={{ color: "var(--text-muted)", fontSize: "0.82rem" }}>shipped</span>
+                    <span style={{ fontWeight: 800, fontSize: "0.88rem", color: "var(--foreground)" }}>{item.project_title}</span>
+                  </div>
+                )}
+              </div>
+              <span style={{ color: "var(--text-muted)", fontSize: "0.7rem", fontWeight: 600, fontFamily: "var(--font-jetbrains-mono)", whiteSpace: "nowrap", flexShrink: 0 }}>{relativeTime(item.date)}</span>
+            </div>
+
+            {item.type === "project" && (
+              <div style={{ paddingLeft: 50 }}>
+                {item.project_description && <p style={{ color: "var(--text-muted)", fontSize: "0.82rem", lineHeight: 1.5, margin: "0 0 10px 0", display: "-webkit-box", WebkitLineClamp: 3, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{item.project_description}</p>}
+                {item.tech_stack && item.tech_stack.length > 0 && (
+                  <div style={{ display: "flex", flexWrap: "wrap", gap: 4, marginBottom: 10 }}>
+                    {item.tech_stack.slice(0, 6).map((tech) => (
+                      <span key={tech} style={{ fontSize: "0.68rem", fontWeight: 700, fontFamily: "var(--font-jetbrains-mono)", padding: "2px 8px", borderRadius: 4, border: "1px solid var(--border-hard)", background: "var(--bg-surface)", color: "var(--foreground)", textTransform: "lowercase" }}>{tech}</span>
+                    ))}
+                    {item.tech_stack.length > 6 && <span style={{ fontSize: "0.68rem", fontWeight: 600, color: "var(--text-muted)", padding: "2px 6px" }}>+{item.tech_stack.length - 6}</span>}
+                  </div>
+                )}
+                {(item.live_url || item.github_url) && (
+                  <div style={{ display: "flex", gap: 10 }}>
+                    {item.live_url && <a href={item.live_url} target="_blank" rel="noopener noreferrer" style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: "0.75rem", fontWeight: 700, fontFamily: "var(--font-jetbrains-mono)", color: "var(--accent)", textDecoration: "none" }}><ExternalLink size={12} />Live</a>}
+                    {item.github_url && <a href={item.github_url} target="_blank" rel="noopener noreferrer" style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: "0.75rem", fontWeight: 700, fontFamily: "var(--font-jetbrains-mono)", color: "var(--text-muted)", textDecoration: "none" }}><Github size={12} />Source</a>}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -11,6 +11,7 @@ import { ThemeToggle } from "@/components/ui/theme-toggle";
 
 const navLinks = [
   { href: "/explore", label: "Explore" },
+  { href: "/feed", label: "Feed" },
   { href: "/leaderboard", label: "Leaderboard" },
   { href: "/agent", label: "AI Agents" },
   { href: "/dashboard", label: "Dashboard" },


### PR DESCRIPTION
## Summary
- New `/feed` page showing real-time builder activity
- **Streak items**: "🔥 username logged a coding day" with streak count badge
- **Project items**: "🚀 username shipped ProjectName" with description, tech stack pills, live/source links
- New `/api/feed` endpoint aggregates streak_logs + projects from Supabase
- **"Feed" added to navbar** between Explore and Leaderboard
- Matches brutalist design system (thick borders, box shadows, accent colors)
- 60s cache on API for performance

## Test plan
- [ ] Visit /feed — verify activity items load
- [ ] Check streak items show username, flame icon, streak count
- [ ] Check project items show title, description, tech pills, links
- [ ] Verify Feed link appears in navbar (desktop + mobile)
- [ ] Test empty state (if no data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new Feed page displaying recent community activity including streaks and projects
  * Each feed entry shows user avatars, activity summaries, relative timestamps, and links to view user profiles and external project resources
  * Feed is accessible from the main navigation menu and optimized for performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->