### PR TITLE
feat: real GitHub events in feed — commits, PRs, repos

### DIFF
--- a/src/app/api/cron/github-sync/route.ts
+++ b/src/app/api/cron/github-sync/route.ts
@@ -210,6 +210,50 @@ export async function GET(req: NextRequest) {
               return { userInfo, status: "skipped", reason: "No recent qualifying events" };
             }
 
+            // Save events to feed_events table for the activity feed
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const feedRows = recentEvents.slice(0, 10).map((event: any) => {
+              const repoName = (event.repo?.name || 'unknown').replace(/^[^/]+\//, '');
+              let message = '';
+              let eventType = 'push';
+              let githubUrl = '';
+
+              if (event.type === 'PushEvent') {
+                eventType = 'push';
+                message = event.payload?.commits?.[0]?.message?.split('
+')[0] || 'pushed code';
+                const sha = event.payload?.commits?.[0]?.sha || '';
+                githubUrl = sha ? 'https://github.com/' + event.repo?.name + '/commit/' + sha : '';
+              } else if (event.type === 'PullRequestEvent') {
+                eventType = 'pr';
+                message = event.payload?.pull_request?.title || 'opened a pull request';
+                githubUrl = event.payload?.pull_request?.html_url || '';
+              } else if (event.type === 'CreateEvent') {
+                eventType = 'create';
+                const refType = event.payload?.ref_type || 'repository';
+                message = 'created ' + refType + (event.payload?.ref ? ' ' + event.payload.ref : '');
+                githubUrl = 'https://github.com/' + event.repo?.name;
+              } else if (event.type === 'IssuesEvent') {
+                eventType = 'issue';
+                message = event.payload?.issue?.title || 'opened an issue';
+                githubUrl = event.payload?.issue?.html_url || '';
+              }
+
+              return {
+                user_id: userInfo.userId,
+                event_type: eventType,
+                repo_name: repoName,
+                message: message.slice(0, 500),
+                github_url: githubUrl,
+                created_at: event.created_at,
+              };
+            });
+
+            if (feedRows.length > 0) {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              await (supabase as any).from('feed_events').insert(feedRows);
+            }
+
             // Extract unique activity dates
             const activityDates = [
               ...new Set(

--- a/src/app/api/cron/github-sync/route.ts
+++ b/src/app/api/cron/github-sync/route.ts
@@ -220,8 +220,7 @@ export async function GET(req: NextRequest) {
 
               if (event.type === 'PushEvent') {
                 eventType = 'push';
-                message = event.payload?.commits?.[0]?.message?.split('
-')[0] || 'pushed code';
+                message = event.payload?.commits?.[0]?.message?.split("\n")[0] || 'pushed code';
                 const sha = event.payload?.commits?.[0]?.sha || '';
                 githubUrl = sha ? 'https://github.com/' + event.repo?.name + '/commit/' + sha : '';
               } else if (event.type === 'PullRequestEvent') {

--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -10,17 +10,19 @@ function getPublicClient() {
 
 type FeedItem = {
   id: string;
-  type: "streak" | "project";
+  type: "push" | "pr" | "create" | "issue" | "project";
   username: string;
   avatar_url: string | null;
   badge_level: string;
   streak: number;
   date: string;
+  repo_name?: string;
+  message?: string;
+  github_url?: string;
   project_title?: string;
   project_description?: string;
   tech_stack?: string[];
   live_url?: string;
-  github_url?: string;
 };
 
 export async function GET(request: NextRequest) {
@@ -30,15 +32,19 @@ export async function GET(request: NextRequest) {
   try {
     const supabase = getPublicClient();
 
-    const { data: streakLogs, error: streakError } = await supabase
-      .from("streak_logs")
-      .select("id, activity_date, user_id, users!inner(username, avatar_url, badge_level, streak)")
-      .order("activity_date", { ascending: false })
+    // Fetch GitHub events from feed_events table
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: events, error: eventsError } = await (supabase as any)
+      .from("feed_events")
+      .select("id, event_type, repo_name, message, github_url, created_at, user_id, users!inner(username, avatar_url, badge_level, streak)")
+      .order("created_at", { ascending: false })
       .limit(100);
 
-    if (streakError) console.error("Feed: streak_logs fetch error:", streakError);
+    if (eventsError) console.error("Feed: feed_events fetch error:", eventsError);
 
-    const { data: projects, error: projectError } = await supabase
+    // Fetch recent projects with user info
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: projects, error: projectError } = await (supabase as any)
       .from("projects")
       .select("id, title, description, tech_stack, live_url, github_url, created_at, user_id, users!inner(username, avatar_url, badge_level, streak)")
       .eq("flagged", false)
@@ -49,23 +55,28 @@ export async function GET(request: NextRequest) {
 
     const feed: FeedItem[] = [];
 
-    if (streakLogs) {
-      for (const log of streakLogs) {
+    // Map GitHub events to feed items
+    if (events) {
+      for (const event of events) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const user = log.users as any;
+        const user = event.users as any;
         if (!user?.username) continue;
         feed.push({
-          id: `streak-${log.id}`,
-          type: "streak",
+          id: `event-${event.id}`,
+          type: event.event_type || "push",
           username: user.username,
           avatar_url: user.avatar_url || null,
           badge_level: user.badge_level || "none",
           streak: user.streak || 0,
-          date: log.activity_date,
+          date: event.created_at,
+          repo_name: event.repo_name,
+          message: event.message,
+          github_url: event.github_url,
         });
       }
     }
 
+    // Map projects to feed items
     if (projects) {
       for (const project of projects) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -85,6 +96,34 @@ export async function GET(request: NextRequest) {
           live_url: project.live_url || undefined,
           github_url: project.github_url || undefined,
         });
+      }
+    }
+
+    // Fallback: if no feed_events yet, use streak_logs
+    if (!events || events.length === 0) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data: streakLogs } = await (supabase as any)
+        .from("streak_logs")
+        .select("id, activity_date, user_id, users!inner(username, avatar_url, badge_level, streak)")
+        .order("activity_date", { ascending: false })
+        .limit(50);
+
+      if (streakLogs) {
+        for (const log of streakLogs) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const user = log.users as any;
+          if (!user?.username) continue;
+          feed.push({
+            id: `streak-${log.id}`,
+            type: "push",
+            username: user.username,
+            avatar_url: user.avatar_url || null,
+            badge_level: user.badge_level || "none",
+            streak: user.streak || 0,
+            date: log.activity_date,
+            message: "logged a coding day",
+          });
+        }
       }
     }
 

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -3,36 +3,48 @@
 import { useState, useEffect } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { Activity, Rocket, Flame, ExternalLink, Github, Loader2 } from "lucide-react";
+import { Activity, Rocket, Flame, ExternalLink, Github, Loader2, GitPullRequest, GitBranch, AlertCircle } from "lucide-react";
 
 type FeedItem = {
   id: string;
-  type: "streak" | "project";
+  type: "push" | "pr" | "create" | "issue" | "project";
   username: string;
   avatar_url: string | null;
   badge_level: string;
   streak: number;
   date: string;
+  repo_name?: string;
+  message?: string;
+  github_url?: string;
   project_title?: string;
   project_description?: string;
   tech_stack?: string[];
   live_url?: string;
-  github_url?: string;
 };
 
 function relativeTime(dateStr: string): string {
-  const now = Date.now();
-  const then = new Date(dateStr).getTime();
-  const diff = now - then;
-  const seconds = Math.floor(diff / 1000);
-  if (seconds < 60) return "just now";
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  if (days < 30) return `${days}d ago`;
-  return `${Math.floor(days / 30)}mo ago`;
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+function EventIcon({ type }: { type: string }) {
+  if (type === "pr") return <GitPullRequest size={14} style={{ color: "var(--accent)", flexShrink: 0 }} />;
+  if (type === "create") return <GitBranch size={14} style={{ color: "var(--accent)", flexShrink: 0 }} />;
+  if (type === "issue") return <AlertCircle size={14} style={{ color: "var(--accent)", flexShrink: 0 }} />;
+  if (type === "project") return <Rocket size={14} style={{ color: "var(--accent)", flexShrink: 0 }} />;
+  return <Flame size={14} style={{ color: "var(--accent)", flexShrink: 0 }} />;
+}
+
+function actionText(item: FeedItem): string {
+  if (item.type === "project") return `shipped ${item.project_title}`;
+  if (item.type === "pr") return "opened a PR";
+  if (item.type === "create") return "created";
+  if (item.type === "issue") return "opened an issue";
+  return "pushed to";
 }
 
 export default function FeedPage() {
@@ -63,71 +75,82 @@ export default function FeedPage() {
           <Activity size={22} style={{ color: "var(--accent)" }} />
           <h1 style={{ fontSize: "1.75rem", fontWeight: 900, textTransform: "uppercase", letterSpacing: "-0.02em", color: "var(--foreground)", fontFamily: "var(--font-space-grotesk)", margin: 0 }}>Feed</h1>
         </div>
-        <p style={{ color: "var(--text-muted)", fontSize: "0.9rem", fontWeight: 500, margin: 0 }}>See what builders are shipping and who&apos;s keeping their streak alive.</p>
+        <p style={{ color: "var(--text-muted)", fontSize: "0.9rem", fontWeight: 500, margin: 0 }}>Real-time GitHub activity from builders on VibeTalent.</p>
       </div>
 
       {error && <div style={{ textAlign: "center", padding: "40px 24px", color: "var(--text-muted)", fontSize: "0.85rem", background: "var(--bg-surface)", border: "2px solid var(--border-hard)", borderRadius: 12, boxShadow: "var(--shadow-brutal-sm)" }}>Failed to load feed. Try refreshing.</div>}
-
       {!error && feed.length === 0 && (
         <div style={{ textAlign: "center", padding: "60px 24px", color: "var(--text-muted)", fontSize: "0.9rem", background: "var(--bg-surface)", border: "2px solid var(--border-hard)", borderRadius: 12, boxShadow: "var(--shadow-brutal-sm)" }}>
           <Activity size={32} style={{ color: "var(--border-hard)", marginBottom: 12 }} />
           <p style={{ fontWeight: 700, marginBottom: 4, color: "var(--foreground)" }}>No activity yet</p>
-          <p>Be the first to log a streak or ship a project.</p>
+          <p>Activity will appear here as builders push code and ship projects.</p>
         </div>
       )}
 
-      <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
         {feed.map((item) => (
-          <div key={item.id} style={{ background: "var(--bg-surface)", border: "2px solid var(--border-hard)", borderRadius: 12, padding: 16, boxShadow: "var(--shadow-brutal-sm)" }}>
-            <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: item.type === "project" ? 12 : 0 }}>
-              <Link href={`/profile/${item.username}`} style={{ flexShrink: 0, textDecoration: "none" }}>
-                <div style={{ width: 40, height: 40, borderRadius: "50%", border: "2px solid var(--border-hard)", overflow: "hidden", backgroundColor: "var(--bg-inverted)", display: "flex", alignItems: "center", justifyContent: "center" }}>
+          <div key={item.id} style={{ background: "var(--bg-surface)", border: "2px solid var(--border-hard)", borderRadius: 12, padding: "14px 16px", boxShadow: "var(--shadow-brutal-sm)" }}>
+            <div style={{ display: "flex", alignItems: "flex-start", gap: 10 }}>
+              {/* Avatar */}
+              <Link href={`/profile/${item.username}`} style={{ flexShrink: 0, textDecoration: "none", marginTop: 2 }}>
+                <div style={{ width: 36, height: 36, borderRadius: "50%", border: "2px solid var(--border-hard)", overflow: "hidden", backgroundColor: "var(--bg-inverted)", display: "flex", alignItems: "center", justifyContent: "center" }}>
                   {item.avatar_url ? (
-                    <Image src={item.avatar_url} alt={item.username} width={40} height={40} style={{ width: "100%", height: "100%", objectFit: "cover", borderRadius: "50%" }} />
+                    <Image src={item.avatar_url} alt={item.username} width={36} height={36} style={{ width: "100%", height: "100%", objectFit: "cover", borderRadius: "50%" }} />
                   ) : (
-                    <span style={{ color: "var(--text-on-inverted)", fontWeight: 800, fontSize: "0.75rem" }}>{item.username.slice(0, 2).toUpperCase()}</span>
+                    <span style={{ color: "var(--text-on-inverted)", fontWeight: 800, fontSize: "0.7rem" }}>{item.username.slice(0, 2).toUpperCase()}</span>
                   )}
                 </div>
               </Link>
-              <div style={{ flex: 1, minWidth: 0 }}>
-                {item.type === "streak" ? (
-                  <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
-                    <Flame size={16} style={{ color: "var(--accent)", flexShrink: 0 }} />
-                    <Link href={`/profile/${item.username}`} style={{ fontWeight: 800, fontSize: "0.88rem", color: "var(--foreground)", textDecoration: "none" }}>{item.username}</Link>
-                    <span style={{ color: "var(--text-muted)", fontSize: "0.82rem" }}>logged a coding day</span>
-                    {item.streak > 1 && <span style={{ fontSize: "0.72rem", fontWeight: 700, fontFamily: "var(--font-jetbrains-mono)", color: "var(--accent)", background: "rgba(255,58,0,0.08)", padding: "2px 8px", borderRadius: 6, border: "1px solid rgba(255,58,0,0.2)", whiteSpace: "nowrap" }}>{item.streak} day streak</span>}
-                  </div>
-                ) : (
-                  <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
-                    <Rocket size={16} style={{ color: "var(--accent)", flexShrink: 0 }} />
-                    <Link href={`/profile/${item.username}`} style={{ fontWeight: 800, fontSize: "0.88rem", color: "var(--foreground)", textDecoration: "none" }}>{item.username}</Link>
-                    <span style={{ color: "var(--text-muted)", fontSize: "0.82rem" }}>shipped</span>
-                    <span style={{ fontWeight: 800, fontSize: "0.88rem", color: "var(--foreground)" }}>{item.project_title}</span>
-                  </div>
-                )}
-              </div>
-              <span style={{ color: "var(--text-muted)", fontSize: "0.7rem", fontWeight: 600, fontFamily: "var(--font-jetbrains-mono)", whiteSpace: "nowrap", flexShrink: 0 }}>{relativeTime(item.date)}</span>
-            </div>
 
-            {item.type === "project" && (
-              <div style={{ paddingLeft: 50 }}>
-                {item.project_description && <p style={{ color: "var(--text-muted)", fontSize: "0.82rem", lineHeight: 1.5, margin: "0 0 10px 0", display: "-webkit-box", WebkitLineClamp: 3, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{item.project_description}</p>}
-                {item.tech_stack && item.tech_stack.length > 0 && (
-                  <div style={{ display: "flex", flexWrap: "wrap", gap: 4, marginBottom: 10 }}>
-                    {item.tech_stack.slice(0, 6).map((tech) => (
-                      <span key={tech} style={{ fontSize: "0.68rem", fontWeight: 700, fontFamily: "var(--font-jetbrains-mono)", padding: "2px 8px", borderRadius: 4, border: "1px solid var(--border-hard)", background: "var(--bg-surface)", color: "var(--foreground)", textTransform: "lowercase" }}>{tech}</span>
-                    ))}
-                    {item.tech_stack.length > 6 && <span style={{ fontSize: "0.68rem", fontWeight: 600, color: "var(--text-muted)", padding: "2px 6px" }}>+{item.tech_stack.length - 6}</span>}
+              {/* Content */}
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap", marginBottom: item.type !== "project" && item.message ? 4 : 0 }}>
+                  <EventIcon type={item.type} />
+                  <Link href={`/profile/${item.username}`} style={{ fontWeight: 800, fontSize: "0.85rem", color: "var(--foreground)", textDecoration: "none", fontFamily: "var(--font-space-grotesk)" }}>{item.username}</Link>
+                  <span style={{ color: "var(--text-muted)", fontSize: "0.8rem" }}>{actionText(item)}</span>
+                  {item.repo_name && item.type !== "project" && (
+                    <span style={{ fontWeight: 700, fontSize: "0.8rem", fontFamily: "var(--font-jetbrains-mono)", color: "var(--foreground)" }}>{item.repo_name}</span>
+                  )}
+                  {item.streak > 1 && item.type === "push" && (
+                    <span style={{ fontSize: "0.68rem", fontWeight: 700, fontFamily: "var(--font-jetbrains-mono)", color: "var(--accent)", background: "rgba(255,58,0,0.08)", padding: "1px 6px", borderRadius: 4, border: "1px solid rgba(255,58,0,0.2)", whiteSpace: "nowrap" }}>{item.streak}d streak</span>
+                  )}
+                </div>
+
+                {/* Commit message / PR title */}
+                {item.type !== "project" && item.message && item.message !== "logged a coding day" && (
+                  <div style={{ fontSize: "0.78rem", color: "var(--text-muted)", fontFamily: "var(--font-jetbrains-mono)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", maxWidth: "100%" }}>
+                    {item.github_url ? (
+                      <a href={item.github_url} target="_blank" rel="noopener noreferrer" style={{ color: "var(--text-muted)", textDecoration: "none" }}>&quot;{item.message}&quot;</a>
+                    ) : (
+                      <span>&quot;{item.message}&quot;</span>
+                    )}
                   </div>
                 )}
-                {(item.live_url || item.github_url) && (
-                  <div style={{ display: "flex", gap: 10 }}>
-                    {item.live_url && <a href={item.live_url} target="_blank" rel="noopener noreferrer" style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: "0.75rem", fontWeight: 700, fontFamily: "var(--font-jetbrains-mono)", color: "var(--accent)", textDecoration: "none" }}><ExternalLink size={12} />Live</a>}
-                    {item.github_url && <a href={item.github_url} target="_blank" rel="noopener noreferrer" style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: "0.75rem", fontWeight: 700, fontFamily: "var(--font-jetbrains-mono)", color: "var(--text-muted)", textDecoration: "none" }}><Github size={12} />Source</a>}
+
+                {/* Project details */}
+                {item.type === "project" && (
+                  <div style={{ marginTop: 6 }}>
+                    {item.project_description && <p style={{ color: "var(--text-muted)", fontSize: "0.8rem", lineHeight: 1.5, margin: "0 0 8px 0", display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{item.project_description}</p>}
+                    {item.tech_stack && item.tech_stack.length > 0 && (
+                      <div style={{ display: "flex", flexWrap: "wrap", gap: 4, marginBottom: 8 }}>
+                        {item.tech_stack.slice(0, 5).map((tech) => (
+                          <span key={tech} style={{ fontSize: "0.65rem", fontWeight: 700, fontFamily: "var(--font-jetbrains-mono)", padding: "1px 6px", borderRadius: 3, border: "1px solid var(--border-hard)", color: "var(--foreground)", textTransform: "lowercase" }}>{tech}</span>
+                        ))}
+                      </div>
+                    )}
+                    {(item.live_url || item.github_url) && (
+                      <div style={{ display: "flex", gap: 10 }}>
+                        {item.live_url && <a href={item.live_url} target="_blank" rel="noopener noreferrer" style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: "0.72rem", fontWeight: 700, fontFamily: "var(--font-jetbrains-mono)", color: "var(--accent)", textDecoration: "none" }}><ExternalLink size={11} />Live</a>}
+                        {item.github_url && <a href={item.github_url} target="_blank" rel="noopener noreferrer" style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: "0.72rem", fontWeight: 700, fontFamily: "var(--font-jetbrains-mono)", color: "var(--text-muted)", textDecoration: "none" }}><Github size={11} />Source</a>}
+                      </div>
+                    )}
                   </div>
                 )}
               </div>
-            )}
+
+              {/* Time */}
+              <span style={{ color: "var(--text-muted)", fontSize: "0.68rem", fontWeight: 600, fontFamily: "var(--font-jetbrains-mono)", whiteSpace: "nowrap", flexShrink: 0, marginTop: 2 }}>{relativeTime(item.date)}</span>
+            </div>
           </div>
         ))}
       </div>

--- a/src/components/ui/live-activity-feed.tsx
+++ b/src/components/ui/live-activity-feed.tsx
@@ -3,15 +3,17 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import Image from "next/image";
-import { Flame, Rocket, Zap, ArrowRight } from "lucide-react";
+import { Flame, Rocket, Zap, ArrowRight, GitPullRequest, GitBranch } from "lucide-react";
 
 type FeedItem = {
   id: string;
-  type: "streak" | "project";
+  type: "push" | "pr" | "create" | "issue" | "project";
   username: string;
   avatar_url: string | null;
   streak: number;
   date: string;
+  repo_name?: string;
+  message?: string;
   project_title?: string;
 };
 
@@ -22,6 +24,13 @@ function relativeTime(dateStr: string): string {
   const hrs = Math.floor(mins / 60);
   if (hrs < 24) return `${hrs}h ago`;
   return `${Math.floor(hrs / 24)}d ago`;
+}
+
+function EventIcon({ type }: { type: string }) {
+  if (type === "pr") return <GitPullRequest size={14} style={{ color: "var(--accent)", flexShrink: 0 }} />;
+  if (type === "create") return <GitBranch size={14} style={{ color: "var(--accent)", flexShrink: 0 }} />;
+  if (type === "project") return <Rocket size={14} style={{ color: "var(--accent)", flexShrink: 0 }} />;
+  return <Flame size={14} style={{ color: "var(--accent)", flexShrink: 0 }} />;
 }
 
 export function LiveActivityFeed() {
@@ -39,170 +48,48 @@ export function LiveActivityFeed() {
 
   return (
     <section className="mx-auto max-w-7xl px-4 sm:px-6 py-12">
-      <div
-        style={{
-          border: "2px solid var(--border-hard)",
-          borderRadius: "12px",
-          boxShadow: "var(--shadow-brutal-sm)",
-          background: "var(--bg-surface)",
-          overflow: "hidden",
-        }}
-      >
-        {/* Header */}
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            padding: "14px 20px",
-            borderBottom: "2px solid var(--border-hard)",
-            background: "var(--bg-inverted)",
-          }}
-        >
-          <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+      <div style={{ border: "2px solid var(--border-hard)", borderRadius: 12, boxShadow: "var(--shadow-brutal-sm)", background: "var(--bg-surface)", overflow: "hidden" }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "14px 20px", borderBottom: "2px solid var(--border-hard)", background: "var(--bg-inverted)" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
             <Zap size={16} style={{ color: "var(--accent)" }} />
-            <span
-              style={{
-                fontSize: "0.75rem",
-                fontWeight: 800,
-                textTransform: "uppercase",
-                letterSpacing: "0.08em",
-                color: "var(--text-on-inverted)",
-                fontFamily: "var(--font-space-grotesk)",
-              }}
-            >
-              Live Activity
-            </span>
-            <span
-              style={{
-                width: 8,
-                height: 8,
-                borderRadius: "50%",
-                background: "#4ade80",
-                display: "inline-block",
-                animation: "pulse 2s ease-in-out infinite",
-              }}
-            />
+            <span style={{ fontSize: "0.75rem", fontWeight: 800, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--text-on-inverted)", fontFamily: "var(--font-space-grotesk)" }}>Live Activity</span>
+            <span style={{ width: 8, height: 8, borderRadius: "50%", background: "#4ade80", display: "inline-block", animation: "pulse 2s ease-in-out infinite" }} />
           </div>
-          <Link
-            href="/feed"
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: "4px",
-              fontSize: "0.72rem",
-              fontWeight: 700,
-              color: "var(--accent)",
-              textDecoration: "none",
-              fontFamily: "var(--font-jetbrains-mono)",
-              textTransform: "uppercase",
-              letterSpacing: "0.04em",
-            }}
-          >
+          <Link href="/feed" style={{ display: "flex", alignItems: "center", gap: 4, fontSize: "0.72rem", fontWeight: 700, color: "var(--accent)", textDecoration: "none", fontFamily: "var(--font-jetbrains-mono)", textTransform: "uppercase", letterSpacing: "0.04em" }}>
             View Full Feed <ArrowRight size={12} />
           </Link>
         </div>
-
-        {/* Feed items */}
         <div>
           {feed.map((item, idx) => (
-            <div
-              key={item.id}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "10px",
-                padding: "12px 20px",
-                borderBottom: idx < feed.length - 1 ? "1px solid var(--border-subtle, var(--border-hard))" : "none",
-              }}
-            >
-              {/* Avatar */}
+            <div key={item.id} style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 20px", borderBottom: idx < feed.length - 1 ? "1px solid var(--border-subtle, var(--border-hard))" : "none" }}>
               <Link href={`/profile/${item.username}`} style={{ flexShrink: 0, textDecoration: "none" }}>
-                <div
-                  style={{
-                    width: 28,
-                    height: 28,
-                    borderRadius: "50%",
-                    border: "2px solid var(--border-hard)",
-                    overflow: "hidden",
-                    backgroundColor: "var(--bg-inverted)",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                  }}
-                >
+                <div style={{ width: 28, height: 28, borderRadius: "50%", border: "2px solid var(--border-hard)", overflow: "hidden", backgroundColor: "var(--bg-inverted)", display: "flex", alignItems: "center", justifyContent: "center" }}>
                   {item.avatar_url ? (
-                    <Image
-                      src={item.avatar_url}
-                      alt={item.username}
-                      width={28}
-                      height={28}
-                      style={{ width: "100%", height: "100%", objectFit: "cover", borderRadius: "50%" }}
-                    />
+                    <Image src={item.avatar_url} alt={item.username} width={28} height={28} style={{ width: "100%", height: "100%", objectFit: "cover", borderRadius: "50%" }} />
                   ) : (
-                    <span style={{ color: "var(--text-on-inverted)", fontWeight: 800, fontSize: "0.6rem" }}>
-                      {item.username.slice(0, 2).toUpperCase()}
-                    </span>
+                    <span style={{ color: "var(--text-on-inverted)", fontWeight: 800, fontSize: "0.6rem" }}>{item.username.slice(0, 2).toUpperCase()}</span>
                   )}
                 </div>
               </Link>
-
-              {/* Icon */}
-              {item.type === "streak" ? (
-                <Flame size={14} style={{ color: "var(--accent)", flexShrink: 0 }} />
-              ) : (
-                <Rocket size={14} style={{ color: "var(--accent)", flexShrink: 0 }} />
-              )}
-
-              {/* Text */}
-              <div style={{ flex: 1, minWidth: 0, display: "flex", alignItems: "center", gap: "5px", flexWrap: "wrap" }}>
-                <Link
-                  href={`/profile/${item.username}`}
-                  style={{
-                    fontWeight: 800,
-                    fontSize: "0.82rem",
-                    color: "var(--foreground)",
-                    textDecoration: "none",
-                    fontFamily: "var(--font-space-grotesk)",
-                  }}
-                >
-                  {item.username}
-                </Link>
-                <span style={{ color: "var(--text-muted)", fontSize: "0.78rem" }}>
-                  {item.type === "streak" ? "logged a coding day" : `shipped ${item.project_title}`}
-                </span>
-                {item.type === "streak" && item.streak > 1 && (
-                  <span
-                    style={{
-                      fontSize: "0.68rem",
-                      fontWeight: 700,
-                      fontFamily: "var(--font-jetbrains-mono)",
-                      color: "var(--accent)",
-                      background: "rgba(255,58,0,0.08)",
-                      padding: "1px 6px",
-                      borderRadius: "4px",
-                      border: "1px solid rgba(255,58,0,0.2)",
-                      whiteSpace: "nowrap",
-                    }}
-                  >
-                    {item.streak}d streak
-                  </span>
+              <EventIcon type={item.type} />
+              <div style={{ flex: 1, minWidth: 0, display: "flex", alignItems: "center", gap: 5, overflow: "hidden" }}>
+                <Link href={`/profile/${item.username}`} style={{ fontWeight: 800, fontSize: "0.8rem", color: "var(--foreground)", textDecoration: "none", fontFamily: "var(--font-space-grotesk)", flexShrink: 0 }}>{item.username}</Link>
+                {item.type === "project" ? (
+                  <span style={{ color: "var(--text-muted)", fontSize: "0.76rem", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>shipped <strong style={{ color: "var(--foreground)" }}>{item.project_title}</strong></span>
+                ) : (
+                  <>
+                    <span style={{ color: "var(--text-muted)", fontSize: "0.76rem", flexShrink: 0 }}>{item.type === "pr" ? "PR" : "pushed"}</span>
+                    {item.repo_name && <span style={{ fontWeight: 700, fontSize: "0.76rem", fontFamily: "var(--font-jetbrains-mono)", color: "var(--foreground)", flexShrink: 0 }}>{item.repo_name}</span>}
+                    {item.message && item.message !== "logged a coding day" && (
+                      <span style={{ color: "var(--text-muted)", fontSize: "0.72rem", fontFamily: "var(--font-jetbrains-mono)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{item.message}</span>
+                    )}
+                  </>
+                )}
+                {item.streak > 1 && item.type === "push" && (
+                  <span style={{ fontSize: "0.65rem", fontWeight: 700, fontFamily: "var(--font-jetbrains-mono)", color: "var(--accent)", background: "rgba(255,58,0,0.08)", padding: "1px 6px", borderRadius: 4, border: "1px solid rgba(255,58,0,0.2)", whiteSpace: "nowrap", flexShrink: 0 }}>{item.streak}d</span>
                 )}
               </div>
-
-              {/* Time */}
-              <span
-                style={{
-                  color: "var(--text-muted)",
-                  fontSize: "0.68rem",
-                  fontWeight: 600,
-                  fontFamily: "var(--font-jetbrains-mono)",
-                  whiteSpace: "nowrap",
-                  flexShrink: 0,
-                }}
-              >
-                {relativeTime(item.date)}
-              </span>
+              <span style={{ color: "var(--text-muted)", fontSize: "0.65rem", fontWeight: 600, fontFamily: "var(--font-jetbrains-mono)", whiteSpace: "nowrap", flexShrink: 0 }}>{relativeTime(item.date)}</span>
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- **GitHub sync cron** now saves events to `feed_events` table (push, PR, create, issue) with repo name, commit message, and GitHub URL
- **Feed API** reads from `feed_events` with fallback to `streak_logs` if table is empty
- **Feed page** shows: repo name, commit message/PR title, clickable GitHub links
- **Homepage live feed** updated to show push/PR details inline
- Requires `feed_events` table in Supabase (already created by Abhinav)

## What it looks like
```
🔥 unknownking07 pushed vibe-talent
   "feat: add Feed page — live builder activity stream"    2h ago

🚀 builder42 shipped VibeTracker
   A habit tracking app for developers...                   5h ago
```

## Test plan
- [ ] Wait for next GitHub sync cron run (or trigger manually)
- [ ] Visit /feed — verify events show repo names and commit messages
- [ ] Homepage live feed shows the same data
- [ ] Fallback works if feed_events is empty (shows streak_logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activity feed now shows GitHub events (pushes, PRs, issues, branch creates) alongside projects.
  * Feed items include repo name, optional message, and link to the GitHub activity.

* **UI Improvements**
  * Simplified relative timestamps and updated icons/action labels per event type.
  * Streak badge now appears for push events and message/spacing refinements on feed cards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->