### PR TITLE
fix: prevent false login redirect on dashboard navigation

### DIFF
--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -39,14 +39,14 @@ export async function updateSession(request: NextRequest) {
     }
   );
 
-  // Use getSession() (reads cookies locally, no network call) for the
-  // middleware guard. The dashboard component calls getUser() itself for
-  // the verified auth state — no need to do it twice.
+  // Use getUser() to validate the JWT and refresh the session if needed.
+  // getSession() only reads cookies locally and won't refresh an expired
+  // access token, which causes false redirects to login on client-side nav.
   const {
-    data: { session },
-  } = await supabase.auth.getSession();
+    data: { user },
+  } = await supabase.auth.getUser();
 
-  if (!session) {
+  if (!user) {
     const url = request.nextUrl.clone();
     url.pathname = "/auth/login";
     return NextResponse.redirect(url);


### PR DESCRIPTION
## Summary
- Replaced `getSession()` with `getUser()` in Supabase middleware to fix authenticated users being incorrectly redirected to the login page when clicking Dashboard
- `getSession()` only reads cookies locally and doesn't refresh expired access tokens, while `getUser()` validates the JWT server-side and refreshes automatically

## Test plan
- [ ] Log in, wait for session token to age, then click Dashboard from navbar — should load without flashing login page
- [ ] Hard refresh on /dashboard still works as before
- [ ] Unauthenticated users are still redirected to login

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced authentication verification for protected routes to ensure more reliable user login redirection and session handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->