### PR TITLE
fix: block crawlers from indexing opengraph-image endpoints

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -8,6 +8,7 @@ const privateDisallow = [
   "/admin",
   "/auth/",
   "/hire/chat/",
+  "/*/opengraph-image",
 ];
 
 export default function robots(): MetadataRoute.Robots {


### PR DESCRIPTION
## Summary
- Adds `/*/opengraph-image` to the robots.txt disallow list
- Prevents Google from crawling dynamic OG image routes (they return PNG images, not HTML pages)
- Fixes "Crawled - currently not indexed" validation failure in Google Search Console

## Test plan
- [ ] Verify `robots.txt` output includes the new disallow rule after deploy
- [ ] Validate fix in Google Search Console for the affected URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated crawler directives to optimize how search engines handle generated image resources on the site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->