### PR TITLE
fix: ensure new users get baseline vibe score on signup

### DIFF
--- a/src/app/auth/profile-setup/page.tsx
+++ b/src/app/auth/profile-setup/page.tsx
@@ -220,6 +220,9 @@ export default function ProfileSetupPage() {
       );
 
       if (dbError) throw dbError;
+      // Ensure baseline vibe score is set for new users
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (supabase as any).rpc("update_user_streak", { p_user_id: userId }).catch(() => {});
       setStep(2);
     } catch (err: unknown) {
       const message =

--- a/supabase/migrations/20260413_vibe_score_on_user_create.sql
+++ b/supabase/migrations/20260413_vibe_score_on_user_create.sql
@@ -1,0 +1,16 @@
+-- Trigger: set baseline vibe score when a new user row is created.
+-- Without this, users created after the last backfill migration
+-- could sit at vibe_score=0 until their first project/streak/endorsement.
+
+CREATE OR REPLACE FUNCTION trigger_init_vibe_score()
+RETURNS TRIGGER AS $$
+BEGIN
+  PERFORM update_user_streak(NEW.id);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER on_user_create
+  AFTER INSERT ON users
+  FOR EACH ROW
+  EXECUTE FUNCTION trigger_init_vibe_score();


### PR DESCRIPTION
## Summary
- Add `on_user_create` database trigger so new users get their baseline vibe score (10) immediately on signup
- Add RPC safety net in profile-setup that explicitly calls `update_user_streak` after profile creation
- Migration SQL already run in production

## Context
Users who signed up after the last backfill migration had vibe_score=0 because no trigger fired on user creation. The existing triggers (project, endorsement, streak, review) all work — this was the only missing one.

## Test plan
- [ ] New user signs up → vibe_score starts at 10 (not 0)
- [ ] Adding a project still updates score via on_project_change trigger
- [ ] Endorsement still updates score via on_endorsement_change trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)