### PR TITLE
fix: Razorpay checkout script loading error

### DIFF
--- a/src/components/ui/featured-carousel.tsx
+++ b/src/components/ui/featured-carousel.tsx
@@ -486,10 +486,20 @@ type UserProject = { id: string; title: string };
 
 function loadRazorpayScript(): Promise<boolean> {
   return new Promise((resolve) => {
-    if (document.getElementById("razorpay-script")) {
+    // Already loaded and ready
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if ((window as any).Razorpay) {
       resolve(true);
       return;
     }
+    // Script tag exists but not loaded yet — wait for it
+    const existing = document.getElementById("razorpay-script");
+    if (existing) {
+      existing.addEventListener("load", () => resolve(true));
+      existing.addEventListener("error", () => resolve(false));
+      return;
+    }
+    // Load fresh
     const script = document.createElement("script");
     script.id = "razorpay-script";
     script.src = "https://checkout.razorpay.com/v1/checkout.js";


### PR DESCRIPTION
## Summary
- Fix `window.Razorpay is not a constructor` error when clicking "Pay with Card"
- Script tag could exist in DOM while `window.Razorpay` wasn't ready yet
- Now checks the constructor exists before using it, and waits for load event if script is still loading

## Test plan
- [ ] Click "Pay with Card" → Razorpay modal opens without error
- [ ] Click again after first use → still works (reuses loaded script)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced payment script detection and loading to ensure more reliable initialization of payment functionality across different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->