### PR TITLE
feat: display names, GitHub verification, and profile completion flow

### DIFF
--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -13,9 +13,11 @@ type FeedItem = {
   id: string;
   type: "push" | "pr" | "create" | "issue" | "project" | "streak" | "joined";
   username: string;
+  display_name: string | null;
   avatar_url: string | null;
   badge_level: string;
   streak: number;
+  github_verified: boolean;
   date: string;
   repo_name?: string;
   message?: string;
@@ -43,20 +45,20 @@ export async function GET(request: NextRequest) {
     // Run all queries in parallel instead of sequentially
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const [usersResult, eventsResult, streakResult, projectsResult, recentUsersResult] = await Promise.all([
-      supabase.from("users").select("id, username, avatar_url, badge_level, streak").order("vibe_score", { ascending: false }).limit(200),
+      supabase.from("users").select("id, username, display_name, avatar_url, badge_level, streak, github_username").order("vibe_score", { ascending: false }).limit(200),
       supabase.from("feed_events").select("id, event_type, repo_name, message, github_url, created_at, user_id").order("created_at", { ascending: false }).limit(200).then(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (r: any) => r, () => ({ data: null, error: "feed_events not available" })
       ),
       supabase.from("streak_logs").select("id, activity_date, user_id").order("activity_date", { ascending: false }).limit(100),
       supabase.from("projects").select("id, title, description, tech_stack, live_url, github_url, created_at, user_id").eq("flagged", false).order("created_at", { ascending: false }).limit(30),
-      supabase.from("users").select("id, username, avatar_url, badge_level, streak, created_at").order("created_at", { ascending: false }).limit(50),
+      supabase.from("users").select("id, username, display_name, avatar_url, badge_level, streak, created_at, github_username").order("created_at", { ascending: false }).limit(50),
     ]);
 
     // Build user lookup map
-    const userMap = new Map<string, { username: string; avatar_url: string | null; badge_level: string; streak: number }>();
+    const userMap = new Map<string, { username: string; display_name: string | null; avatar_url: string | null; badge_level: string; streak: number; github_verified: boolean }>();
     for (const u of (usersResult.data || [])) {
-      userMap.set(u.id, { username: u.username, avatar_url: u.avatar_url, badge_level: u.badge_level || "none", streak: u.streak || 0 });
+      userMap.set(u.id, { username: u.username, display_name: u.display_name || null, avatar_url: u.avatar_url, badge_level: u.badge_level || "none", streak: u.streak || 0, github_verified: Boolean(u.github_username) });
     }
 
     // 1. Process GitHub events
@@ -68,9 +70,11 @@ export async function GET(request: NextRequest) {
           id: `event-${event.id}`,
           type: event.event_type || "push",
           username: user.username,
+          display_name: user.display_name,
           avatar_url: user.avatar_url,
           badge_level: user.badge_level,
           streak: user.streak,
+          github_verified: user.github_verified,
           date: event.created_at,
           repo_name: event.repo_name,
           message: event.message,
@@ -94,9 +98,11 @@ export async function GET(request: NextRequest) {
         id: `streak-${log.id}`,
         type: "streak",
         username: user.username,
+        display_name: user.display_name,
         avatar_url: user.avatar_url,
         badge_level: user.badge_level,
         streak: user.streak,
+        github_verified: user.github_verified,
         date: log.activity_date,
         message: "logged a day of coding",
       });
@@ -110,9 +116,11 @@ export async function GET(request: NextRequest) {
         id: `project-${project.id}`,
         type: "project",
         username: user.username,
+        display_name: user.display_name,
         avatar_url: user.avatar_url,
         badge_level: user.badge_level,
         streak: user.streak,
+        github_verified: user.github_verified,
         date: project.created_at,
         project_title: project.title,
         project_description: project.description,
@@ -128,9 +136,11 @@ export async function GET(request: NextRequest) {
         id: `joined-${user.id}`,
         type: "joined",
         username: user.username,
+        display_name: user.display_name || null,
         avatar_url: user.avatar_url,
         badge_level: user.badge_level || "none",
         streak: user.streak || 0,
+        github_verified: Boolean(user.github_username),
         date: user.created_at,
         message: "joined VibeTalent",
       });

--- a/src/app/api/github/activity/route.ts
+++ b/src/app/api/github/activity/route.ts
@@ -19,7 +19,8 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // Get GitHub username from user profile or social_links
+    // Only use OAuth-verified github_username. Never trust social_links.github
+    // for streak sync — it's a free-text field and could be spoofed.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { data: profile } = await (supabase as any)
       .from("users")
@@ -27,18 +28,11 @@ export async function POST(req: NextRequest) {
       .eq("id", user.id)
       .single();
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { data: socialLinks } = await (supabase as any)
-      .from("social_links")
-      .select("github")
-      .eq("user_id", user.id)
-      .single();
-
-    const githubUsername = profile?.github_username || socialLinks?.github;
+    const githubUsername = profile?.github_username;
 
     if (!githubUsername) {
       return NextResponse.json(
-        { error: "No GitHub username configured. Add your GitHub username in your profile settings." },
+        { error: "GitHub ownership not verified. Connect your GitHub account in settings to enable streak sync." },
         { status: 400 }
       );
     }

--- a/src/app/api/share-card/[username]/route.tsx
+++ b/src/app/api/share-card/[username]/route.tsx
@@ -225,19 +225,49 @@ export async function GET(
               </div>
 
               {/* Name + badge */}
-              <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-                <span
-                  style={{
-                    fontSize: 42,
-                    fontWeight: 300,
-                    color: TEXT,
-                    textTransform: "uppercase",
-                    letterSpacing: "4px",
-                    lineHeight: 1,
-                  }}
-                >
-                  @{user.username}
-                </span>
+              <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+                  <span
+                    style={{
+                      fontSize: 42,
+                      fontWeight: 300,
+                      color: TEXT,
+                      textTransform: "uppercase",
+                      letterSpacing: "4px",
+                      lineHeight: 1,
+                    }}
+                  >
+                    {user.display_name || `@${user.username}`}
+                  </span>
+                  {user.github_username && (
+                    <svg
+                      width="36"
+                      height="36"
+                      viewBox="0 0 24 24"
+                      fill="#1D9BF0"
+                      stroke="#FFFFFF"
+                      strokeWidth="2.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <path d="M3.85 8.62a4 4 0 0 1 4.78-4.77 4 4 0 0 1 6.74 0 4 4 0 0 1 4.78 4.78 4 4 0 0 1 0 6.74 4 4 0 0 1-4.77 4.78 4 4 0 0 1-6.75 0 4 4 0 0 1-4.78-4.77 4 4 0 0 1 0-6.76Z" />
+                      <path d="m9 12 2 2 4-4" stroke="#FFFFFF" />
+                    </svg>
+                  )}
+                </div>
+                {user.display_name && (
+                  <span
+                    style={{
+                      display: "flex",
+                      fontSize: 18,
+                      fontWeight: 500,
+                      color: "rgba(28,28,28,0.6)",
+                      letterSpacing: "2px",
+                    }}
+                  >
+                    @{user.username}
+                  </span>
+                )}
                 <div
                   style={{
                     display: "flex",

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -43,9 +43,33 @@ export async function GET(request: Request) {
           user.user_metadata?.picture ||
           null;
 
+        // Find the GitHub identity in the user's linked identities.
+        // This handles both initial GitHub OAuth signup AND linkIdentity
+        // flows where a Google/email user links their GitHub account later.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const githubIdentity = user.identities?.find((i: any) => i.provider === "github");
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const ghData = (githubIdentity?.identity_data ?? {}) as any;
         const githubUsername =
+          ghData.user_name ||
+          ghData.preferred_username ||
           user.user_metadata?.user_name ||
           user.user_metadata?.preferred_username ||
+          null;
+
+        // Pull display name from any OAuth provider (GitHub, Google).
+        // Order of preference: github full_name > any identity full_name/name > user_metadata.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const googleIdentity = user.identities?.find((i: any) => i.provider === "google");
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const googleData = (googleIdentity?.identity_data ?? {}) as any;
+        const oauthDisplayName =
+          ghData.full_name ||
+          ghData.name ||
+          googleData.full_name ||
+          googleData.name ||
+          user.user_metadata?.full_name ||
+          user.user_metadata?.name ||
           null;
 
         // Use service role client for DB operations to bypass RLS
@@ -53,7 +77,7 @@ export async function GET(request: Request) {
 
         const { data: profile } = await adminSb
           .from("users")
-          .select("avatar_url, github_username")
+          .select("username, display_name, avatar_url, github_username")
           .eq("id", user.id)
           .single();
 
@@ -69,12 +93,39 @@ export async function GET(request: Request) {
             updates.github_username = githubUsername;
           }
 
+          // Only set display_name if we don't already have one — never overwrite
+          // a user's manually-edited name with the OAuth-provided one on re-login.
+          if (oauthDisplayName && !profile.display_name) {
+            updates.display_name = oauthDisplayName;
+          }
+
           if (Object.keys(updates).length > 0) {
             await adminSb
               .from("users")
               .update(updates)
               .eq("id", user.id);
           }
+        }
+
+        // Auto-populate the public social link to the verified GitHub handle
+        // so profiles display GitHub without requiring manual entry.
+        if (githubUsername) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          await (adminSb.from("social_links") as any).upsert(
+            { user_id: user.id, github: githubUsername },
+            { onConflict: "user_id" }
+          );
+        }
+
+        // Send first-time users (email confirm or OAuth) to profile setup
+        // unless the caller explicitly asked for a specific destination
+        const hasExplicitNext = searchParams.get("next") !== null;
+        if (!profile?.username && !hasExplicitNext) {
+          const setupResponse = NextResponse.redirect(`${origin}/auth/profile-setup`);
+          forwardedResponse.cookies.getAll().forEach((c) => {
+            setupResponse.cookies.set(c);
+          });
+          return setupResponse;
         }
       }
 

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -57,27 +57,12 @@ export async function GET(request: Request) {
           user.user_metadata?.preferred_username ||
           null;
 
-        // Pull display name from any OAuth provider (GitHub, Google).
-        // Order of preference: github full_name > any identity full_name/name > user_metadata.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const googleIdentity = user.identities?.find((i: any) => i.provider === "google");
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const googleData = (googleIdentity?.identity_data ?? {}) as any;
-        const oauthDisplayName =
-          ghData.full_name ||
-          ghData.name ||
-          googleData.full_name ||
-          googleData.name ||
-          user.user_metadata?.full_name ||
-          user.user_metadata?.name ||
-          null;
-
         // Use service role client for DB operations to bypass RLS
         const adminSb = createAdminClient();
 
         const { data: profile } = await adminSb
           .from("users")
-          .select("username, display_name, avatar_url, github_username")
+          .select("username, avatar_url, github_username")
           .eq("id", user.id)
           .single();
 
@@ -93,11 +78,12 @@ export async function GET(request: Request) {
             updates.github_username = githubUsername;
           }
 
-          // Only set display_name if we don't already have one — never overwrite
-          // a user's manually-edited name with the OAuth-provided one on re-login.
-          if (oauthDisplayName && !profile.display_name) {
-            updates.display_name = oauthDisplayName;
-          }
+          // NOTE: display_name is intentionally NOT touched here. Profile-setup
+          // step 1 already pre-fills it from user_metadata.full_name for new
+          // users, so first-time signups still get a nice default to accept
+          // or edit. Leaving the callback out of display_name means users who
+          // intentionally clear the field in settings won't have it restored
+          // on their next OAuth login.
 
           if (Object.keys(updates).length > 0) {
             await adminSb

--- a/src/app/auth/profile-setup/page.tsx
+++ b/src/app/auth/profile-setup/page.tsx
@@ -20,6 +20,7 @@ import {
 
 interface ProfileData {
   username: string;
+  display_name: string;
   bio: string;
 }
 
@@ -52,11 +53,14 @@ export default function ProfileSetupPage() {
   const [error, setError] = useState("");
   const [userId, setUserId] = useState<string | null>(null);
   const [oauthAvatarUrl, setOauthAvatarUrl] = useState<string | null>(null);
+  const [verifiedGithub, setVerifiedGithub] = useState<string | null>(null);
+  const [connectingGithub, setConnectingGithub] = useState(false);
   const [streakLogged, setStreakLogged] = useState(false);
 
   // Step 1
   const [profile, setProfile] = useState<ProfileData>({
     username: "",
+    display_name: "",
     bio: "",
   });
 
@@ -95,6 +99,30 @@ export default function ProfileSetupPage() {
         user.user_metadata?.picture ||
         null;
       setOauthAvatarUrl(avatar);
+
+      // Pre-fill display_name from OAuth metadata if available.
+      const oauthFullName =
+        user.user_metadata?.full_name ||
+        user.user_metadata?.name ||
+        "";
+      if (oauthFullName) {
+        setProfile((p) => (p.display_name ? p : { ...p, display_name: oauthFullName }));
+      }
+
+      // Check if GitHub ownership has already been verified (via OAuth signup
+      // or a prior linkIdentity flow). This is the only trusted source.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data: userRow } = await (supabase.from("users") as any)
+        .select("display_name, github_username")
+        .eq("id", user.id)
+        .single();
+      if (userRow?.display_name) {
+        setProfile((p) => ({ ...p, display_name: userRow.display_name }));
+      }
+      if (userRow?.github_username) {
+        setVerifiedGithub(userRow.github_username);
+        setSocials((s) => ({ ...s, github: userRow.github_username }));
+      }
 
       // If returning user redirected to step 2, pre-fill existing socials
       if (initialStep === 2) {
@@ -146,6 +174,7 @@ export default function ProfileSetupPage() {
         {
           id: userId,
           username: profile.username,
+          display_name: profile.display_name.trim() || null,
           bio: profile.bio || null,
           ...(oauthAvatarUrl ? { avatar_url: oauthAvatarUrl } : {}),
         },
@@ -163,12 +192,27 @@ export default function ProfileSetupPage() {
     }
   };
 
+  const handleConnectGithub = async () => {
+    setConnectingGithub(true);
+    setError("");
+    const { error: linkError } = await supabase.auth.linkIdentity({
+      provider: "github",
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback?next=/auth/profile-setup?step=2`,
+      },
+    });
+    if (linkError) {
+      setError(`Couldn't connect GitHub: ${linkError.message}`);
+      setConnectingGithub(false);
+    }
+    // Success → browser redirects to GitHub OAuth.
+  };
+
   const handleStep2Next = async () => {
-    const github = socials.github.trim();
     const twitter = socials.twitter.trim();
     const telegram = socials.telegram.trim();
-    if (!github) {
-      setError("GitHub username is required so we can verify your work.");
+    if (!verifiedGithub) {
+      setError("Connect your GitHub account to verify ownership before continuing.");
       return;
     }
     if (!twitter && !telegram) {
@@ -180,7 +224,8 @@ export default function ProfileSetupPage() {
     setLoading(true);
 
     try {
-      const github = socials.github.trim();
+      // Always use the verified handle, never a free-text value.
+      const github = verifiedGithub;
       const website = socials.website.trim();
       const hasLinks = github || twitter || website || telegram;
 
@@ -373,6 +418,23 @@ export default function ProfileSetupPage() {
 
       <div>
         <label className="text-xs font-bold uppercase tracking-wide text-[var(--text-secondary)] mb-1.5 block">
+          Display Name
+        </label>
+        <input
+          type="text"
+          value={profile.display_name}
+          onChange={(e) => setProfile({ ...profile, display_name: e.target.value })}
+          placeholder="Your full name (e.g. Abhinav Kumar)"
+          maxLength={50}
+          className="input-brutal w-full"
+        />
+        <p className="text-[10px] text-[var(--text-secondary)] mt-1">
+          Shown above your @username on your profile. Optional but recommended.
+        </p>
+      </div>
+
+      <div>
+        <label className="text-xs font-bold uppercase tracking-wide text-[var(--text-secondary)] mb-1.5 block">
           Bio
         </label>
         <textarea
@@ -422,17 +484,40 @@ export default function ProfileSetupPage() {
         </div>
       </div>
 
-      <div className="flex items-center gap-3">
-        <Github size={18} className="text-[var(--text-secondary)] shrink-0" />
-        <input
-          type="text"
-          value={socials.github}
-          onChange={(e) => setSocials({ ...socials, github: e.target.value })}
-          placeholder="GitHub username *"
-          className="input-brutal w-full"
-          required
-        />
-      </div>
+      {verifiedGithub ? (
+        <div
+          className="flex items-center gap-3 px-4 py-3"
+          style={{
+            backgroundColor: "var(--status-success-bg)",
+            border: "2px solid var(--border-hard)",
+          }}
+        >
+          <Github size={18} className="text-[var(--status-success-text)] shrink-0" />
+          <span className="font-bold text-[var(--status-success-text)]">@{verifiedGithub}</span>
+          <span className="text-xs font-bold uppercase text-[var(--status-success-text)] opacity-70 ml-auto">
+            Verified ✓
+          </span>
+        </div>
+      ) : (
+        <div>
+          <button
+            type="button"
+            onClick={handleConnectGithub}
+            disabled={connectingGithub}
+            className="w-full flex items-center justify-center gap-2 px-5 py-3 text-sm font-extrabold uppercase tracking-wide text-white cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed transition-colors hover:bg-[var(--bg-pill-hover)]"
+            style={{
+              backgroundColor: "var(--bg-inverted)",
+              border: "2px solid var(--border-hard)",
+            }}
+          >
+            <Github size={18} />
+            {connectingGithub ? "Connecting..." : "Connect GitHub to verify *"}
+          </button>
+          <p className="mt-1.5 text-xs font-medium text-[var(--text-muted)]">
+            We verify ownership via GitHub OAuth so employers can trust your contributions.
+          </p>
+        </div>
+      )}
 
       <div className="flex items-center gap-3">
         <svg

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -3,14 +3,17 @@
 import { useState, useEffect, useMemo } from "react";
 import Image from "next/image";
 import Link from "next/link";
+import { BadgeCheck } from "lucide-react";
 
 type FeedItem = {
   id: string;
   type: "push" | "pr" | "create" | "issue" | "project" | "streak" | "joined";
   username: string;
+  display_name?: string | null;
   avatar_url: string | null;
   badge_level: string;
   streak: number;
+  github_verified?: boolean;
   date: string;
   repo_name?: string;
   message?: string;
@@ -209,7 +212,22 @@ export default function FeedPage() {
 
                   <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: 6, paddingTop: 4 }}>
                     <div style={{ fontSize: 15, color: "var(--text-secondary)" }}>
-                      <Link href={`/profile/${item.username}`} style={{ color: "var(--foreground)", fontWeight: 600, textDecoration: "none" }}>{item.username}</Link>
+                      <Link href={`/profile/${item.username}`} style={{ color: "var(--foreground)", fontWeight: 600, textDecoration: "none", display: "inline-flex", alignItems: "center", gap: 4 }}>
+                        {item.display_name || item.username}
+                        {item.github_verified && (
+                          <BadgeCheck
+                            size={14}
+                            className="text-white fill-[#1D9BF0] shrink-0"
+                            strokeWidth={2.5}
+                            aria-label="GitHub verified"
+                          />
+                        )}
+                      </Link>
+                      {item.display_name && (
+                        <span style={{ color: "var(--text-muted)", fontWeight: 500, marginLeft: 6 }}>
+                          @{item.username}
+                        </span>
+                      )}
                       {" "}{actionText(item)}
                       {item.repo_name && item.type !== "project" && item.type !== "streak" && (
                         <span className="fl-tag fl-tag-dark">{item.repo_name}</span>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -346,3 +346,12 @@ body:has(.chat-page-wrapper) main {
   transform: none !important;
   box-shadow: var(--shadow-brutal) !important;
 }
+
+/* Settings "New" field pulse — used when landing on /settings?complete=name */
+@keyframes settings-highlight-pulse {
+  0%, 100% { outline-color: var(--accent); }
+  50% { outline-color: transparent; }
+}
+.settings-highlight-pulse {
+  animation: settings-highlight-pulse 1.6s ease-in-out infinite;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -355,3 +355,11 @@ body:has(.chat-page-wrapper) main {
 .settings-highlight-pulse {
   animation: settings-highlight-pulse 1.6s ease-in-out infinite;
 }
+
+/* Respect users who prefer reduced motion — show a static highlight instead */
+@media (prefers-reduced-motion: reduce) {
+  .settings-highlight-pulse {
+    animation: none;
+    outline: 3px solid var(--accent);
+  }
+}

--- a/src/app/profile/[username]/opengraph-image.tsx
+++ b/src/app/profile/[username]/opengraph-image.tsx
@@ -130,6 +130,7 @@ export default async function Image({
               flex: 1,
             }}
           >
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
             <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
               <span
                 style={{
@@ -139,8 +140,23 @@ export default async function Image({
                   textTransform: "uppercase",
                 }}
               >
-                @{user.username}
+                {user.display_name || `@${user.username}`}
               </span>
+              {user.github_username && (
+                <svg
+                  width="44"
+                  height="44"
+                  viewBox="0 0 24 24"
+                  fill="#1D9BF0"
+                  stroke="#FFFFFF"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M3.85 8.62a4 4 0 0 1 4.78-4.77 4 4 0 0 1 6.74 0 4 4 0 0 1 4.78 4.78 4 4 0 0 1 0 6.74 4 4 0 0 1-4.77 4.78 4 4 0 0 1-6.75 0 4 4 0 0 1-4.78-4.77 4 4 0 0 1 0-6.76Z" />
+                  <path d="m9 12 2 2 4-4" stroke="#FFFFFF" />
+                </svg>
+              )}
               {badgeLabel && (
                 <span
                   style={{
@@ -156,6 +172,12 @@ export default async function Image({
                   {badgeLabel}
                 </span>
               )}
+            </div>
+            {user.display_name && (
+              <span style={{ fontSize: 24, color: "#71717A", fontWeight: 500 }}>
+                @{user.username}
+              </span>
+            )}
             </div>
 
             {user.bio && (

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import Image from "next/image";
+import { useSearchParams } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import type { UserWithSocials } from "@/lib/types/database";
 import { EmailPreferences } from "@/components/dashboard/email-preferences";
@@ -35,6 +36,7 @@ function extractUsername(value: string, platform: "twitter" | "telegram"): strin
 }
 
 export default function SettingsPage() {
+  const searchParams = useSearchParams();
   const [user, setUser] = useState<UserWithSocials | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -138,8 +140,7 @@ export default function SettingsPage() {
   // scroll to the display name field and pulse it until the user starts typing.
   useEffect(() => {
     if (!user) return;
-    const params = new URLSearchParams(window.location.search);
-    if (params.get("complete") === "name" && !user.display_name) {
+    if (searchParams.get("complete") === "name" && !user.display_name) {
       setHighlightName(true);
       // Defer until after the form fields have mounted
       setTimeout(() => {
@@ -147,7 +148,7 @@ export default function SettingsPage() {
         displayNameRef.current?.focus();
       }, 120);
     }
-  }, [user]);
+  }, [user, searchParams]);
 
   const handleAvatarUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -243,6 +244,15 @@ export default function SettingsPage() {
         farcaster: profileForm.ide || null,
       },
     });
+    // Let other parts of the app (navbar onboarding dot, etc.) react to the
+    // profile change without requiring a page reload.
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(
+        new CustomEvent("profile-updated", {
+          detail: { display_name: trimmedDisplayName || null },
+        })
+      );
+    }
     setSaving(false);
   };
 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -9,18 +9,19 @@ import {
   Save,
   Camera,
   Users,
+  Github,
+  CheckCircle2,
 } from "lucide-react";
 
 /**
  * Extract a bare username from a value that might be a full URL or @-prefixed handle.
  */
-function extractUsername(value: string, platform: "twitter" | "github" | "telegram"): string {
+function extractUsername(value: string, platform: "twitter" | "telegram"): string {
   let v = value.trim();
   if (!v) return "";
   v = v.replace(/\/+$/, "");
   const patterns: Record<string, RegExp[]> = {
     twitter: [/^https?:\/\/(www\.)?(twitter|x)\.com\//i],
-    github: [/^https?:\/\/(www\.)?github\.com\//i],
     telegram: [/^https?:\/\/(www\.)?(t\.me|telegram\.me)\//i],
   };
   for (const re of patterns[platform]) {
@@ -43,13 +44,16 @@ export default function SettingsPage() {
 
   const [profileForm, setProfileForm] = useState({
     username: "",
+    display_name: "",
     bio: "",
     twitter: "",
-    github: "",
     telegram: "",
     website: "",
     ide: "",
   });
+  const [connectingGithub, setConnectingGithub] = useState(false);
+  const [highlightName, setHighlightName] = useState(false);
+  const displayNameRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -120,13 +124,28 @@ export default function SettingsPage() {
     if (user) {
       setProfileForm({
         username: user.username,
+        display_name: user.display_name || "",
         bio: user.bio || "",
         twitter: user.social_links?.twitter || "",
-        github: user.social_links?.github || "",
         telegram: user.social_links?.telegram || "",
         website: user.social_links?.website || "",
         ide: user.social_links?.farcaster || "",
       });
+    }
+  }, [user]);
+
+  // When arriving via ?complete=name (e.g. from the navbar onboarding dot),
+  // scroll to the display name field and pulse it until the user starts typing.
+  useEffect(() => {
+    if (!user) return;
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("complete") === "name" && !user.display_name) {
+      setHighlightName(true);
+      // Defer until after the form fields have mounted
+      setTimeout(() => {
+        displayNameRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+        displayNameRef.current?.focus();
+      }, 120);
     }
   }, [user]);
 
@@ -186,15 +205,24 @@ export default function SettingsPage() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sb = supabase as any;
 
+    const trimmedDisplayName = profileForm.display_name.trim();
     await sb
       .from("users")
-      .update({ username: profileForm.username.trim(), bio: profileForm.bio.trim() })
+      .update({
+        username: profileForm.username.trim(),
+        display_name: trimmedDisplayName || null,
+        bio: profileForm.bio.trim(),
+      })
       .eq("id", user.id);
+
+    // Preserve the verified GitHub handle — it's only set via OAuth linking,
+    // never from a free-text field on this page.
+    const verifiedGithub = user.github_username || user.social_links?.github || null;
 
     await sb.from("social_links").upsert({
       user_id: user.id,
       twitter: twitter || null,
-      github: profileForm.github.trim() || null,
+      github: verifiedGithub,
       telegram: telegram || null,
       website: profileForm.website.trim() || null,
       farcaster: profileForm.ide || null,
@@ -203,18 +231,33 @@ export default function SettingsPage() {
     setUser({
       ...user,
       username: profileForm.username,
+      display_name: trimmedDisplayName || null,
       bio: profileForm.bio,
       social_links: {
         id: user.social_links?.id || "",
         user_id: user.id,
         twitter: profileForm.twitter || null,
-        github: profileForm.github || null,
+        github: verifiedGithub,
         telegram: profileForm.telegram || null,
         website: profileForm.website || null,
         farcaster: profileForm.ide || null,
       },
     });
     setSaving(false);
+  };
+
+  const handleConnectGithub = async () => {
+    setConnectingGithub(true);
+    const supabase = createClient();
+    const { error } = await supabase.auth.linkIdentity({
+      provider: "github",
+      options: { redirectTo: `${window.location.origin}/auth/callback?next=/settings` },
+    });
+    if (error) {
+      alert(`Couldn't connect GitHub: ${error.message}`);
+      setConnectingGithub(false);
+    }
+    // On success the browser redirects to GitHub, so no further UI update needed.
   };
 
   if (loading) {
@@ -296,6 +339,37 @@ export default function SettingsPage() {
             />
           </div>
           <div>
+            <label className="text-xs font-bold uppercase tracking-wide text-[var(--text-muted)] mb-1.5 flex items-center gap-2">
+              Display Name
+              {highlightName && (
+                <span
+                  className="px-1.5 py-0.5 text-[10px] font-extrabold text-white uppercase"
+                  style={{ backgroundColor: "var(--accent)", border: "1px solid var(--border-hard)" }}
+                >
+                  New
+                </span>
+              )}
+            </label>
+            <input
+              ref={displayNameRef}
+              type="text"
+              value={profileForm.display_name}
+              onChange={(e) => {
+                setProfileForm({ ...profileForm, display_name: e.target.value });
+                if (highlightName) setHighlightName(false);
+              }}
+              placeholder="Your full name (e.g. Abhinav Kumar)"
+              maxLength={50}
+              className={`input-brutal ${highlightName ? "settings-highlight-pulse" : ""}`}
+              style={highlightName ? { outline: "3px solid var(--accent)", outlineOffset: 2 } : undefined}
+            />
+            <p className="mt-1.5 text-xs font-medium text-[var(--text-muted)]">
+              {highlightName
+                ? "Add your full name so employers know who you are."
+                : "Shown above your @username on your profile and in search results."}
+            </p>
+          </div>
+          <div>
             <label className="text-xs font-bold uppercase tracking-wide text-[var(--text-muted)] mb-1.5 block">Bio</label>
             <textarea
               value={profileForm.bio}
@@ -321,17 +395,38 @@ export default function SettingsPage() {
             </div>
             <div>
               <label className="text-xs font-bold uppercase tracking-wide text-[var(--text-muted)] mb-1.5 block">GitHub</label>
-              <div className="relative">
-                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-muted-soft)] font-bold text-sm select-none">@</span>
-                <input
-                  type="text"
-                  value={profileForm.github}
-                  onChange={(e) => setProfileForm({ ...profileForm, github: extractUsername(e.target.value, "github") })}
-                  placeholder="username"
-                  className="input-brutal"
-                  style={{ paddingLeft: "1.75rem" }}
-                />
-              </div>
+              {user.github_username ? (
+                <div
+                  className="flex items-center gap-2 px-3 py-2.5 text-sm"
+                  style={{
+                    backgroundColor: "var(--status-success-bg)",
+                    border: "2px solid var(--border-hard)",
+                  }}
+                >
+                  <CheckCircle2 size={16} className="text-[var(--status-success-text)] flex-shrink-0" />
+                  <span className="font-bold text-[var(--status-success-text)]">@{user.github_username}</span>
+                  <span className="text-xs font-bold uppercase text-[var(--status-success-text)] opacity-70 ml-auto">Verified</span>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={handleConnectGithub}
+                  disabled={connectingGithub}
+                  className="w-full flex items-center justify-center gap-2 px-3 py-2.5 text-sm font-extrabold uppercase tracking-wide text-white cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed transition-colors hover:bg-[var(--bg-pill-hover)]"
+                  style={{
+                    backgroundColor: "var(--bg-inverted)",
+                    border: "2px solid var(--border-hard)",
+                  }}
+                >
+                  <Github size={16} />
+                  {connectingGithub ? "Connecting..." : "Connect GitHub"}
+                </button>
+              )}
+              <p className="mt-1.5 text-xs font-medium text-[var(--text-muted)]">
+                {user.github_username
+                  ? "Ownership verified via GitHub OAuth."
+                  : "Verify ownership to enable streak sync."}
+              </p>
             </div>
             <div>
               <label className="text-xs font-bold uppercase tracking-wide text-[var(--text-muted)] mb-1.5 block">Telegram</label>

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -116,7 +116,19 @@ export function Navbar() {
       }
     });
 
-    return () => subscription.unsubscribe();
+    // Refetch the profile whenever something in the app saves it (e.g. the
+    // settings page saves a display name). Without this, the onboarding dot
+    // would only clear on a full reload.
+    const handleProfileUpdated = async () => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (user) fetchProfile(user.id, user.email);
+    };
+    window.addEventListener("profile-updated", handleProfileUpdated);
+
+    return () => {
+      subscription.unsubscribe();
+      window.removeEventListener("profile-updated", handleProfileUpdated);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [checkUnread]);
 

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname, useRouter } from "next/navigation";
-import { Flame, Menu, X, LogOut, Settings, User, Users } from "lucide-react";
+import { Flame, Menu, X, LogOut, Settings, User, Users, BadgeCheck } from "lucide-react";
 import { useState, useEffect, useRef, useCallback } from "react";
 import { createClient } from "@/lib/supabase/client";
 import { NotificationBell } from "@/components/ui/notification-bell";
@@ -51,7 +51,7 @@ export function Navbar() {
   const [mobileOpen, setMobileOpen] = useState(false);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [profileDropdownOpen, setProfileDropdownOpen] = useState(false);
-  const [userProfile, setUserProfile] = useState<{ username: string; avatar_url: string | null } | null>(null);
+  const [userProfile, setUserProfile] = useState<{ username: string; avatar_url: string | null; github_username: string | null; display_name: string | null } | null>(null);
   const [hasUnreadNotifications, setHasUnreadNotifications] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -75,20 +75,25 @@ export function Navbar() {
       try {
         const { data: profile, error } = await sb
           .from("users")
-          .select("username, avatar_url")
+          .select("username, avatar_url, github_username, display_name")
           .eq("id", userId)
           .single();
         if (error) console.error("Navbar profile fetch error:", error);
         if (profile && profile.username) {
-          setUserProfile({ username: profile.username, avatar_url: profile.avatar_url });
+          setUserProfile({
+            username: profile.username,
+            avatar_url: profile.avatar_url,
+            github_username: profile.github_username || null,
+            display_name: profile.display_name || null,
+          });
         } else if (email) {
           // Fallback: use email prefix as display name
-          setUserProfile({ username: email.split("@")[0], avatar_url: null });
+          setUserProfile({ username: email.split("@")[0], avatar_url: null, github_username: null, display_name: null });
         }
       } catch (err) {
         console.error("Navbar profile fetch failed:", err);
         if (email) {
-          setUserProfile({ username: email.split("@")[0], avatar_url: null });
+          setUserProfile({ username: email.split("@")[0], avatar_url: null, github_username: null, display_name: null });
         }
       }
     }
@@ -233,6 +238,29 @@ export function Navbar() {
                   size={48}
                 />
               </button>
+              {userProfile?.github_username && (
+                <BadgeCheck
+                  size={18}
+                  strokeWidth={2.5}
+                  className="text-white fill-[#1D9BF0] absolute -bottom-0.5 -right-0.5 pointer-events-none"
+                  style={{ filter: "drop-shadow(0 0 2px var(--bg-base))" }}
+                  aria-label="GitHub verified"
+                />
+              )}
+              {userProfile && !userProfile.display_name && (
+                <span
+                  className="absolute -top-0.5 -right-0.5 pointer-events-none"
+                  style={{
+                    width: 12,
+                    height: 12,
+                    borderRadius: "50%",
+                    backgroundColor: "var(--accent)",
+                    border: "2px solid var(--bg-base)",
+                  }}
+                  aria-label="Profile needs completion"
+                  title="Complete your profile"
+                />
+              )}
               {profileDropdownOpen && (
                 <div
                   role="menu"
@@ -253,13 +281,30 @@ export function Navbar() {
                     My Profile
                   </Link>
                   <Link
-                    href="/settings"
+                    href={userProfile && !userProfile.display_name ? "/settings?complete=name" : "/settings"}
                     onClick={() => setProfileDropdownOpen(false)}
                     className="flex items-center gap-2 px-4 py-3 text-sm font-bold uppercase tracking-wide transition-colors"
                     style={{ color: "var(--foreground)" }}
                   >
                     <Settings size={16} />
-                    Settings
+                    <span>Settings</span>
+                    {userProfile && !userProfile.display_name && (
+                      <span
+                        className="ml-auto flex items-center gap-1 text-[10px] font-extrabold uppercase"
+                        style={{ color: "var(--accent)" }}
+                      >
+                        <span
+                          style={{
+                            width: 8,
+                            height: 8,
+                            borderRadius: "50%",
+                            backgroundColor: "var(--accent)",
+                            display: "inline-block",
+                          }}
+                        />
+                        1 to do
+                      </span>
+                    )}
                   </Link>
                   <Link
                     href="/settings#referral"
@@ -358,7 +403,17 @@ export function Navbar() {
                   size={36}
                 />
               </div>
-              <span className="text-sm font-extrabold text-[var(--foreground)]">{userProfile.username}</span>
+              <span className="text-sm font-extrabold text-[var(--foreground)] flex items-center gap-1">
+                {userProfile.username}
+                {userProfile.github_username && (
+                  <BadgeCheck
+                    size={14}
+                    strokeWidth={2.5}
+                    className="text-white fill-[#1D9BF0] shrink-0"
+                    aria-label="GitHub verified"
+                  />
+                )}
+              </span>
             </div>
           )}
 

--- a/src/components/leaderboard/leaderboard-content.tsx
+++ b/src/components/leaderboard/leaderboard-content.tsx
@@ -5,7 +5,7 @@ import { BadgeDisplay } from "@/components/ui/badge-display";
 import type { UserWithSocials } from "@/lib/types/database";
 import { StreakCounter } from "@/components/ui/streak-counter";
 import { VibeScore } from "@/components/ui/vibe-score";
-import { Trophy, Flame, Code2, Zap, ChevronLeft, ChevronRight } from "lucide-react";
+import { Trophy, Flame, Code2, Zap, ChevronLeft, ChevronRight, BadgeCheck } from "lucide-react";
 import Link from "next/link";
 import Image from "next/image";
 
@@ -123,7 +123,20 @@ export function LeaderboardContent({ users }: { users: UserWithSocials[] }) {
                 )}
               </div>
               <div className="text-xs font-extrabold text-[var(--text-muted)] mb-1 uppercase">#{rank}</div>
-              <div className="font-extrabold text-[var(--foreground)] text-sm uppercase">@{user.username}</div>
+              <div className="font-extrabold text-[var(--foreground)] text-sm uppercase flex items-center justify-center gap-1">
+                {user.display_name || `@${user.username}`}
+                {user.github_username && (
+                  <BadgeCheck
+                    size={14}
+                    className="text-white fill-[#1D9BF0] shrink-0"
+                    strokeWidth={2.5}
+                    aria-label="GitHub verified"
+                  />
+                )}
+              </div>
+              {user.display_name && (
+                <div className="text-xs font-medium text-[var(--text-muted)]">@{user.username}</div>
+              )}
               <div className="mt-2">
                 <BadgeDisplay level={user.badge_level} size="sm" />
               </div>
@@ -181,7 +194,22 @@ export function LeaderboardContent({ users }: { users: UserWithSocials[] }) {
                           initials
                         )}
                       </div>
-                      <span className="font-bold text-sm uppercase">@{user.username}</span>
+                      <div className="flex flex-col min-w-0">
+                        <span className="font-bold text-sm uppercase flex items-center gap-1 truncate">
+                          {user.display_name || `@${user.username}`}
+                          {user.github_username && (
+                            <BadgeCheck
+                              size={14}
+                              className="text-white fill-[#1D9BF0] shrink-0"
+                              strokeWidth={2.5}
+                              aria-label="GitHub verified"
+                            />
+                          )}
+                        </span>
+                        {user.display_name && (
+                          <span className="text-xs font-medium text-[var(--text-muted)] normal-case truncate">@{user.username}</span>
+                        )}
+                      </div>
                     </Link>
                   </td>
                   <td className="px-3 sm:px-4 py-3 text-right">

--- a/src/components/profile/profile-sidebar.tsx
+++ b/src/components/profile/profile-sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Image from "next/image";
-import { Github, Globe, Bot, Code2, Share2, Link2 as LinkIcon, Check, Send } from "lucide-react";
+import { Github, Globe, Bot, Code2, Share2, Link2 as LinkIcon, Check, Send, BadgeCheck } from "lucide-react";
 import Link from "next/link";
 import type { UserWithSocials, BadgeLevel } from "@/lib/types/database";
 import { HireModal } from "@/components/ui/hire-modal";
@@ -143,9 +143,27 @@ export function ProfileSidebar({ user, isOwner = false }: ProfileSidebarProps) {
           )}
         </div>
 
-        {/* Name + role */}
+        {/* Name + handle + role */}
         <div className="mt-2">
-          <h1 className="text-xl font-extrabold uppercase tracking-tight text-[var(--foreground)]">@{user.username}</h1>
+          <h1 className="text-xl font-extrabold uppercase tracking-tight text-[var(--foreground)] flex items-center justify-center gap-1.5">
+            <span>{user.display_name || `@${user.username}`}</span>
+            {user.github_username && (
+              <span
+                className="inline-flex items-center"
+                title={`GitHub ownership verified: @${user.github_username}`}
+                aria-label={`GitHub verified as @${user.github_username}`}
+              >
+                <BadgeCheck
+                  size={20}
+                  className="text-white fill-[#1D9BF0]"
+                  strokeWidth={2.5}
+                />
+              </span>
+            )}
+          </h1>
+          {user.display_name && (
+            <p className="text-sm font-medium text-[var(--text-muted)] mt-0.5">@{user.username}</p>
+          )}
           <p className="text-sm font-bold text-[var(--text-muted)] uppercase mt-0.5">{deriveRole(user.projects)}</p>
         </div>
 

--- a/src/components/ui/vibecoder-card.tsx
+++ b/src/components/ui/vibecoder-card.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 import { BadgeDisplay } from "./badge-display";
 import { StreakCounter } from "./streak-counter";
 import { VibeScore } from "./vibe-score";
-import { Code2, ExternalLink, Activity } from "lucide-react";
+import { Code2, ExternalLink, Activity, BadgeCheck } from "lucide-react";
 import type { UserWithSocials } from "@/lib/types/database";
 
 interface VibecoderCardProps {
@@ -68,10 +68,23 @@ export function VibecoderCard({ user, rank }: VibecoderCardProps) {
           </div>
 
           <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2 flex-wrap">
-              <h3 className="font-extrabold uppercase text-[var(--foreground)] group-hover:text-[var(--accent)] transition-colors">
-                @{user.username}
-              </h3>
+            <div className="flex items-start gap-2 flex-wrap">
+              <div className="min-w-0">
+                <h3 className="font-extrabold uppercase text-[var(--foreground)] group-hover:text-[var(--accent)] transition-colors flex items-center gap-1 truncate">
+                  {user.display_name || `@${user.username}`}
+                  {user.github_username && (
+                    <BadgeCheck
+                      size={16}
+                      className="text-white fill-[#1D9BF0] shrink-0"
+                      strokeWidth={2.5}
+                      aria-label={`GitHub verified as @${user.github_username}`}
+                    />
+                  )}
+                </h3>
+                {user.display_name && (
+                  <p className="text-xs font-medium text-[var(--text-muted)] truncate">@{user.username}</p>
+                )}
+              </div>
               <BadgeDisplay level={user.badge_level} size="sm" />
             </div>
 

--- a/src/lib/__tests__/agent-scoring.test.ts
+++ b/src/lib/__tests__/agent-scoring.test.ts
@@ -33,8 +33,10 @@ function createMockUser(overrides: Partial<UserWithSocials> = {}): UserWithSocia
   return {
     id: "user-1",
     username: "testuser",
+    display_name: null,
     bio: "Full stack developer",
     avatar_url: null,
+    github_username: null,
     streak: 30,
     longest_streak: 60,
     vibe_score: 100,

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -220,7 +220,8 @@ export const mockUsers: UserWithSocials[] = [
   {
     id: "u1",
     username: "vibemaster",
-
+    display_name: null,
+    github_username: null,
     bio: "Full-stack vibecoder shipping products daily. I turn ideas into deployed apps before my coffee gets cold.",
     avatar_url: null,
     streak: 127,
@@ -245,6 +246,8 @@ export const mockUsers: UserWithSocials[] = [
   {
     id: "u2",
     username: "shipfast_dev",
+    display_name: null,
+    github_username: null,
     bio: "Building in public. 90-day streak and counting. React + Node specialist.",
     avatar_url: null,
     streak: 94,
@@ -269,6 +272,8 @@ export const mockUsers: UserWithSocials[] = [
   {
     id: "u3",
     username: "code_ninja",
+    display_name: null,
+    github_username: null,
     bio: "Python & AI enthusiast. Automating everything one bot at a time.",
     avatar_url: null,
     streak: 45,
@@ -293,6 +298,8 @@ export const mockUsers: UserWithSocials[] = [
   {
     id: "u4",
     username: "web3_builder",
+    display_name: null,
+    github_username: null,
     bio: "Solidity dev gone full-stack. Building the decentralized future, one vibe at a time.",
     avatar_url: null,
     streak: 210,
@@ -317,6 +324,8 @@ export const mockUsers: UserWithSocials[] = [
   {
     id: "u5",
     username: "indie_hacker",
+    display_name: null,
+    github_username: null,
     bio: "Solo founder building micro-SaaS products. Shipped 12 projects in 6 months.",
     avatar_url: null,
     streak: 380,
@@ -341,6 +350,8 @@ export const mockUsers: UserWithSocials[] = [
   {
     id: "u6",
     username: "midnight_coder",
+    display_name: null,
+    github_username: null,
     bio: "I code after midnight. Dark mode is not a preference, it's a lifestyle.",
     avatar_url: null,
     streak: 15,
@@ -365,6 +376,8 @@ export const mockUsers: UserWithSocials[] = [
   {
     id: "u7",
     username: "mobile_mira",
+    display_name: null,
+    github_username: null,
     bio: "Mobile-first developer. React Native by day, Flutter experiments by night. 30+ apps on the stores.",
     avatar_url: null,
     streak: 68,
@@ -389,6 +402,8 @@ export const mockUsers: UserWithSocials[] = [
   {
     id: "u8",
     username: "infra_ivan",
+    display_name: null,
+    github_username: null,
     bio: "DevOps engineer who treats infrastructure as code. If it's not in a container, it doesn't exist.",
     avatar_url: null,
     streak: 302,
@@ -413,6 +428,8 @@ export const mockUsers: UserWithSocials[] = [
   {
     id: "u9",
     username: "pixel_priya",
+    display_name: null,
+    github_username: null,
     bio: "Designer who codes. Bridging the gap between Figma and production with pixel-perfect components.",
     avatar_url: null,
     streak: 22,
@@ -437,6 +454,8 @@ export const mockUsers: UserWithSocials[] = [
   {
     id: "u10",
     username: "data_diego",
+    display_name: null,
+    github_username: null,
     bio: "ML engineer turning messy data into production models. Python, TensorFlow, and too many Jupyter notebooks.",
     avatar_url: null,
     streak: 156,
@@ -461,6 +480,8 @@ export const mockUsers: UserWithSocials[] = [
   {
     id: "u11",
     username: "gamedev_grace",
+    display_name: null,
+    github_username: null,
     bio: "Unity developer and creative coder. Making games that run everywhere, even in your browser.",
     avatar_url: null,
     streak: 8,
@@ -485,6 +506,8 @@ export const mockUsers: UserWithSocials[] = [
   {
     id: "u12",
     username: "rust_renzo",
+    display_name: null,
+    github_username: null,
     bio: "Systems programmer obsessed with performance. Rust and Go for backends, PostgreSQL for everything else.",
     avatar_url: null,
     streak: 245,

--- a/src/lib/supabase/queries.ts
+++ b/src/lib/supabase/queries.ts
@@ -4,7 +4,7 @@ import type { UserWithSocials, HireRequest } from "@/lib/types/database";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const supabase = () => createClient() as any;
 
-const USER_FIELDS = "id, username, bio, avatar_url, vibe_score, streak, longest_streak, badge_level, created_at";
+const USER_FIELDS = "id, username, display_name, bio, avatar_url, github_username, vibe_score, streak, longest_streak, badge_level, created_at";
 const PROJECT_FIELDS = "id, user_id, title, description, tech_stack, live_url, github_url, image_url, build_time, tags, verified, created_at";
 const SOCIAL_FIELDS = "id, user_id, twitter, telegram, github, website, farcaster";
 

--- a/src/lib/supabase/server-queries.ts
+++ b/src/lib/supabase/server-queries.ts
@@ -2,7 +2,7 @@ import { unstable_cache } from "next/cache";
 import { createClient } from "@supabase/supabase-js";
 import type { UserWithSocials } from "@/lib/types/database";
 
-const USER_FIELDS = "id, username, bio, avatar_url, vibe_score, streak, longest_streak, badge_level, created_at";
+const USER_FIELDS = "id, username, display_name, bio, avatar_url, github_username, vibe_score, streak, longest_streak, badge_level, created_at";
 const PROJECT_FIELDS = "id, user_id, title, description, tech_stack, live_url, github_url, image_url, build_time, tags, verified, created_at";
 const SOCIAL_FIELDS = "id, user_id, twitter, telegram, github, website, farcaster";
 

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -3,8 +3,10 @@ export type BadgeLevel = "none" | "bronze" | "silver" | "gold" | "diamond";
 export interface User {
   id: string;
   username: string;
+  display_name: string | null;
   bio: string | null;
   avatar_url: string | null;
+  github_username: string | null;
   streak: number;
   longest_streak: number;
   vibe_score: number;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -298,6 +298,11 @@ ALTER TABLE projects ADD COLUMN IF NOT EXISTS live_url_ok BOOLEAN;
 -- Add github_username column to users (populated from GitHub OAuth on login)
 ALTER TABLE users ADD COLUMN IF NOT EXISTS github_username TEXT;
 
+-- Add display_name column to users (Twitter-style "real name" above @username).
+-- Nullable — optional field. Auto-populated from OAuth metadata on first signup
+-- via the profile-setup flow, editable in settings afterwards.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS display_name TEXT;
+
 -- Project reports table (spam prevention)
 CREATE TABLE project_reports (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),


### PR DESCRIPTION
## Summary

Adds Twitter-style display names and a blue verified checkmark for OAuth-verified GitHub ownership across the whole app, plus a gentle onboarding prompt for existing users to complete their profile.

- **Display name** column on `users`, editable in settings. Profile-setup step 1 pre-fills it from OAuth `user_metadata.full_name` so new GitHub/Google signups get a sensible default to accept or change. Shown stacked above `@username` on profiles, cards, feed, leaderboard, share card, and OG image.
- **Verified GitHub checkmark** (Twitter-style blue badge) wherever usernames appear, driven by the existing `github_username` column which is only set through trusted OAuth identities.
- **Closes a streak-farming vector**: `/api/github/activity` no longer falls back to the free-text `social_links.github` field, so a Google/email user can't claim someone else's commits by typing their handle.
- **`supabase.auth.linkIdentity("github")` flow** added to settings and profile-setup so users who signed up with Google/email can prove ownership without starting over.
- **New signups** (email confirm or OAuth) now redirect to `/auth/profile-setup` instead of `/dashboard` when their profile is incomplete.
- **Onboarding dot**: the navbar shows an orange dot on the avatar and in the Settings dropdown entry whenever `display_name` is null. Clicking it lands on `/settings?complete=name`, which scrolls to the field and pulses the outline until the user saves. The dot clears reactively via a `profile-updated` window event dispatched from Settings — no dismiss state needed, no full reload required.

## Schema changes

`ALTER TABLE users ADD COLUMN display_name TEXT` is committed in `supabase/schema.sql` alongside the existing `github_username` column. A one-time backfill from `auth.identities` was run directly in the production Supabase project before merge; it's not part of the schema file because it's operational, not structural.

## Required Supabase dashboard setting

**Authentication → Sign In / Providers → "Allow manual linking"** must be **ON** for the `linkIdentity` button to work. Without it, Connect GitHub errors out with "Manual linking is disabled".

## Test plan

- [ ] Sign up with a fresh email → confirmation email arrives → clicking link lands on `/auth/profile-setup` (not `/dashboard`)
- [ ] In profile-setup step 1, "Display Name" field visible and optional; saves to `users.display_name`
- [ ] In profile-setup step 2, "Connect GitHub" button required before Next; clicking links the identity and pre-fills verified handle
- [ ] Sign up with GitHub OAuth → display_name pre-filled from OAuth metadata in profile-setup; github_username auto-populated
- [ ] Existing user without display_name sees an orange dot on their navbar avatar when logged in
- [ ] Clicking avatar → dropdown shows dot on Settings with "1 to do" label
- [ ] Clicking Settings → lands on `/settings?complete=name`, scrolls to the field, pulses outline
- [ ] Saving the display name clears the dot everywhere **without requiring a page reload**
- [ ] Clearing the display name (saving empty string) keeps it empty — does not get restored from OAuth on next login
- [ ] Verified checkmark visible next to `@username` on: profile sidebar, explore cards, feed rows, leaderboard table, navbar avatar, share card (PNG), OG image
- [ ] `/api/github/activity` returns 400 "GitHub ownership not verified" when `users.github_username` is null, even if `social_links.github` is set
- [ ] Motion-sensitive users (OS setting: Reduce Motion) see a static highlight instead of the pulse animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)