### PR TITLE
feat: re-engagement email + feedback page for inactive users

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -7,6 +7,13 @@
       "runtimeArgs": ["/opt/homebrew/bin/npm", "run", "dev"],
       "env": { "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" },
       "port": 3001
+    },
+    {
+      "name": "vibe-talent",
+      "runtimeExecutable": "/opt/homebrew/bin/node",
+      "runtimeArgs": ["/opt/homebrew/bin/npm", "run", "dev"],
+      "env": { "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" },
+      "port": 3000
     }
   ]
 }

--- a/src/app/api/cron/daily/route.ts
+++ b/src/app/api/cron/daily/route.ts
@@ -27,6 +27,7 @@ export async function GET(req: NextRequest) {
     { name: "profile-view-digest", path: "/api/cron/profile-view-digest" },
     { name: "milestone-check", path: "/api/cron/milestone-check" },
     { name: "weekly-digest", path: "/api/cron/weekly-digest" },
+    { name: "re-engagement", path: "/api/cron/re-engagement" },
   ];
 
   const results: Record<string, { status: number; data?: unknown; error?: string }> = {};

--- a/src/app/api/cron/re-engagement/route.ts
+++ b/src/app/api/cron/re-engagement/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { runReEngagement } from "@/lib/cron-jobs/re-engagement";
+
+export async function GET(req: NextRequest) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) {
+    return NextResponse.json({ error: "CRON_SECRET not configured" }, { status: 500 });
+  }
+
+  const authHeader = req.headers.get("authorization");
+  if (authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const result = await runReEngagement();
+    return NextResponse.json({ message: "Re-engagement check completed", ...result });
+  } catch (error) {
+    console.error("Re-engagement cron error:", error);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/email-preferences/route.ts
+++ b/src/app/api/email-preferences/route.ts
@@ -23,6 +23,7 @@ export async function GET() {
       milestone_alerts: true,
       weekly_digest: true,
       hire_notifications: true,
+      re_engagement: true,
     });
   } catch {
     return NextResponse.json({ error: "Server error" }, { status: 500 });
@@ -48,6 +49,7 @@ export async function PATCH(req: Request) {
         milestone_alerts: body.milestone_alerts ?? true,
         weekly_digest: body.weekly_digest ?? true,
         hire_notifications: body.hire_notifications ?? true,
+        re_engagement: body.re_engagement ?? true,
         updated_at: new Date().toISOString(),
       });
 

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const { username, reason, details, would_return } = body;
+
+    if (!reason) {
+      return NextResponse.json({ error: "Reason is required" }, { status: 400 });
+    }
+
+    const sb = createAdminClient();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { error } = await (sb as any).from("feedback").insert({
+      username: username || null,
+      reason,
+      details: details || null,
+      would_return: would_return || null,
+      source: "re_engagement_email",
+      created_at: new Date().toISOString(),
+    });
+
+    if (error) {
+      console.error("Failed to save feedback:", error);
+      return NextResponse.json({ error: "Failed to save feedback" }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,24 +1,35 @@
 import { NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 
+const VALID_REASONS = new Set([
+  "not_useful", "confusing", "no_time",
+  "missing_features", "found_alternative", "other",
+]);
+
+const VALID_WOULD_RETURN = new Set(["yes", "maybe", "no"]);
+
 export async function POST(req: Request) {
   try {
     const body = await req.json();
-    const { username, reason, details, would_return } = body;
+    const { username, reason, details, would_return, source } = body;
 
-    if (!reason) {
-      return NextResponse.json({ error: "Reason is required" }, { status: 400 });
+    if (!reason || typeof reason !== "string" || !VALID_REASONS.has(reason)) {
+      return NextResponse.json({ error: "Invalid reason" }, { status: 400 });
+    }
+
+    if (would_return && !VALID_WOULD_RETURN.has(would_return)) {
+      return NextResponse.json({ error: "Invalid would_return value" }, { status: 400 });
     }
 
     const sb = createAdminClient();
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { error } = await (sb as any).from("feedback").insert({
-      username: username || null,
+      username: typeof username === "string" ? username.slice(0, 100) : null,
       reason,
-      details: details || null,
+      details: typeof details === "string" ? details.slice(0, 2000) : null,
       would_return: would_return || null,
-      source: "re_engagement_email",
+      source: typeof source === "string" ? source.slice(0, 50) : "re_engagement_email",
       created_at: new Date().toISOString(),
     });
 

--- a/src/app/feedback/page.tsx
+++ b/src/app/feedback/page.tsx
@@ -95,7 +95,7 @@ function FeedbackForm() {
           Quick feedback
         </h1>
         <p className="text-sm text-[var(--text-muted)] mb-6">
-          No guilt trip — we just want to build something you'd actually use. Takes 30 seconds.
+          No guilt trip — we just want to build something you&apos;d actually use. Takes 30 seconds.
         </p>
 
         <form onSubmit={handleSubmit} className="space-y-5">
@@ -131,7 +131,7 @@ function FeedbackForm() {
           {/* Details */}
           <div>
             <label className="block text-sm font-bold text-[var(--foreground)] mb-2">
-              What's the #1 thing that would bring you back?
+              What&apos;s the #1 thing that would bring you back?
               <span className="font-normal text-[var(--text-muted)]"> (optional)</span>
             </label>
             <textarea

--- a/src/app/feedback/page.tsx
+++ b/src/app/feedback/page.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { Suspense } from "react";
+
+const REASONS = [
+  { value: "not_useful", label: "Didn't find it useful" },
+  { value: "confusing", label: "Too confusing to use" },
+  { value: "no_time", label: "Just got busy / no time" },
+  { value: "missing_features", label: "Missing features I need" },
+  { value: "found_alternative", label: "Using something else" },
+  { value: "other", label: "Other" },
+];
+
+function FeedbackForm() {
+  const searchParams = useSearchParams();
+  const username = searchParams.get("u") || "";
+
+  const [reason, setReason] = useState("");
+  const [details, setDetails] = useState("");
+  const [wouldReturn, setWouldReturn] = useState<string>("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!reason) return;
+
+    setSubmitting(true);
+    try {
+      await fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          username,
+          reason,
+          details,
+          would_return: wouldReturn,
+        }),
+      });
+      setSubmitted(true);
+    } catch {
+      // Still show success — we don't want to frustrate them
+      setSubmitted(true);
+    }
+    setSubmitting(false);
+  };
+
+  if (submitted) {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-4" style={{ background: "var(--bg-base)" }}>
+        <div
+          className="w-full max-w-lg p-8 text-center"
+          style={{
+            backgroundColor: "var(--bg-surface)",
+            border: "2px solid var(--border-hard)",
+            boxShadow: "var(--shadow-brutal)",
+          }}
+        >
+          <div className="text-4xl mb-4">🙏</div>
+          <h1 className="text-2xl font-extrabold text-[var(--foreground)] mb-3">
+            Thanks for your honesty
+          </h1>
+          <p className="text-[var(--text-muted)] mb-6">
+            Your feedback directly shapes what we build next. We genuinely appreciate you taking the time.
+          </p>
+          <a
+            href="/dashboard"
+            className="inline-block px-6 py-3 font-bold text-sm text-white"
+            style={{
+              background: "var(--accent)",
+              border: "2px solid var(--border-hard)",
+              boxShadow: "var(--shadow-brutal)",
+            }}
+          >
+            Back to VibeTalent
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4" style={{ background: "var(--bg-base)" }}>
+      <div
+        className="w-full max-w-lg p-8"
+        style={{
+          backgroundColor: "var(--bg-surface)",
+          border: "2px solid var(--border-hard)",
+          boxShadow: "var(--shadow-brutal)",
+        }}
+      >
+        <h1 className="text-2xl font-extrabold text-[var(--foreground)] mb-2">
+          Quick feedback
+        </h1>
+        <p className="text-sm text-[var(--text-muted)] mb-6">
+          No guilt trip — we just want to build something you'd actually use. Takes 30 seconds.
+        </p>
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          {/* Reason */}
+          <div>
+            <label className="block text-sm font-bold text-[var(--foreground)] mb-2">
+              What made you stop using VibeTalent?
+            </label>
+            <div className="space-y-2">
+              {REASONS.map((r) => (
+                <label
+                  key={r.value}
+                  className="flex items-center gap-3 p-3 cursor-pointer transition-colors"
+                  style={{
+                    border: reason === r.value ? "2px solid var(--accent)" : "2px solid var(--border-subtle)",
+                    background: reason === r.value ? "var(--accent-muted, rgba(255,58,0,0.05))" : "transparent",
+                  }}
+                >
+                  <input
+                    type="radio"
+                    name="reason"
+                    value={r.value}
+                    checked={reason === r.value}
+                    onChange={(e) => setReason(e.target.value)}
+                    className="accent-[var(--accent)]"
+                  />
+                  <span className="text-sm text-[var(--foreground)]">{r.label}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {/* Details */}
+          <div>
+            <label className="block text-sm font-bold text-[var(--foreground)] mb-2">
+              What's the #1 thing that would bring you back?
+              <span className="font-normal text-[var(--text-muted)]"> (optional)</span>
+            </label>
+            <textarea
+              value={details}
+              onChange={(e) => setDetails(e.target.value)}
+              placeholder="Be brutally honest — it helps us more than you think"
+              rows={3}
+              className="w-full px-3 py-2 text-sm bg-transparent text-[var(--foreground)] placeholder:text-[var(--text-muted)] resize-none"
+              style={{ border: "2px solid var(--border-subtle)" }}
+            />
+          </div>
+
+          {/* Would return */}
+          <div>
+            <label className="block text-sm font-bold text-[var(--foreground)] mb-2">
+              Would you try VibeTalent again if we fixed this?
+            </label>
+            <div className="flex gap-2">
+              {["Yes", "Maybe", "No"].map((opt) => (
+                <button
+                  key={opt}
+                  type="button"
+                  onClick={() => setWouldReturn(opt.toLowerCase())}
+                  className="flex-1 py-2 text-sm font-bold transition-colors"
+                  style={{
+                    border: wouldReturn === opt.toLowerCase() ? "2px solid var(--accent)" : "2px solid var(--border-subtle)",
+                    background: wouldReturn === opt.toLowerCase() ? "var(--accent)" : "transparent",
+                    color: wouldReturn === opt.toLowerCase() ? "#FFFFFF" : "var(--foreground)",
+                  }}
+                >
+                  {opt}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            disabled={!reason || submitting}
+            className="w-full py-3 font-bold text-sm text-white disabled:opacity-50"
+            style={{
+              background: "var(--accent)",
+              border: "2px solid var(--border-hard)",
+              boxShadow: "var(--shadow-brutal)",
+            }}
+          >
+            {submitting ? "Sending..." : "Send Feedback"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default function FeedbackPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center" style={{ background: "var(--bg-base)" }}>
+          <div className="text-[var(--text-muted)]">Loading...</div>
+        </div>
+      }
+    >
+      <FeedbackForm />
+    </Suspense>
+  );
+}

--- a/src/app/feedback/page.tsx
+++ b/src/app/feedback/page.tsx
@@ -22,27 +22,32 @@ function FeedbackForm() {
   const [wouldReturn, setWouldReturn] = useState<string>("");
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!reason) return;
 
     setSubmitting(true);
+    setError(false);
     try {
-      await fetch("/api/feedback", {
+      const res = await fetch("/api/feedback", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           username,
           reason,
-          details,
+          details: details.slice(0, 2000),
           would_return: wouldReturn,
         }),
       });
-      setSubmitted(true);
+      if (res.ok) {
+        setSubmitted(true);
+      } else {
+        setError(true);
+      }
     } catch {
-      // Still show success — we don't want to frustrate them
-      setSubmitted(true);
+      setError(true);
     }
     setSubmitting(false);
   };
@@ -99,11 +104,17 @@ function FeedbackForm() {
         </p>
 
         <form onSubmit={handleSubmit} className="space-y-5">
+          {error && (
+            <div className="p-3 text-sm font-bold text-red-600" style={{ border: "2px solid currentColor" }}>
+              Something went wrong. Please try again.
+            </div>
+          )}
+
           {/* Reason */}
-          <div>
-            <label className="block text-sm font-bold text-[var(--foreground)] mb-2">
+          <fieldset>
+            <legend className="block text-sm font-bold text-[var(--foreground)] mb-2">
               What made you stop using VibeTalent?
-            </label>
+            </legend>
             <div className="space-y-2">
               {REASONS.map((r) => (
                 <label
@@ -126,7 +137,7 @@ function FeedbackForm() {
                 </label>
               ))}
             </div>
-          </div>
+          </fieldset>
 
           {/* Details */}
           <div>
@@ -149,12 +160,13 @@ function FeedbackForm() {
             <label className="block text-sm font-bold text-[var(--foreground)] mb-2">
               Would you try VibeTalent again if we fixed this?
             </label>
-            <div className="flex gap-2">
+            <div className="flex gap-2" role="group" aria-label="Would you try VibeTalent again if we fixed this?">
               {["Yes", "Maybe", "No"].map((opt) => (
                 <button
                   key={opt}
                   type="button"
                   onClick={() => setWouldReturn(opt.toLowerCase())}
+                  aria-pressed={wouldReturn === opt.toLowerCase()}
                   className="flex-1 py-2 text-sm font-bold transition-colors"
                   style={{
                     border: wouldReturn === opt.toLowerCase() ? "2px solid var(--accent)" : "2px solid var(--border-subtle)",

--- a/src/components/dashboard/email-preferences.tsx
+++ b/src/components/dashboard/email-preferences.tsx
@@ -9,6 +9,7 @@ interface Preferences {
   milestone_alerts: boolean;
   weekly_digest: boolean;
   hire_notifications: boolean;
+  re_engagement: boolean;
 }
 
 const PREF_LABELS: { key: keyof Preferences; label: string; description: string }[] = [
@@ -17,6 +18,7 @@ const PREF_LABELS: { key: keyof Preferences; label: string; description: string 
   { key: "milestone_alerts", label: "Milestone Alerts", description: "Notifications for badge and vibe score milestones" },
   { key: "weekly_digest", label: "Weekly Digest", description: "Weekly recap of your stats and activity" },
   { key: "hire_notifications", label: "Hire Notifications", description: "Emails when someone wants to hire you" },
+  { key: "re_engagement", label: "Feedback Requests", description: "Occasional emails asking for your feedback if you've been away" },
 ];
 
 export function EmailPreferences() {
@@ -26,6 +28,7 @@ export function EmailPreferences() {
     milestone_alerts: true,
     weekly_digest: true,
     hire_notifications: true,
+    re_engagement: true,
   });
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);

--- a/src/lib/cron-jobs/re-engagement.ts
+++ b/src/lib/cron-jobs/re-engagement.ts
@@ -47,6 +47,21 @@ export async function runReEngagement(): Promise<{ sent: number; skipped: number
 
   const recentlyActiveIds = new Set((recentLogs || []).map((l: { user_id: string }) => l.user_id));
 
+  // Get last activity date per user for accurate "days since last active" in the email
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: lastActivityLogs } = await (sb as any)
+    .from("streak_logs")
+    .select("user_id, activity_date")
+    .in("user_id", userIds)
+    .order("activity_date", { ascending: false });
+
+  const lastActivityMap = new Map<string, string>();
+  for (const log of (lastActivityLogs || [])) {
+    if (!lastActivityMap.has(log.user_id)) {
+      lastActivityMap.set(log.user_id, log.activity_date);
+    }
+  }
+
   // Check email preferences
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { data: prefs } = await (sb as any)
@@ -70,26 +85,32 @@ export async function runReEngagement(): Promise<{ sent: number; skipped: number
   const skipped = users.length - targets.length;
 
   for (const user of targets) {
-    // Calculate days since signup
-    const signupDate = new Date(user.created_at);
-    const daysSince = Math.floor((Date.now() - signupDate.getTime()) / (1000 * 60 * 60 * 24));
+    // Calculate days since last activity (fall back to signup date if no activity)
+    const lastActivity = lastActivityMap.get(user.id);
+    const referenceDate = lastActivity ? new Date(lastActivity) : new Date(user.created_at);
+    const daysSince = Math.floor((Date.now() - referenceDate.getTime()) / (1000 * 60 * 60 * 24));
 
     // Get user email from auth
     const { data: authUser } = await sb.auth.admin.getUserById(user.id);
     if (!authUser?.user?.email) continue;
 
+    // Log first to prevent duplicates if email succeeds but log fails on retry
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { error: logError } = await (sb as any).from("email_log").insert({
+      user_id: user.id,
+      email_type: "re_engagement",
+      sent_at: new Date().toISOString(),
+    });
+
+    if (logError) {
+      console.error(`Failed to log re-engagement email for ${user.username}:`, logError);
+      continue;
+    }
+
     await sendReEngagementEmail({
       email: authUser.user.email,
       username: user.username,
       daysSinceLastActive: daysSince,
-    });
-
-    // Log that we sent this email so we don't send again
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await (sb as any).from("email_log").insert({
-      user_id: user.id,
-      email_type: "re_engagement",
-      sent_at: new Date().toISOString(),
     });
 
     sent++;

--- a/src/lib/cron-jobs/re-engagement.ts
+++ b/src/lib/cron-jobs/re-engagement.ts
@@ -1,0 +1,99 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import { sendReEngagementEmail } from "@/lib/email";
+
+const INACTIVE_DAYS = 4;
+
+/**
+ * Send re-engagement emails to users who haven't been active for 4+ days.
+ * Only sends once per user (tracked via email_log).
+ */
+export async function runReEngagement(): Promise<{ sent: number; skipped: number }> {
+  const sb = createAdminClient();
+
+  const cutoffDate = new Date();
+  cutoffDate.setDate(cutoffDate.getDate() - INACTIVE_DAYS);
+  const cutoffStr = cutoffDate.toISOString().split("T")[0];
+
+  // Get all users who signed up at least INACTIVE_DAYS ago
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: users, error } = await (sb as any)
+    .from("users")
+    .select("id, username, created_at")
+    .lte("created_at", cutoffDate.toISOString());
+
+  if (error || !users || users.length === 0) {
+    return { sent: 0, skipped: 0 };
+  }
+
+  const userIds = users.map((u: { id: string }) => u.id);
+
+  // Check who already received a re-engagement email (only send once)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: alreadySent } = await (sb as any)
+    .from("email_log")
+    .select("user_id")
+    .in("user_id", userIds)
+    .eq("email_type", "re_engagement");
+
+  const alreadySentIds = new Set((alreadySent || []).map((e: { user_id: string }) => e.user_id));
+
+  // Get recent activity — users who logged activity in the last INACTIVE_DAYS days
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: recentLogs } = await (sb as any)
+    .from("streak_logs")
+    .select("user_id")
+    .in("user_id", userIds)
+    .gte("activity_date", cutoffStr);
+
+  const recentlyActiveIds = new Set((recentLogs || []).map((l: { user_id: string }) => l.user_id));
+
+  // Check email preferences
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: prefs } = await (sb as any)
+    .from("email_preferences")
+    .select("user_id, re_engagement")
+    .in("user_id", userIds);
+
+  const prefMap = new Map(
+    (prefs || []).map((p: { user_id: string; re_engagement: boolean }) => [p.user_id, p.re_engagement])
+  );
+
+  // Filter to inactive users who haven't been emailed and haven't opted out
+  const targets = users.filter((u: { id: string }) => {
+    if (alreadySentIds.has(u.id)) return false;
+    if (recentlyActiveIds.has(u.id)) return false;
+    if (prefMap.get(u.id) === false) return false;
+    return true;
+  });
+
+  let sent = 0;
+  const skipped = users.length - targets.length;
+
+  for (const user of targets) {
+    // Calculate days since signup
+    const signupDate = new Date(user.created_at);
+    const daysSince = Math.floor((Date.now() - signupDate.getTime()) / (1000 * 60 * 60 * 24));
+
+    // Get user email from auth
+    const { data: authUser } = await sb.auth.admin.getUserById(user.id);
+    if (!authUser?.user?.email) continue;
+
+    await sendReEngagementEmail({
+      email: authUser.user.email,
+      username: user.username,
+      daysSinceLastActive: daysSince,
+    });
+
+    // Log that we sent this email so we don't send again
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (sb as any).from("email_log").insert({
+      user_id: user.id,
+      email_type: "re_engagement",
+      sent_at: new Date().toISOString(),
+    });
+
+    sent++;
+  }
+
+  return { sent, skipped };
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -531,6 +531,71 @@ export async function sendVibeScoreMilestoneEmail({
 /**
  * Send an email when a builder receives a new review. Fire-and-forget.
  */
+/**
+ * Send a re-engagement email to inactive users asking for feedback. Fire-and-forget.
+ */
+export async function sendReEngagementEmail({
+  email,
+  username,
+  daysSinceLastActive,
+}: {
+  email: string;
+  username: string;
+  daysSinceLastActive: number;
+}): Promise<void> {
+  const client = getResend();
+  if (!client) return;
+
+  const siteUrl = getSiteUrl();
+  const safeUsername = escapeHtml(username);
+  const feedbackUrl = `${siteUrl}/feedback?ref=re-engagement&u=${encodeURIComponent(username)}`;
+
+  try {
+    await sendEmail(client, {
+      to: email,
+      subject: `We miss you on VibeTalent — quick question?`,
+      text: `Hey @${username}, we noticed you haven't been active on VibeTalent for ${daysSinceLastActive} days. We'd love to hear what happened — was something missing, confusing, or just not useful?\n\nTake 30 seconds to let us know: ${feedbackUrl}\n\nYour feedback genuinely shapes what we build next.\n\n— The VibeTalent Team\n\nUnsubscribe: ${unsubUrl(email)}`,
+      html: `
+        <div style="font-family: 'Space Grotesk', Arial, sans-serif; max-width: 600px; margin: 0 auto; border: 2px solid #0F0F0F; background: #FFFFFF;">
+          <div style="background: #0F0F0F; color: #FFFFFF; padding: 24px 32px;">
+            <h1 style="margin: 0; font-size: 20px; font-weight: 800;">⚡ VibeTalent</h1>
+          </div>
+          <div style="padding: 32px;">
+            <h2 style="color: #0F0F0F; font-size: 24px; font-weight: 700; margin: 0 0 16px;">
+              We'd love your honest feedback
+            </h2>
+            <p style="color: #52525B; font-size: 16px; line-height: 1.6; margin: 0 0 16px;">
+              Hey <strong>@${safeUsername}</strong>, we noticed you haven't been on VibeTalent for <strong>${daysSinceLastActive} days</strong>.
+            </p>
+            <p style="color: #52525B; font-size: 16px; line-height: 1.6; margin: 0 0 24px;">
+              No guilt trip — we just want to understand what happened. Was something missing? Confusing? Not useful? Your feedback genuinely shapes what we build next.
+            </p>
+            <div style="border: 2px solid #0F0F0F; padding: 20px; margin: 0 0 24px; background: #FAFAFA;">
+              <p style="color: #0F0F0F; font-size: 14px; font-weight: 700; margin: 0 0 8px;">Quick question:</p>
+              <p style="color: #52525B; font-size: 14px; line-height: 1.5; margin: 0;">
+                What's the #1 thing that would bring you back?
+              </p>
+            </div>
+            <a href="${feedbackUrl}" style="display: inline-block; background: #FF3A00; color: #FFFFFF; padding: 12px 24px; text-decoration: none; font-weight: 700; font-size: 14px; border: 2px solid #0F0F0F; box-shadow: 4px 4px 0 #0F0F0F;">
+              Share Feedback (30 sec)
+            </a>
+            <a href="${siteUrl}/dashboard" style="display: inline-block; background: #FFFFFF; color: #0F0F0F; padding: 12px 24px; text-decoration: none; font-weight: 700; font-size: 14px; border: 2px solid #0F0F0F; box-shadow: 4px 4px 0 #0F0F0F; margin-left: 12px;">
+              Back to VibeTalent
+            </a>
+          </div>
+          <div style="background: #F4F4F5; padding: 16px 32px; border-top: 2px solid #0F0F0F;">
+            <p style="color: #52525B; font-size: 12px; margin: 0;">
+              You received this because you haven't been active on VibeTalent recently. <a href="${unsubUrl(email)}" style="color: #52525B;">Unsubscribe</a>
+            </p>
+          </div>
+        </div>
+      `,
+    });
+  } catch (error) {
+    console.error("Failed to send re-engagement email:", error);
+  }
+}
+
 export async function sendReviewNotificationEmail({
   email,
   username,


### PR DESCRIPTION
## Summary
- Sends a one-time re-engagement email to users inactive for 4+ days asking what made them stop
- New `/feedback` page with radio reasons, open text field, and "would you return?" buttons
- Cron job runs daily via existing orchestrator, respects email preferences, only sends once per user (tracked via `email_log`)
- New `re_engagement` toggle added to email preferences in settings

## DB migrations (already run)
```sql
ALTER TABLE email_preferences ADD COLUMN IF NOT EXISTS re_engagement BOOLEAN DEFAULT TRUE;
CREATE TABLE IF NOT EXISTS feedback (
  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
  username TEXT,
  reason TEXT NOT NULL,
  details TEXT,
  would_return TEXT,
  source TEXT DEFAULT 're_engagement_email',
  created_at TIMESTAMPTZ DEFAULT NOW()
);
```

## Test plan
- [ ] Verify `/feedback` page renders correctly and submits
- [ ] Verify new "Feedback Requests" toggle appears in email settings
- [ ] Test cron endpoint manually: `GET /api/cron/re-engagement` with Bearer token
- [ ] Confirm email only sends once per user (check `email_log` table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Re‑engagement emails to inactive users (sending logic and scheduler integration)
  * Feedback page + submission endpoint for quick user feedback on inactivity/return intent
  * New email preference toggle for re‑engagement messages in account settings
  * Daily cron now includes the re‑engagement job in its routine
<!-- end of auto-generated comment: release notes by coderabbit.ai -->