### PR TITLE
fix: nudge GitHub URL on project submission

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -229,6 +229,7 @@ export default function DashboardPage() {
 
   const [showProjectForm, setShowProjectForm] = useState(false);
   const [projectError, setProjectError] = useState("");
+  const [githubSkipped, setGithubSkipped] = useState(false);
   const [projectForm, setProjectForm] = useState({
     title: "",
     description: "",
@@ -590,6 +591,10 @@ export default function DashboardPage() {
         setProjectError("GitHub URL must be in the format: https://github.com/username/repo");
         return;
       }
+    } else if (!githubSkipped) {
+      setProjectError("Adding a GitHub URL helps verify your project and boosts your quality score. Click submit again to skip.");
+      setGithubSkipped(true);
+      return;
     }
 
     setAddingProject(true);
@@ -637,6 +642,7 @@ export default function DashboardPage() {
     setProjectImagePreview(null);
     setShowProjectForm(false);
     setAddingProject(false);
+    setGithubSkipped(false);
 
     // Auto-verify if project has a GitHub URL
     if (projectForm.github_url && insertedProject?.id) {
@@ -687,6 +693,10 @@ export default function DashboardPage() {
         setProjectError("GitHub URL must be in the format: https://github.com/username/repo");
         return;
       }
+    } else if (!githubSkipped) {
+      setProjectError("Adding a GitHub URL helps verify your project and boosts your quality score. Click save again to skip.");
+      setGithubSkipped(true);
+      return;
     }
 
     setSavingEdit(true);
@@ -734,6 +744,7 @@ export default function DashboardPage() {
     setEditingProjectId(null);
     setEditingOriginalGithubUrl("");
     setSavingEdit(false);
+    setGithubSkipped(false);
 
     if (githubUrlChanged && projectForm.github_url && savedEditingId) {
       verifyProject(savedEditingId);
@@ -1095,6 +1106,7 @@ export default function DashboardPage() {
                 setShowProjectForm(false);
                 setEditingProjectId(null);
                 setProjectForm({ title: "", description: "", tech_stack: "", live_url: "", github_url: "", build_time: "", tags: "" });
+                setGithubSkipped(false);
               } else {
                 setShowProjectForm(true);
               }
@@ -1185,7 +1197,7 @@ export default function DashboardPage() {
                 />
                 <input
                   type="text"
-                  placeholder="GitHub URL"
+                  placeholder="GitHub URL (recommended)"
                   value={projectForm.github_url}
                   onChange={(e) => setProjectForm({ ...projectForm, github_url: e.target.value })}
                   className="input-brutal"


### PR DESCRIPTION
## Summary
- Shows warning when GitHub URL is missing on first submit: "Adding a GitHub URL helps verify your project and boosts your quality score. Click submit again to skip."
- Same nudge on project edit
- Placeholder updated to "GitHub URL (recommended)"
- Skip state resets when form is closed or after successful submission

## Test plan
- [ ] Submit project without GitHub URL — see warning on first click, submits on second
- [ ] Submit project with GitHub URL — no warning
- [ ] Edit project, remove GitHub URL — see warning on first save, saves on second
- [ ] Cancel form and reopen — warning resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub URL field is now optional when creating or editing projects; users receive guidance on the first attempt to skip it, then can proceed without one on subsequent attempts
  * Updated field label to indicate GitHub URL is recommended but not required

<!-- end of auto-generated comment: release notes by coderabbit.ai -->