### PR TITLE
fix: live activity feed polls every 30s

### DIFF
--- a/src/components/ui/live-activity-feed.tsx
+++ b/src/components/ui/live-activity-feed.tsx
@@ -67,10 +67,15 @@ export function LiveActivityFeed() {
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
-    fetch("/api/feed?limit=20")
-      .then((r) => r.json())
-      .then((d) => { setFeed(d.feed || []); setLoaded(true); })
-      .catch(() => setLoaded(true));
+    function fetchFeed() {
+      fetch("/api/feed?limit=20")
+        .then((r) => r.json())
+        .then((d) => { setFeed(d.feed || []); setLoaded(true); })
+        .catch(() => setLoaded(true));
+    }
+    fetchFeed();
+    const interval = setInterval(fetchFeed, 30000);
+    return () => clearInterval(interval);
   }, []);
 
   const grouped = useMemo(() => groupFeedItems(feed).slice(0, 6), [feed]);


### PR DESCRIPTION
## Summary
- Feed was fetching once on mount and never updating — not actually "live"
- Now polls `/api/feed` every 30 seconds so new activity appears without page reload
- No extra API cost — same endpoint, just on an interval

🤖 Generated with [Claude Code](https://claude.com/claude-code)