### PR TITLE
feat: hourly github-sync cron for faster feed

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,12 @@
   "redirects": [
     {
       "source": "/(.*)",
-      "has": [{ "type": "host", "value": "vibetalent.work" }],
+      "has": [
+        {
+          "type": "host",
+          "value": "vibetalent.work"
+        }
+      ],
       "destination": "https://www.vibetalent.work/$1",
       "permanent": true
     }
@@ -15,6 +20,10 @@
     {
       "path": "/api/cron/check-live-urls",
       "schedule": "0 3 * * 0"
+    },
+    {
+      "path": "/api/cron/github-sync",
+      "schedule": "0 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Added hourly cron for `/api/cron/github-sync` so the feed updates every hour instead of once daily.

## Test plan
- [ ] Verify cron appears in Vercel dashboard after deploy
- [ ] Feed populates within 1 hour of merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)