### PR TITLE
feat: feed triggers github-sync on visit — no Pro plan needed

### DIFF
--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -8,6 +8,10 @@ function getPublicClient() {
   );
 }
 
+// Simple in-memory throttle — only trigger sync every 30 min per instance
+let lastSyncTrigger = 0;
+const SYNC_INTERVAL = 30 * 60 * 1000; // 30 minutes
+
 type FeedItem = {
   id: string;
   type: "push" | "pr" | "create" | "issue" | "project" | "streak";
@@ -30,6 +34,20 @@ export async function GET(request: NextRequest) {
   const limit = Math.min(Math.max(isNaN(rawLimit) ? 50 : rawLimit, 1), 100);
 
   try {
+    // Trigger github-sync in the background (fire-and-forget) so feed is fresh
+    // Only runs if last sync was >30 min ago (tracked via simple cache)
+    const now = Date.now();
+    if (now - lastSyncTrigger > SYNC_INTERVAL) {
+      lastSyncTrigger = now;
+      const baseUrl = request.nextUrl.origin || "https://www.vibetalent.work";
+      const cronSecret = process.env.CRON_SECRET;
+      if (cronSecret) {
+        fetch(`${baseUrl}/api/cron/github-sync`, {
+          headers: { Authorization: `Bearer ${cronSecret}` },
+        }).catch(() => {});
+      }
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const supabase = getPublicClient() as any;
     const feed: FeedItem[] = [];

--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -8,9 +8,9 @@ function getPublicClient() {
   );
 }
 
-// Simple in-memory throttle — only trigger sync every 30 min per instance
+// Throttle: only trigger sync every 30 min per serverless instance
 let lastSyncTrigger = 0;
-const SYNC_INTERVAL = 30 * 60 * 1000; // 30 minutes
+const SYNC_INTERVAL = 30 * 60 * 1000;
 
 type FeedItem = {
   id: string;
@@ -34,8 +34,7 @@ export async function GET(request: NextRequest) {
   const limit = Math.min(Math.max(isNaN(rawLimit) ? 50 : rawLimit, 1), 100);
 
   try {
-    // Trigger github-sync in the background (fire-and-forget) so feed is fresh
-    // Only runs if last sync was >30 min ago (tracked via simple cache)
+    // Trigger github-sync in background if stale (fire-and-forget)
     const now = Date.now();
     if (now - lastSyncTrigger > SYNC_INTERVAL) {
       lastSyncTrigger = now;
@@ -90,7 +89,7 @@ export async function GET(request: NextRequest) {
         }
       }
     } catch {
-      // feed_events table may not exist yet â€” fall through to streak_logs
+      // feed_events table may not exist yet
     }
 
     // Fallback: if no feed_events, use streak_logs


### PR DESCRIPTION
## Summary
When someone visits /feed (or homepage loads the feed widget), it triggers github-sync in the background. Throttled to once per 30 minutes per serverless instance so it doesn't spam GitHub API. 

This means the feed stays fresh without needing Vercel Pro hourly crons.

## How it works
1. User visits /feed
2. Feed API fires off `/api/cron/github-sync` in background (fire-and-forget)
3. Current feed data returns immediately (doesn't wait for sync)
4. Next visit (after sync completes) shows updated data
5. Won't re-trigger for 30 minutes

## Test plan
- [ ] Visit /feed — check if github-sync runs (check Vercel function logs)
- [ ] Visit again within 30min — should NOT re-trigger
- [ ] After 30min, visit again — should trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented per-instance throttling for background data synchronization to enhance efficiency. Sync operations now respect a 30-minute interval between triggers, reducing redundant requests and unnecessary resource consumption while maintaining data consistency and system performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->