### PR TITLE
fix: remove hourly cron — blocking all Vercel deploys

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -20,10 +20,6 @@
     {
       "path": "/api/cron/check-live-urls",
       "schedule": "0 3 * * 0"
-    },
-    {
-      "path": "/api/cron/github-sync",
-      "schedule": "0 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## CRITICAL FIX
The hourly github-sync cron (`0 * * * *`) was blocking ALL Vercel deployments because the Hobby plan only supports daily crons. Removed it — the daily orchestrator at `/api/cron/daily` already calls github-sync anyway.

Merge ASAP to unblock deploys.