### PR TITLE
fix: feed shows weeks of history + dedup streak_logs

### DIFF
--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -30,8 +30,8 @@ type FeedItem = {
 };
 
 export async function GET(request: NextRequest) {
-  const rawLimit = parseInt(request.nextUrl.searchParams.get("limit") || "50");
-  const limit = Math.min(Math.max(isNaN(rawLimit) ? 50 : rawLimit, 1), 100);
+  const rawLimit = parseInt(request.nextUrl.searchParams.get("limit") || "100");
+  const limit = Math.min(Math.max(isNaN(rawLimit) ? 100 : rawLimit, 1), 200);
 
   try {
     // Trigger github-sync in background if stale (fire-and-forget)
@@ -60,17 +60,15 @@ export async function GET(request: NextRequest) {
       userMap.set(u.id, { username: u.username, avatar_url: u.avatar_url, badge_level: u.badge_level || "none", streak: u.streak || 0 });
     }
 
-    // Try feed_events first (may not exist yet or be empty)
-    let hasFeedEvents = false;
+    // 1. Fetch detailed GitHub events from feed_events
     try {
       const { data: events, error: eventsError } = await supabase
         .from("feed_events")
         .select("id, event_type, repo_name, message, github_url, created_at, user_id")
         .order("created_at", { ascending: false })
-        .limit(100);
+        .limit(200);
 
-      if (!eventsError && events && events.length > 0) {
-        hasFeedEvents = true;
+      if (!eventsError && events) {
         for (const event of events) {
           const user = userMap.get(event.user_id);
           if (!user) continue;
@@ -92,37 +90,45 @@ export async function GET(request: NextRequest) {
       // feed_events table may not exist yet
     }
 
-    // Fallback: if no feed_events, use streak_logs
-    if (!hasFeedEvents) {
-      const { data: streakLogs } = await supabase
-        .from("streak_logs")
-        .select("id, activity_date, user_id")
-        .order("activity_date", { ascending: false })
-        .limit(100);
+    // 2. ALWAYS include streak_logs for historical depth
+    // These go back weeks while feed_events only has data since today
+    const { data: streakLogs } = await supabase
+      .from("streak_logs")
+      .select("id, activity_date, user_id")
+      .order("activity_date", { ascending: false })
+      .limit(300);
 
-      for (const log of (streakLogs || [])) {
-        const user = userMap.get(log.user_id);
-        if (!user) continue;
-        feed.push({
-          id: `streak-${log.id}`,
-          type: "streak",
-          username: user.username,
-          avatar_url: user.avatar_url,
-          badge_level: user.badge_level,
-          streak: user.streak,
-          date: log.activity_date,
-          message: "logged a coding day",
-        });
-      }
+    // Build set of user+date combos from feed_events to avoid duplicates
+    const coveredDates = new Set(
+      feed.map(f => f.username + "|" + f.date.slice(0, 10))
+    );
+
+    for (const log of (streakLogs || [])) {
+      const user = userMap.get(log.user_id);
+      if (!user) continue;
+      // Skip if feed_events already covers this user on this date
+      const key = user.username + "|" + log.activity_date;
+      if (coveredDates.has(key)) continue;
+      coveredDates.add(key); // also dedup within streak_logs
+      feed.push({
+        id: `streak-${log.id}`,
+        type: "streak",
+        username: user.username,
+        avatar_url: user.avatar_url,
+        badge_level: user.badge_level,
+        streak: user.streak,
+        date: log.activity_date,
+        message: "logged a coding day",
+      });
     }
 
-    // Always include recent projects
+    // 3. Always include recent projects
     const { data: projects } = await supabase
       .from("projects")
       .select("id, title, description, tech_stack, live_url, github_url, created_at, user_id")
       .eq("flagged", false)
       .order("created_at", { ascending: false })
-      .limit(20);
+      .limit(30);
 
     for (const project of (projects || [])) {
       const user = userMap.get(project.user_id);


### PR DESCRIPTION
## Summary
- streak_logs now ALWAYS loads alongside feed_events (was only fallback before)
- Dedupes by user+date so same day doesn't appear twice
- Increased limits: 200 feed_events, 300 streak_logs, default 100 items returned
- Feed now shows weeks of builder activity, not just the last hour

Also: Abi needs to run this SQL to fix existing duplicates in feed_events:
```sql
DELETE FROM feed_events a USING feed_events b
WHERE a.id > b.id AND a.user_id = b.user_id AND a.created_at = b.created_at
  AND a.repo_name = b.repo_name AND a.event_type = b.event_type;

CREATE UNIQUE INDEX IF NOT EXISTS idx_feed_events_unique
  ON feed_events(user_id, event_type, repo_name, created_at);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)