### PR TITLE
feat: smart pagination with ellipsis and jump buttons

### DIFF
--- a/src/components/explore/explore-content.tsx
+++ b/src/components/explore/explore-content.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useMemo, useCallback } from "react";
 import { VibecoderCard } from "@/components/ui/vibecoder-card";
-import { Search, SlidersHorizontal, Bot, ChevronLeft, ChevronRight } from "lucide-react";
+import { Search, SlidersHorizontal, Bot } from "lucide-react";
+import { Pagination } from "@/components/ui/pagination";
 import Link from "next/link";
 import type { BadgeLevel, UserWithSocials } from "@/lib/types/database";
 
@@ -345,49 +346,9 @@ export function ExploreContent({ users }: { users: UserWithSocials[] }) {
           </div>
 
           {/* Pagination */}
-          {totalPages > 1 && (
-            <div className="flex items-center justify-center gap-2 mt-10">
-              <button
-                onClick={() => goToPage(activePage - 1)}
-                disabled={activePage === 1}
-                className="flex items-center justify-center w-10 h-10 font-extrabold uppercase transition-all disabled:opacity-30 disabled:cursor-not-allowed"
-                style={{
-                  backgroundColor: "var(--bg-surface)",
-                  border: "2px solid var(--border-hard)",
-                  boxShadow: "var(--shadow-brutal-sm)",
-                }}
-              >
-                <ChevronLeft size={16} />
-              </button>
-              {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
-                <button
-                  key={page}
-                  onClick={() => goToPage(page)}
-                  className="flex items-center justify-center w-10 h-10 text-sm font-extrabold uppercase transition-all"
-                  style={{
-                    backgroundColor: activePage === page ? "var(--accent)" : "var(--bg-surface)",
-                    color: activePage === page ? "#FFFFFF" : "var(--foreground)",
-                    border: "2px solid var(--border-hard)",
-                    boxShadow: activePage === page ? "none" : "var(--shadow-brutal-sm)",
-                  }}
-                >
-                  {page}
-                </button>
-              ))}
-              <button
-                onClick={() => goToPage(activePage + 1)}
-                disabled={activePage === totalPages}
-                className="flex items-center justify-center w-10 h-10 font-extrabold uppercase transition-all disabled:opacity-30 disabled:cursor-not-allowed"
-                style={{
-                  backgroundColor: "var(--bg-surface)",
-                  border: "2px solid var(--border-hard)",
-                  boxShadow: "var(--shadow-brutal-sm)",
-                }}
-              >
-                <ChevronRight size={16} />
-              </button>
-            </div>
-          )}
+          <div className="mt-10">
+            <Pagination currentPage={activePage} totalPages={totalPages} onPageChange={goToPage} />
+          </div>
         </>
       ) : (
         <div

--- a/src/components/leaderboard/leaderboard-content.tsx
+++ b/src/components/leaderboard/leaderboard-content.tsx
@@ -5,7 +5,8 @@ import { BadgeDisplay } from "@/components/ui/badge-display";
 import type { UserWithSocials } from "@/lib/types/database";
 import { StreakCounter } from "@/components/ui/streak-counter";
 import { VibeScore } from "@/components/ui/vibe-score";
-import { Trophy, Flame, Code2, Zap, ChevronLeft, ChevronRight, BadgeCheck } from "lucide-react";
+import { Trophy, Flame, Code2, Zap, BadgeCheck } from "lucide-react";
+import { Pagination } from "@/components/ui/pagination";
 import Link from "next/link";
 import Image from "next/image";
 
@@ -237,49 +238,7 @@ export function LeaderboardContent({ users }: { users: UserWithSocials[] }) {
           <p className="mt-4 text-sm font-bold uppercase tracking-wide text-[var(--text-muted)] text-center">
             Showing {(activePage - 1) * PAGE_SIZE + 1}–{Math.min(activePage * PAGE_SIZE, sortedUsers.length)} of {sortedUsers.length} builders
           </p>
-          {totalPages > 1 && (
-            <div className="flex items-center justify-center gap-2 mt-4">
-              <button
-                onClick={() => goToPage(activePage - 1)}
-                disabled={activePage === 1}
-                className="flex items-center justify-center w-10 h-10 font-extrabold uppercase transition-all disabled:opacity-30 disabled:cursor-not-allowed"
-                style={{
-                  backgroundColor: "var(--bg-surface)",
-                  border: "2px solid var(--border-hard)",
-                  boxShadow: "var(--shadow-brutal-sm)",
-                }}
-              >
-                <ChevronLeft size={16} />
-              </button>
-              {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
-                <button
-                  key={page}
-                  onClick={() => goToPage(page)}
-                  className="flex items-center justify-center w-10 h-10 text-sm font-extrabold uppercase transition-all"
-                  style={{
-                    backgroundColor: activePage === page ? "var(--accent)" : "var(--bg-surface)",
-                    color: activePage === page ? "#FFFFFF" : "var(--foreground)",
-                    border: "2px solid var(--border-hard)",
-                    boxShadow: activePage === page ? "none" : "var(--shadow-brutal-sm)",
-                  }}
-                >
-                  {page}
-                </button>
-              ))}
-              <button
-                onClick={() => goToPage(activePage + 1)}
-                disabled={activePage === totalPages}
-                className="flex items-center justify-center w-10 h-10 font-extrabold uppercase transition-all disabled:opacity-30 disabled:cursor-not-allowed"
-                style={{
-                  backgroundColor: "var(--bg-surface)",
-                  border: "2px solid var(--border-hard)",
-                  boxShadow: "var(--shadow-brutal-sm)",
-                }}
-              >
-                <ChevronRight size={16} />
-              </button>
-            </div>
-          )}
+          <Pagination currentPage={activePage} totalPages={totalPages} onPageChange={goToPage} />
         </>
       )}
     </>

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from "lucide-react";
+
+interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+/**
+ * Build the list of page numbers to display, with ellipsis gaps.
+ * Always shows: first page, last page, and up to 2 pages around the current page.
+ * Example for page 5 of 20: [1, "...", 4, 5, 6, "...", 20]
+ */
+function getPageNumbers(current: number, total: number): (number | "...")[] {
+  if (total <= 7) {
+    return Array.from({ length: total }, (_, i) => i + 1);
+  }
+
+  const pages: (number | "...")[] = [];
+  const siblings = 1; // pages on each side of current
+
+  // Always include first page
+  pages.push(1);
+
+  const rangeStart = Math.max(2, current - siblings);
+  const rangeEnd = Math.min(total - 1, current + siblings);
+
+  if (rangeStart > 2) pages.push("...");
+
+  for (let i = rangeStart; i <= rangeEnd; i++) {
+    pages.push(i);
+  }
+
+  if (rangeEnd < total - 1) pages.push("...");
+
+  // Always include last page
+  pages.push(total);
+
+  return pages;
+}
+
+const btnBase =
+  "flex items-center justify-center w-10 h-10 font-extrabold uppercase transition-all";
+
+export function Pagination({ currentPage, totalPages, onPageChange }: PaginationProps) {
+  if (totalPages <= 1) return null;
+
+  const pages = getPageNumbers(currentPage, totalPages);
+
+  return (
+    <div className="flex items-center justify-center gap-2 mt-4">
+      {/* First page */}
+      <button
+        onClick={() => onPageChange(1)}
+        disabled={currentPage === 1}
+        className={`${btnBase} disabled:opacity-30 disabled:cursor-not-allowed`}
+        style={{
+          backgroundColor: "var(--bg-surface)",
+          border: "2px solid var(--border-hard)",
+          boxShadow: "var(--shadow-brutal-sm)",
+        }}
+        aria-label="First page"
+      >
+        <ChevronsLeft size={16} />
+      </button>
+
+      {/* Previous page */}
+      <button
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={currentPage === 1}
+        className={`${btnBase} disabled:opacity-30 disabled:cursor-not-allowed`}
+        style={{
+          backgroundColor: "var(--bg-surface)",
+          border: "2px solid var(--border-hard)",
+          boxShadow: "var(--shadow-brutal-sm)",
+        }}
+        aria-label="Previous page"
+      >
+        <ChevronLeft size={16} />
+      </button>
+
+      {/* Page numbers */}
+      {pages.map((page, idx) =>
+        page === "..." ? (
+          <span
+            key={`ellipsis-${idx}`}
+            className="flex items-center justify-center w-10 h-10 text-sm font-extrabold text-[var(--text-muted)] select-none"
+          >
+            ...
+          </span>
+        ) : (
+          <button
+            key={page}
+            onClick={() => onPageChange(page)}
+            className={`${btnBase} text-sm`}
+            style={{
+              backgroundColor: currentPage === page ? "var(--accent)" : "var(--bg-surface)",
+              color: currentPage === page ? "#FFFFFF" : "var(--foreground)",
+              border: "2px solid var(--border-hard)",
+              boxShadow: currentPage === page ? "none" : "var(--shadow-brutal-sm)",
+            }}
+            aria-label={`Page ${page}`}
+            aria-current={currentPage === page ? "page" : undefined}
+          >
+            {page}
+          </button>
+        )
+      )}
+
+      {/* Next page */}
+      <button
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={currentPage === totalPages}
+        className={`${btnBase} disabled:opacity-30 disabled:cursor-not-allowed`}
+        style={{
+          backgroundColor: "var(--bg-surface)",
+          border: "2px solid var(--border-hard)",
+          boxShadow: "var(--shadow-brutal-sm)",
+        }}
+        aria-label="Next page"
+      >
+        <ChevronRight size={16} />
+      </button>
+
+      {/* Last page */}
+      <button
+        onClick={() => onPageChange(totalPages)}
+        disabled={currentPage === totalPages}
+        className={`${btnBase} disabled:opacity-30 disabled:cursor-not-allowed`}
+        style={{
+          backgroundColor: "var(--bg-surface)",
+          border: "2px solid var(--border-hard)",
+          boxShadow: "var(--shadow-brutal-sm)",
+        }}
+        aria-label="Last page"
+      >
+        <ChevronsRight size={16} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from "lucide-react";
 
 interface PaginationProps {
@@ -45,12 +46,23 @@ const btnBase =
   "flex items-center justify-center w-10 h-10 font-extrabold uppercase transition-all";
 
 export function Pagination({ currentPage, totalPages, onPageChange }: PaginationProps) {
+  const [jumpValue, setJumpValue] = useState("");
+
   if (totalPages <= 1) return null;
 
   const pages = getPageNumbers(currentPage, totalPages);
 
+  const handleJump = () => {
+    const page = parseInt(jumpValue, 10);
+    if (!isNaN(page) && page >= 1 && page <= totalPages) {
+      onPageChange(page);
+      setJumpValue("");
+    }
+  };
+
   return (
-    <div className="flex items-center justify-center gap-2 mt-4">
+    <div className="flex flex-col items-center gap-3 mt-4">
+    <div className="flex items-center justify-center gap-2">
       {/* First page */}
       <button
         onClick={() => onPageChange(1)}
@@ -138,6 +150,38 @@ export function Pagination({ currentPage, totalPages, onPageChange }: Pagination
       >
         <ChevronsRight size={16} />
       </button>
+    </div>
+
+    {/* Go to page */}
+    {totalPages > 7 && (
+      <form
+        onSubmit={(e) => { e.preventDefault(); handleJump(); }}
+        className="flex items-center gap-2"
+      >
+        <label className="text-xs font-bold uppercase tracking-wide text-[var(--text-muted)]">
+          Go to page
+        </label>
+        <input
+          type="number"
+          min={1}
+          max={totalPages}
+          value={jumpValue}
+          onChange={(e) => setJumpValue(e.target.value)}
+          placeholder={`1–${totalPages}`}
+          className="input-brutal w-24 text-center text-sm"
+        />
+        <button
+          type="submit"
+          className="px-3 py-2 text-xs font-extrabold uppercase tracking-wide text-white transition-colors hover:bg-[#E03300]"
+          style={{
+            backgroundColor: "var(--accent)",
+            border: "2px solid var(--border-hard)",
+          }}
+        >
+          Go
+        </button>
+      </form>
+    )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Extracted duplicated inline pagination into a shared `<Pagination />` component
- Shows first page, last page, and 1 page on each side of current — with `...` ellipsis gaps
- Added first/last page jump buttons (`<<` / `>>`) so users can skip to the end instantly
- Works for any number of pages (7 or fewer pages still show all numbers, no ellipsis)

## Before
Every page number rendered as a button — unusable at scale:
`< 1 2 3 4 5 6 7 8 9 10 11 ... 100 >`

## After
Smart truncation with jump buttons:
`<< < 1 ... 4 [5] 6 ... 100 > >>`

## Test plan
- [ ] Leaderboard page with many users — verify ellipsis appears correctly
- [ ] Explore page — same behavior
- [ ] Test edge cases: page 1, page 2, second-to-last, last page
- [ ] Verify first/last jump buttons work
- [ ] 7 or fewer pages should show all numbers without ellipsis

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized pagination controls across explore and leaderboard sections for improved consistency and user experience throughout the application. Pagination now features dedicated navigation buttons for first, previous, next, and last pages, along with numbered page selection options and enhanced visual feedback to indicate the currently active page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->