### PR TITLE
feat: mandatory GitHub + X/Telegram & rename wallet button

### DIFF
--- a/src/app/auth/profile-setup/page.tsx
+++ b/src/app/auth/profile-setup/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { createClient } from "@/lib/supabase/client";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import {
   Flame,
   Github,
@@ -45,7 +45,9 @@ const STEP_LABELS = ["Profile", "Links", "Project", "Go!"] as const;
 
 export default function ProfileSetupPage() {
   const router = useRouter();
-  const [step, setStep] = useState(1);
+  const searchParams = useSearchParams();
+  const initialStep = Number(searchParams.get("step")) || 1;
+  const [step, setStep] = useState(initialStep);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [userId, setUserId] = useState<string | null>(null);
@@ -93,9 +95,27 @@ export default function ProfileSetupPage() {
         user.user_metadata?.picture ||
         null;
       setOauthAvatarUrl(avatar);
+
+      // If returning user redirected to step 2, pre-fill existing socials
+      if (initialStep === 2) {
+        const supabase = createClient();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { data } = await (supabase.from("social_links") as any)
+          .select("*")
+          .eq("user_id", user.id)
+          .single();
+        if (data) {
+          setSocials({
+            github: data.github || "",
+            twitter: data.twitter || "",
+            website: data.website || "",
+            telegram: data.telegram || "",
+          });
+        }
+      }
     };
     checkAuth();
-  }, [router]);
+  }, [router, initialStep]);
 
   /* ── Helpers ─────────────────────────────────────────────── */
 
@@ -144,8 +164,13 @@ export default function ProfileSetupPage() {
   };
 
   const handleStep2Next = async () => {
+    const github = socials.github.trim();
     const twitter = socials.twitter.trim();
     const telegram = socials.telegram.trim();
+    if (!github) {
+      setError("GitHub username is required so we can verify your work.");
+      return;
+    }
     if (!twitter && !telegram) {
       setError("Please add your X (Twitter) or Telegram so clients can contact you.");
       return;
@@ -175,7 +200,12 @@ export default function ProfileSetupPage() {
         if (dbError) throw dbError;
       }
 
-      setStep(3);
+      // If returning user (came from dashboard redirect), skip to streak step
+      if (initialStep === 2) {
+        setStep(4);
+      } else {
+        setStep(3);
+      }
     } catch (err: unknown) {
       const message =
         err instanceof Error ? err.message : "Failed to save links";
@@ -387,7 +417,7 @@ export default function ProfileSetupPage() {
             Social Links
           </h2>
           <p className="text-xs text-[var(--text-secondary)] font-medium">
-            X or Telegram required so clients can reach you
+            GitHub required + X or Telegram so clients can reach you
           </p>
         </div>
       </div>
@@ -398,8 +428,9 @@ export default function ProfileSetupPage() {
           type="text"
           value={socials.github}
           onChange={(e) => setSocials({ ...socials, github: e.target.value })}
-          placeholder="GitHub username"
+          placeholder="GitHub username *"
           className="input-brutal w-full"
+          required
         />
       </div>
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -75,6 +75,15 @@ export default function DashboardPage() {
         window.location.href = "/auth/profile-setup";
         return;
       }
+
+      // Enforce mandatory socials: GitHub + (X or Telegram)
+      const hasGithub = socials?.github?.trim();
+      const hasTwitter = socials?.twitter?.trim();
+      const hasTelegram = socials?.telegram?.trim();
+      if (!hasGithub || (!hasTwitter && !hasTelegram)) {
+        window.location.href = "/auth/profile-setup?step=2";
+        return;
+      }
       setHeatmapData(streakData);
 
       // Calculate actual streak from streak_logs (in case DB trigger didn't run)

--- a/src/components/ui/featured-carousel.tsx
+++ b/src/components/ui/featured-carousel.tsx
@@ -618,7 +618,7 @@ function PromoteForm({ onSuccess, isLoggedIn }: { onSuccess: () => void; isLogge
           }}
           className="btn-brutal btn-brutal-primary text-sm flex items-center gap-2"
         >
-          <Wallet size={16} /> Connect Wallet
+          <Wallet size={16} /> Pay with USDC
         </button>
       ) : (
         <div className="space-y-4">


### PR DESCRIPTION
## Summary
- **Mandatory socials during profile setup**: GitHub username is now required in step 2, plus at least one of X (Twitter) or Telegram so clients can contact builders
- **Existing user enforcement**: Dashboard now checks if user has GitHub + (X or Telegram). If missing, redirects to profile setup step 2 with pre-filled existing data
- **Returning user flow**: After completing mandatory socials, returning users skip to the streak step (step 4) instead of the project step
- **Renamed promote button**: "Connect Wallet" → "Pay with USDC" on the homepage featured section

## Test plan
- [ ] New user signup: verify step 2 blocks without GitHub, and without X or Telegram
- [ ] Existing user without socials: verify dashboard redirects to `/auth/profile-setup?step=2`
- [ ] Existing user with partial socials: verify their existing data is pre-filled
- [ ] After completing socials, returning user goes to streak step (not project step)
- [ ] Homepage: verify promote button says "Pay with USDC"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Profile setup flow now supports resuming from step 2 with pre-filled social links data.

* **Bug Fixes**
  * Dashboard now validates required social profiles (GitHub + X/Twitter or Telegram) before granting access.

* **Improvements**
  * Strengthened GitHub username validation in profile setup with clearer requirements.
  * Updated wallet action button label to "Pay with USDC."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->