### PR TITLE
fix: remove grayscale from feed avatars

### DIFF
--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -139,7 +139,7 @@ export default function FeedPage() {
         .fl-feed-item { display: flex; gap: 16px; padding: 24px 0; border-bottom: 1px solid rgba(255,255,255,0.08); transition: all 0.2s; }
         .fl-feed-item:hover { background: rgba(255,255,255,0.02); border-radius: 8px; margin: 0 -16px; padding: 24px 16px; }
         .fl-avatar { width: 48px; height: 48px; border-radius: 50%; background: var(--bg-surface, #15151A); border: 1px solid var(--border-hard, #2A2A33); display: flex; align-items: center; justify-content: center; flex-shrink: 0; overflow: hidden; }
-        .fl-avatar img { width: 100%; height: 100%; object-fit: cover; filter: grayscale(100%) contrast(1.2); opacity: 0.8; }
+        .fl-avatar img { width: 100%; height: 100%; object-fit: cover; opacity: 1; }
         .fl-avatar.orange { background: var(--accent, #FF4A2A); border-color: var(--accent, #FF4A2A); color: #0A0A0E; font-weight: 600; font-size: 14px; }
         .fl-tag { display: inline-flex; align-items: center; gap: 4px; padding: 2px 8px; border-radius: 999px; font-size: 12px; font-weight: 500; vertical-align: middle; margin: 0 4px; }
         .fl-tag-dark { background: var(--bg-surface, #15151A); border: 1px solid var(--border-hard, #2A2A33); color: var(--foreground, #fff); }


### PR DESCRIPTION
Avatars now show in full color instead of black and white.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Feed avatar images now display with original colors and full opacity instead of a faded appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->