### PR TITLE
fix: auth redirect fallback for dashboard navigation

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { createClient } from "@/lib/supabase/client";
 import Link from "next/link";
 import { Flame, Github, Mail, Lock } from "lucide-react";
@@ -12,6 +12,16 @@ export default function LoginPage() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [consentProvider, setConsentProvider] = useState<"github" | "google" | null>(null);
+
+  // Redirect already-authenticated users to dashboard
+  useEffect(() => {
+    const supabase = createClient();
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (user) {
+        window.location.href = "/dashboard";
+      }
+    });
+  }, []);
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -39,14 +39,24 @@ export async function updateSession(request: NextRequest) {
     }
   );
 
-  // Use getUser() to validate the JWT and refresh the session if needed.
-  // getSession() only reads cookies locally and won't refresh an expired
-  // access token, which causes false redirects to login on client-side nav.
+  // Try getUser() first (validates JWT, refreshes token if needed).
+  // Fall back to getSession() (local cookie read) if the network call fails,
+  // so we don't redirect authenticated users to login on transient errors.
   const {
     data: { user },
+    error,
   } = await supabase.auth.getUser();
 
   if (!user) {
+    // If getUser() failed due to a network/server error, check session locally
+    if (error) {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (session) {
+        return supabaseResponse;
+      }
+    }
     const url = request.nextUrl.clone();
     url.pathname = "/auth/login";
     return NextResponse.redirect(url);


### PR DESCRIPTION
## Summary
- Middleware now falls back to `getSession()` (local cookie read) when `getUser()` fails due to network/server errors, preventing false redirects to login
- Login page now checks if user is already authenticated and redirects to `/dashboard`, so users never get stuck on the login page while logged in

## Context
The previous `getUser()` fix wasn't sufficient — the Supabase API call can fail on the edge runtime (timeouts, transient errors), causing authenticated users to see the login page. This adds a fallback + client-side safety net.

## Test plan
- [ ] Log in, click Dashboard — should load without showing login page
- [ ] Clear cookies, visit /dashboard — should redirect to login
- [ ] If already logged in and visit /auth/login directly — should redirect to dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Enhanced authentication session detection to properly identify already-logged-in users
  - Improved session validation logic for more reliable authentication handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->