### PR TITLE
fix: show clear error messages for OAuth failures

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -3,10 +3,28 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 
+// Map Supabase error codes to user-friendly messages
+const ERROR_MESSAGES: Record<string, string> = {
+  identity_already_exists:
+    "This GitHub account is already linked to another VibeTalent account. Please sign in with that account instead, or use a different GitHub account.",
+};
+
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
   const next = searchParams.get("next") ?? "/dashboard";
+
+  // Handle OAuth errors returned by Supabase (no code param present)
+  const errorCode = searchParams.get("error_code");
+  if (errorCode) {
+    const message =
+      ERROR_MESSAGES[errorCode] ||
+      searchParams.get("error_description")?.replace(/\+/g, " ") ||
+      "Authentication failed. Please try again.";
+    return NextResponse.redirect(
+      `${origin}/auth/login?error=${encodeURIComponent(message)}`
+    );
+  }
 
   if (code) {
     const cookieStore = await cookies();
@@ -119,5 +137,5 @@ export async function GET(request: Request) {
     }
   }
 
-  return NextResponse.redirect(`${origin}/auth/login?error=auth_failed`);
+  return NextResponse.redirect(`${origin}/auth/login?error=${encodeURIComponent("Authentication failed. Please try again.")}`);
 }

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -17,6 +17,12 @@ export default function LoginPage() {
   const reason = searchParams.get("reason");
   const redirectTo = searchParams.get("redirect") || "/dashboard";
 
+  // Show OAuth errors forwarded from the auth callback
+  useEffect(() => {
+    const urlError = searchParams.get("error");
+    if (urlError) setError(urlError);
+  }, [searchParams]);
+
   // Redirect already-authenticated users to dashboard
   useEffect(() => {
     const supabase = createClient();


### PR DESCRIPTION
## Summary
- Auth callback now parses Supabase error params (`error_code`, `error_description`) instead of silently redirecting
- Maps `identity_already_exists` to a clear message: "This GitHub account is already linked to another VibeTalent account"
- Login page reads the `error` query param and displays it in the existing styled error box
- Generic fallback message for unknown OAuth errors

## Context
A user tried connecting GitHub but their account was already linked to a different VibeTalent profile. They got silently kicked to the homepage with zero feedback — had to open DevTools and read the URL to figure out what happened.

## Test plan
- [ ] Visit `/auth/login?error=Test+error+message` — verify red error box appears
- [ ] Trigger `identity_already_exists` by linking a GitHub already bound to another account
- [ ] Verify normal GitHub OAuth login still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth authentication error handling by displaying user-friendly error messages on the login page when OAuth attempts fail
  * Added intelligent fallback system for OAuth error codes to provide appropriate feedback to users during authentication failures
  * Enhanced error message handling and transmission through the authentication flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->