### PR TITLE
fix: live activity header — white text + green blinking dot

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -269,6 +269,21 @@ html {
   100% { background-position: 200% 0; }
 }
 
+@keyframes blink {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.3; transform: scale(0.85); }
+}
+
+.live-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  background-color: #22c55e;
+  border-radius: 50%;
+  animation: blink 1.5s ease-in-out infinite;
+  box-shadow: 0 0 6px #22c55e;
+}
+
 .animate-fade-in-up {
   animation: fadeInUp 0.25s ease-out both;
 }

--- a/src/components/ui/live-activity-feed.tsx
+++ b/src/components/ui/live-activity-feed.tsx
@@ -87,6 +87,7 @@ export function LiveActivityFeed() {
   );
   if (grouped.length === 0) return null;
 
+  // v2: white text + green blinking dot
   return (
     <section className="mx-auto max-w-7xl px-4 sm:px-6 py-12">
       <article style={{
@@ -101,7 +102,7 @@ export function LiveActivityFeed() {
       }}>
         <header style={{
           backgroundColor: "var(--accent, #ff4400)",
-          color: "#000",
+          color: "#fff",
           padding: "1rem 1.25rem",
           display: "flex",
           justifyContent: "space-between",
@@ -118,7 +119,7 @@ export function LiveActivityFeed() {
             gap: 8,
             fontFamily: "var(--font-space-grotesk, 'Space Grotesk', sans-serif)",
           }}>
-            <div style={{ width: 8, height: 8, backgroundColor: "#000", borderRadius: "50%", animation: "pulse 2s infinite" }} />
+            <span aria-hidden="true" className="live-dot" />
             Live Activity
           </div>
           <Link href="/feed" style={{
@@ -193,7 +194,7 @@ export function LiveActivityFeed() {
           })}
         </div>
       </article>
-      <style>{`@keyframes pulse { 0% { transform: scale(0.95); opacity: 1; } 50% { transform: scale(1.2); opacity: 0.5; } 100% { transform: scale(0.95); opacity: 1; } }`}</style>
+      {/* blink keyframe defined in globals.css */}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- White text on the orange Live Activity header for better readability
- Green blinking dot (#22c55e) replacing the black static dot
- CSS class `.live-dot` with `blink` keyframe in globals.css

## Test plan
- [ ] Check homepage — Live Activity header should have white text and a green blinking dot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Live Activity Feed header styling with enhanced text contrast for improved visibility.
  * Added an animated live indicator with a blinking effect and green glow to provide clearer visual feedback about active updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->