### PR TITLE
fix: broken testimonial avatars (twitter → x rebrand)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -15,7 +15,7 @@ const securityHeaders = [
       "default-src 'self'",
       "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com",
       "style-src 'self' 'unsafe-inline'",
-      "img-src 'self' data: blob: https://*.supabase.co https://avatars.githubusercontent.com https://lh3.googleusercontent.com https://cdn.jsdelivr.net https://www.google-analytics.com",
+      "img-src 'self' data: blob: https://*.supabase.co https://avatars.githubusercontent.com https://lh3.googleusercontent.com https://cdn.jsdelivr.net https://unavatar.io https://www.google-analytics.com",
       "font-src 'self'",
       "connect-src 'self' https://*.supabase.co https://www.google-analytics.com https://api.github.com",
       "frame-ancestors 'none'",

--- a/src/components/ui/testimonial-scroll.tsx
+++ b/src/components/ui/testimonial-scroll.tsx
@@ -40,7 +40,7 @@ export function TestimonialScroll() {
             <div className="flex items-center gap-3">
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
-                src={`https://unavatar.io/twitter/${t.handle.replace("@", "")}`}
+                src={`https://unavatar.io/x/${t.handle.replace("@", "")}`}
                 alt={t.name}
                 width={48}
                 height={48}
@@ -54,8 +54,8 @@ export function TestimonialScroll() {
                 }}
               />
               <div
-                className="w-[48px] h-[48px] items-center justify-center text-sm font-extrabold text-white shrink-0 hidden"
-                style={{ backgroundColor: "var(--bg-inverted)" }}
+                className="w-[48px] h-[48px] items-center justify-center text-sm font-extrabold text-white shrink-0 rounded-sm hidden"
+                style={{ backgroundColor: "var(--bg-inverted)", border: "2px solid var(--border-hard)" }}
               >
                 {t.name.slice(0, 2).toUpperCase()}
               </div>


### PR DESCRIPTION
## Summary
- Changed `unavatar.io/twitter/` to `unavatar.io/x/` — the old endpoint broke after the X rebrand, causing all 48 testimonial profile pictures to fail
- Added `unavatar.io` to CSP `img-src` whitelist so avatars aren't blocked by security headers

## Test plan
- [ ] Verify all testimonial avatars load on homepage "What People Say" section
- [ ] Refresh multiple times to confirm no broken images

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated testimonial avatar source from Twitter to X.

* **Style**
  * Enhanced fallback avatar badge appearance with rounded corners and border styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->