### PR TITLE
fix: add /feed page to sitemap

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -8,6 +8,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: siteUrl, lastModified: new Date(), changeFrequency: "daily" as const, priority: 1 },
     { url: `${siteUrl}/explore`, lastModified: new Date(), changeFrequency: "daily" as const, priority: 0.9 },
     { url: `${siteUrl}/leaderboard`, lastModified: new Date(), changeFrequency: "daily" as const, priority: 0.8 },
+    { url: `${siteUrl}/feed`, lastModified: new Date(), changeFrequency: "hourly" as const, priority: 0.8 },
     { url: `${siteUrl}/agent`, lastModified: new Date(), changeFrequency: "weekly" as const, priority: 0.8 },
     { url: `${siteUrl}/agent/find`, lastModified: new Date(), changeFrequency: "weekly" as const, priority: 0.7 },
     { url: `${siteUrl}/agent/chat`, lastModified: new Date(), changeFrequency: "weekly" as const, priority: 0.7 },


### PR DESCRIPTION
## Summary
- Add `/feed` to sitemap with hourly change frequency for Google indexing

## Test plan
- [ ] Verify `https://vibetalent.work/sitemap.xml` includes `/feed` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated sitemap configuration to include the feed route with optimized search engine settings: configured for hourly crawling with a priority rating of 0.8, enhancing search engine visibility and ensuring the feed page is properly indexed for better discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->