### PR TITLE
fix: show notification bell and profile avatar on mobile navbar

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -7,6 +7,14 @@
       "runtimeArgs": ["/opt/homebrew/bin/npm", "run", "dev"],
       "env": { "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" },
       "port": 3001
+    },
+    {
+      "name": "vibe-talent",
+      "runtimeExecutable": "/opt/homebrew/bin/node",
+      "runtimeArgs": ["/opt/homebrew/bin/npm", "run", "dev"],
+      "env": { "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" },
+      "port": 3000,
+      "autoPort": true
     }
   ]
 }

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -13,8 +13,7 @@
       "runtimeExecutable": "/opt/homebrew/bin/node",
       "runtimeArgs": ["/opt/homebrew/bin/npm", "run", "dev"],
       "env": { "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" },
-      "port": 3000,
-      "autoPort": true
+      "port": 3000
     }
   ]
 }

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -19,6 +19,32 @@ const navLinks = [
 
 const DOCS_URL = "https://vibe-talent.gitbook.io/untitled";
 
+function ProfileAvatar({
+  avatarUrl,
+  username,
+  initials,
+  size,
+}: {
+  avatarUrl: string | null | undefined;
+  username: string | undefined;
+  initials: string;
+  size: number;
+}) {
+  const textClass = size >= 48 ? "text-sm" : "text-xs";
+  return avatarUrl ? (
+    <Image
+      src={avatarUrl}
+      alt={username || "Profile"}
+      width={size}
+      height={size}
+      className="w-full h-full object-cover"
+      style={{ borderRadius: "50%" }}
+    />
+  ) : (
+    <span className={`${textClass} font-extrabold text-white`}>{initials}</span>
+  );
+}
+
 export function Navbar() {
   const pathname = usePathname();
   const router = useRouter();
@@ -200,18 +226,12 @@ export function Navbar() {
                   cursor: "pointer",
                 }}
               >
-                {userProfile?.avatar_url ? (
-                  <Image
-                    src={userProfile.avatar_url}
-                    alt={userProfile.username}
-                    width={48}
-                    height={48}
-                    className="w-full h-full object-cover"
-                    style={{ borderRadius: "50%" }}
-                  />
-                ) : (
-                  <span className="text-sm font-extrabold text-white">{initials}</span>
-                )}
+                <ProfileAvatar
+                  avatarUrl={userProfile?.avatar_url}
+                  username={userProfile?.username}
+                  initials={initials}
+                  size={48}
+                />
               </button>
               {profileDropdownOpen && (
                 <div
@@ -276,35 +296,27 @@ export function Navbar() {
         {/* Mobile toggle */}
         <div className="flex items-center gap-2 sm:hidden">
           <ThemeToggle />
-          {isLoggedIn && (
-            <>
-              <NotificationBell />
-              <Link
-                href={userProfile?.username ? `/profile/${userProfile.username}` : "/dashboard"}
-                aria-label="Profile"
-                className="flex items-center justify-center overflow-hidden"
-                style={{
-                  width: 36,
-                  height: 36,
-                  borderRadius: "50%",
-                  border: "2px solid var(--border-hard)",
-                  backgroundColor: "var(--bg-inverted)",
-                }}
-              >
-                {userProfile?.avatar_url ? (
-                  <Image
-                    src={userProfile.avatar_url}
-                    alt={userProfile.username}
-                    width={36}
-                    height={36}
-                    className="w-full h-full object-cover"
-                    style={{ borderRadius: "50%" }}
-                  />
-                ) : (
-                  <span className="text-xs font-extrabold text-white">{initials}</span>
-                )}
-              </Link>
-            </>
+          {isLoggedIn && <NotificationBell />}
+          {isLoggedIn && userProfile && (
+            <Link
+              href={`/profile/${userProfile.username}`}
+              aria-label="Profile"
+              className="flex items-center justify-center overflow-hidden"
+              style={{
+                width: 36,
+                height: 36,
+                borderRadius: "50%",
+                border: "2px solid var(--border-hard)",
+                backgroundColor: "var(--bg-inverted)",
+              }}
+            >
+              <ProfileAvatar
+                avatarUrl={userProfile.avatar_url}
+                username={userProfile.username}
+                initials={initials}
+                size={36}
+              />
+            </Link>
           )}
           <button
             onClick={() => setMobileOpen(!mobileOpen)}
@@ -339,18 +351,12 @@ export function Navbar() {
                   backgroundColor: "var(--bg-inverted)",
                 }}
               >
-                {userProfile.avatar_url ? (
-                  <Image
-                    src={userProfile.avatar_url}
-                    alt={userProfile.username}
-                    width={36}
-                    height={36}
-                    className="w-full h-full object-cover"
-                    style={{ borderRadius: "50%" }}
-                  />
-                ) : (
-                  <span className="text-xs font-extrabold text-white">{initials}</span>
-                )}
+                <ProfileAvatar
+                  avatarUrl={userProfile.avatar_url}
+                  username={userProfile.username}
+                  initials={initials}
+                  size={36}
+                />
               </div>
               <span className="text-sm font-extrabold text-[var(--foreground)]">{userProfile.username}</span>
             </div>

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -277,6 +277,37 @@ export function Navbar() {
         {/* Mobile toggle */}
         <div className="flex items-center gap-2 sm:hidden">
           <ThemeToggle />
+          {isLoggedIn && (
+            <>
+              <NotificationBell />
+              <Link
+                href={userProfile?.username ? `/profile/${userProfile.username}` : "/dashboard"}
+                aria-label="Profile"
+                className="flex items-center justify-center overflow-hidden"
+                style={{
+                  width: 36,
+                  height: 36,
+                  borderRadius: "50%",
+                  border: "2px solid var(--border-hard)",
+                  backgroundColor: "var(--bg-inverted)",
+                }}
+              >
+                {userProfile?.avatar_url ? (
+                  <Image
+                    src={userProfile.avatar_url}
+                    alt={userProfile.username}
+                    width={36}
+                    height={36}
+                    className="w-full h-full object-cover"
+                    style={{ borderRadius: "50%" }}
+                    unoptimized
+                  />
+                ) : (
+                  <span className="text-xs font-extrabold text-white">{initials}</span>
+                )}
+              </Link>
+            </>
+          )}
           <button
             onClick={() => setMobileOpen(!mobileOpen)}
             style={{ color: "var(--foreground)" }}
@@ -359,10 +390,6 @@ export function Navbar() {
           </a>
           {isLoggedIn ? (
             <>
-            <div className="mt-2 flex items-center gap-3">
-              <NotificationBell />
-              <span className="text-sm font-bold uppercase tracking-wide text-[var(--foreground)]">Notifications</span>
-            </div>
             {userProfile && (
               <>
                 <Link


### PR DESCRIPTION
## Summary
- Mobile navbar now surfaces the notification bell and profile avatar next to the hamburger, matching the desktop layout
- Avatar links to the user's profile page; settings/referral/logout remain accessible via the hamburger
- Removed the now-redundant "Notifications" row from the mobile hamburger menu

## Test plan
- [ ] Open the app on a mobile viewport (≤640px) while logged in — verify bell + avatar appear on the navbar
- [ ] Tap the avatar — verify it navigates to `/profile/{username}`
- [ ] Tap the bell — verify notifications panel opens
- [ ] Open the hamburger — verify Settings, Referral, and Log out are still present
- [ ] Verify logged-out mobile view is unchanged (only theme toggle + hamburger)
- [ ] Verify desktop navbar is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable profile avatar (image or initials) and a logged-in-only notification bell in the mobile header.
  * Added a quick, circular profile link to the user's profile from mobile header.

* **Refactor**
  * Simplified mobile navigation by replacing inline avatar rendering with the reusable avatar and removing the duplicate "Notifications" row.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->