### PR TITLE
fix: detect Phantom/Backpack when connecting Solana wallet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@privy-io/react-auth": "^3.18.0",
+        "@solana-program/memo": "^0.11.0",
+        "@solana-program/system": "^0.12.0",
+        "@solana-program/token": "^0.13.0",
+        "@solana/kit": "^6.8.0",
         "@solana/spl-token": "^0.4.14",
         "@solana/web3.js": "^1.98.4",
         "@supabase/ssr": "^0.9.0",
@@ -466,6 +470,279 @@
         "uncrypto": "^0.1.3",
         "viem": "^2.47.0",
         "zod": "^3.25.76"
+      }
+    },
+    "node_modules/@coinbase/cdp-sdk/node_modules/@solana-program/system": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/system/-/system-0.10.0.tgz",
+      "integrity": "sha512-Go+LOEZmqmNlfr+Gjy5ZWAdY5HbYzk2RBewD9QinEU/bBSzpFfzqDRT55JjFRBGJUvMgf3C2vfXEGT4i8DSI4g==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^5.0"
+      }
+    },
+    "node_modules/@coinbase/cdp-sdk/node_modules/@solana-program/token": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.9.0.tgz",
+      "integrity": "sha512-vnZxndd4ED4Fc56sw93cWZ2djEeeOFxtaPS8SPf5+a+JZjKA/EnKqzbE1y04FuMhIVrLERQ8uR8H2h72eZzlsA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^5.0"
+      }
+    },
+    "node_modules/@coinbase/cdp-sdk/node_modules/@solana/accounts": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-5.5.1.tgz",
+      "integrity": "sha512-TfOY9xixg5rizABuLVuZ9XI2x2tmWUC/OoN556xwfDlhBHBjKfszicYYOyD6nbFmwTGYarCmyGIdteXxTXIdhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@coinbase/cdp-sdk/node_modules/@solana/codecs": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-5.5.1.tgz",
+      "integrity": "sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/options": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@coinbase/cdp-sdk/node_modules/@solana/instruction-plans": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-5.5.1.tgz",
+      "integrity": "sha512-7z3CB7YMcFKuVvgcnNY8bY6IsZ8LG61Iytbz7HpNVGX2u1RthOs1tRW8luTzSG1MPL0Ox7afyAVMYeFqSPHnaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@coinbase/cdp-sdk/node_modules/@solana/kit": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-5.5.1.tgz",
+      "integrity": "sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "5.5.1",
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/instruction-plans": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/offchain-messages": "5.5.1",
+        "@solana/plugin-core": "5.5.1",
+        "@solana/programs": "5.5.1",
+        "@solana/rpc": "5.5.1",
+        "@solana/rpc-api": "5.5.1",
+        "@solana/rpc-parsed-types": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-subscriptions": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/signers": "5.5.1",
+        "@solana/sysvars": "5.5.1",
+        "@solana/transaction-confirmation": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@coinbase/cdp-sdk/node_modules/@solana/offchain-messages": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-5.5.1.tgz",
+      "integrity": "sha512-g+xHH95prTU+KujtbOzj8wn+C7ZNoiLhf3hj6nYq3MTyxOXtBEysguc97jJveUZG0K97aIKG6xVUlMutg5yxhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/nominal-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@coinbase/cdp-sdk/node_modules/@solana/options": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-5.5.1.tgz",
+      "integrity": "sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@coinbase/cdp-sdk/node_modules/@solana/plugin-core": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-5.5.1.tgz",
+      "integrity": "sha512-VUZl30lDQFJeiSyNfzU1EjYt2QZvoBFKEwjn1lilUJw7KgqD5z7mbV7diJhT+dLFs36i0OsjXvq5kSygn8YJ3A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@coinbase/cdp-sdk/node_modules/@solana/programs": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-5.5.1.tgz",
+      "integrity": "sha512-7U9kn0Jsx1NuBLn5HRTFYh78MV4XN145Yc3WP/q5BlqAVNlMoU9coG5IUTJIG847TUqC1lRto3Dnpwm6T4YRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@coinbase/cdp-sdk/node_modules/@solana/signers": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-5.5.1.tgz",
+      "integrity": "sha512-FY0IVaBT2kCAze55vEieR6hag4coqcuJ31Aw3hqRH7mv6sV8oqwuJmUrx+uFwOp1gwd5OEAzlv6N4hOOple4sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/offchain-messages": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@coinbase/cdp-sdk/node_modules/@solana/sysvars": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-5.5.1.tgz",
+      "integrity": "sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "5.5.1",
+        "@solana/codecs": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@coinbase/cdp-sdk/node_modules/abitype": {
@@ -4659,22 +4936,34 @@
         "@solana/kit": "^5.0"
       }
     },
-    "node_modules/@solana-program/system": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@solana-program/system/-/system-0.10.0.tgz",
-      "integrity": "sha512-Go+LOEZmqmNlfr+Gjy5ZWAdY5HbYzk2RBewD9QinEU/bBSzpFfzqDRT55JjFRBGJUvMgf3C2vfXEGT4i8DSI4g==",
+    "node_modules/@solana-program/memo": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/memo/-/memo-0.11.0.tgz",
+      "integrity": "sha512-/WVM2y76hL5zWJJwaHsbvMREeIUzhKDHU+ftMXTf4aLPJFDKG6am4X5RID3CHsI3oYNEMywgVvsFdnorwgEuwA==",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@solana/kit": "^5.0"
+        "@solana/kit": "^6.0.0"
+      }
+    },
+    "node_modules/@solana-program/system": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/system/-/system-0.12.0.tgz",
+      "integrity": "sha512-ZnAAWeGVMWNtJhw3GdifI2HnhZ0A0H0qs8tBkcFvxp/8wIavvO+GOM4Jd0N22u2+Lni2zcwvcrxrsxj6Mjphng==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^6.1.0"
       }
     },
     "node_modules/@solana-program/token": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.9.0.tgz",
-      "integrity": "sha512-vnZxndd4ED4Fc56sw93cWZ2djEeeOFxtaPS8SPf5+a+JZjKA/EnKqzbE1y04FuMhIVrLERQ8uR8H2h72eZzlsA==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.13.0.tgz",
+      "integrity": "sha512-/Apjrd5lwOJGrPB0J5Rv7EBeclvyEBQPAGA85Scm7wBH+GpkbdLDM9uK3TNg8jjFKyWQYai/JtPHbrx7VgFLSg==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@solana-program/system": "^0.12.0"
+      },
       "peerDependencies": {
-        "@solana/kit": "^5.0"
+        "@solana/kit": "^6.5.0"
       }
     },
     "node_modules/@solana-program/token-2022": {
@@ -4688,28 +4977,264 @@
       }
     },
     "node_modules/@solana/accounts": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-5.5.1.tgz",
-      "integrity": "sha512-TfOY9xixg5rizABuLVuZ9XI2x2tmWUC/OoN556xwfDlhBHBjKfszicYYOyD6nbFmwTGYarCmyGIdteXxTXIdhQ==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-6.8.0.tgz",
+      "integrity": "sha512-rXjFYVopaEw1H2PTBQbRjKr+0i4EFuBEhRT5E0dI4cMaabSb4KKypC2gaf47+6cjU3hMlM1AcsyIs72/MqAVBw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "5.5.1",
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-strings": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/rpc-spec": "5.5.1",
-        "@solana/rpc-types": "5.5.1"
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/rpc-spec": "6.8.0",
+        "@solana/rpc-types": "6.8.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/@solana/addresses": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.8.0.tgz",
+      "integrity": "sha512-xVlA0DNX1LVfTueVsbhxDDoqr1VxeXvgJEh2GcIN/vcJPhY3GE3AYtjTbJJmTDgPrzOccI0t6ElVb1gelJH/PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/nominal-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/@solana/assertions": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.8.0.tgz",
+      "integrity": "sha512-OU6prCq39fSvGL8xY1C/9vhghasvAkMiRlituzJxzJpZRfpVRrwhzLd6P5NPAPoQ28qKcenA50kFdw9+ZyneJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/@solana/codecs-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
+      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/@solana/codecs-numbers": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.8.0.tgz",
+      "integrity": "sha512-ebf4f1D19EAe0uhdUYOCEYnn5+EellsBxbJ42tM2yYEoIBVz5FoBBC0gSsq+UTNbQHFa7XagyBT3LewxXttiTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/@solana/codecs-strings": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.8.0.tgz",
+      "integrity": "sha512-Rpk5NVhbKYcPnE7wz3IpTp0GVNVs0IYKdmyzByiimgPTiII8eb8ay4wQiYHGHrpYh62hD14Qy3GiGDFgipRKqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/@solana/nominal-types": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.8.0.tgz",
+      "integrity": "sha512-mLmHr92pM4mEfe49GUmZ5Ry0RMqtMuFQqZYnxQqhDKMcl+Wtt820ezxYgwPhqcMxRzfqaQSO3ZxpSB0RlLBa/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/@solana/rpc-spec": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-6.8.0.tgz",
+      "integrity": "sha512-kE5uOspxCVFJKNUu73hlebGiAFosjfYXbbTXAbGKfksPzy84u1oJFC2IVIobLRnqUCw1x7oJcvfnX00Zs0Itpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0",
+        "@solana/rpc-spec-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/@solana/rpc-spec-types": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-6.8.0.tgz",
+      "integrity": "sha512-ebCWgiQbIgFOehU7PdRFmYCzda3Azc/qa2Y3P8gexSHSsDAO27VwS4E05XSY+a7cIL5MYmvUa1vpDynl1Rkakw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/@solana/rpc-types": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.8.0.tgz",
+      "integrity": "sha512-vACMV9VR2JsZGDcgaMOFN/dwLK57CsE+erassxxtF12sSPXJooz+Vu1vyY2Yp2EkCc7mDf7BNkTKvSXajbt+Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/nominal-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@solana/addresses": {
@@ -4784,22 +5309,22 @@
       }
     },
     "node_modules/@solana/codecs": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-5.5.1.tgz",
-      "integrity": "sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-6.8.0.tgz",
+      "integrity": "sha512-qCSAaw1qszeQflavkIM7c21qJ3BHReP/qgDelZbhsEXpZc852CCZM00FOIWuxePr6X+JjSNqJquxwdDSoZe7Bw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-data-structures": "5.5.1",
-        "@solana/codecs-numbers": "5.5.1",
-        "@solana/codecs-strings": "5.5.1",
-        "@solana/options": "5.5.1"
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-data-structures": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/options": "6.8.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -4896,6 +5421,140 @@
         }
       }
     },
+    "node_modules/@solana/codecs/node_modules/@solana/codecs-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
+      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs/node_modules/@solana/codecs-data-structures": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.8.0.tgz",
+      "integrity": "sha512-lHr0F+nNwgm9c+tWQX398yzYh1qDi7QSCJpY9MQ2azW4FfY2IyPSo7bqzTaWNnJh9pmJx3ZI6jHfXBnLD5k/SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs/node_modules/@solana/codecs-numbers": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.8.0.tgz",
+      "integrity": "sha512-ebf4f1D19EAe0uhdUYOCEYnn5+EellsBxbJ42tM2yYEoIBVz5FoBBC0gSsq+UTNbQHFa7XagyBT3LewxXttiTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs/node_modules/@solana/codecs-strings": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.8.0.tgz",
+      "integrity": "sha512-Rpk5NVhbKYcPnE7wz3IpTp0GVNVs0IYKdmyzByiimgPTiII8eb8ay4wQiYHGHrpYh62hD14Qy3GiGDFgipRKqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/codecs/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@solana/errors": {
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-5.5.1.tgz",
@@ -4967,28 +5626,387 @@
       }
     },
     "node_modules/@solana/instruction-plans": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-5.5.1.tgz",
-      "integrity": "sha512-7z3CB7YMcFKuVvgcnNY8bY6IsZ8LG61Iytbz7HpNVGX2u1RthOs1tRW8luTzSG1MPL0Ox7afyAVMYeFqSPHnaQ==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-6.8.0.tgz",
+      "integrity": "sha512-osAsY8ozqohrcTcHlG1EmO3i9flc0eESMIy9akTHyVvqk915gZgkaTmt4IjcYSwBGt7i+Rh8TmLj27RrTpCKvg==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "5.5.1",
-        "@solana/instructions": "5.5.1",
-        "@solana/keys": "5.5.1",
-        "@solana/promises": "5.5.1",
-        "@solana/transaction-messages": "5.5.1",
-        "@solana/transactions": "5.5.1"
+        "@solana/errors": "6.8.0",
+        "@solana/instructions": "6.8.0",
+        "@solana/keys": "6.8.0",
+        "@solana/promises": "6.8.0",
+        "@solana/transaction-messages": "6.8.0",
+        "@solana/transactions": "6.8.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/addresses": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.8.0.tgz",
+      "integrity": "sha512-xVlA0DNX1LVfTueVsbhxDDoqr1VxeXvgJEh2GcIN/vcJPhY3GE3AYtjTbJJmTDgPrzOccI0t6ElVb1gelJH/PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/nominal-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/assertions": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.8.0.tgz",
+      "integrity": "sha512-OU6prCq39fSvGL8xY1C/9vhghasvAkMiRlituzJxzJpZRfpVRrwhzLd6P5NPAPoQ28qKcenA50kFdw9+ZyneJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/codecs-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
+      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/codecs-data-structures": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.8.0.tgz",
+      "integrity": "sha512-lHr0F+nNwgm9c+tWQX398yzYh1qDi7QSCJpY9MQ2azW4FfY2IyPSo7bqzTaWNnJh9pmJx3ZI6jHfXBnLD5k/SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/codecs-numbers": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.8.0.tgz",
+      "integrity": "sha512-ebf4f1D19EAe0uhdUYOCEYnn5+EellsBxbJ42tM2yYEoIBVz5FoBBC0gSsq+UTNbQHFa7XagyBT3LewxXttiTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/codecs-strings": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.8.0.tgz",
+      "integrity": "sha512-Rpk5NVhbKYcPnE7wz3IpTp0GVNVs0IYKdmyzByiimgPTiII8eb8ay4wQiYHGHrpYh62hD14Qy3GiGDFgipRKqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/functional": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-6.8.0.tgz",
+      "integrity": "sha512-oMSAD/8w9ujx7OplvwRWwHHFnaaxi/Xrji1XH3xAB+gzxupUpBbOmgxQ+e84x+9VN8QWk5aU3L7gmCqdTAR6OA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/instructions": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-6.8.0.tgz",
+      "integrity": "sha512-dTtykhS9IeN3npCfnd7wSS6KmKAh54+g90JRtLYy5/31L2Zvunf3AJz2QUk58vgsAGZ5fuoiMyhCxRJm4rHUBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/keys": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-6.8.0.tgz",
+      "integrity": "sha512-Wo8CnbrVfCP1Jbsb3ElMej/3dmMrl4ArPhI1mDcqIIz/O4j4HmxZYbn2BCWtnV9V/LPM638EMO2r1x6GzDNrPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/nominal-types": "6.8.0",
+        "@solana/promises": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/nominal-types": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.8.0.tgz",
+      "integrity": "sha512-mLmHr92pM4mEfe49GUmZ5Ry0RMqtMuFQqZYnxQqhDKMcl+Wtt820ezxYgwPhqcMxRzfqaQSO3ZxpSB0RlLBa/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/promises": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-6.8.0.tgz",
+      "integrity": "sha512-kIypZG83ZbADbrAq9/LS7LuWlVxlgJSzIpic75+9IuAfC3k5/KSus8LrvggBkCzfAyIslrUh70iz4JcnzUZrOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/rpc-types": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.8.0.tgz",
+      "integrity": "sha512-vACMV9VR2JsZGDcgaMOFN/dwLK57CsE+erassxxtF12sSPXJooz+Vu1vyY2Yp2EkCc7mDf7BNkTKvSXajbt+Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/nominal-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/transaction-messages": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-6.8.0.tgz",
+      "integrity": "sha512-jsJu9mAcN1x7onKOeC4WEvYP04UVcnkOYu/9bMe+S9jqjL+3DMy9kFZpV5FBl+TPuTNJrtOqc6Gc28hUWyyp1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-data-structures": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/functional": "6.8.0",
+        "@solana/instructions": "6.8.0",
+        "@solana/nominal-types": "6.8.0",
+        "@solana/rpc-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/transactions": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-6.8.0.tgz",
+      "integrity": "sha512-Q46m+o3C1yL2EIZBAP5B8ou2VZwHN9wTi+muIS6/giCKO3jwUtnTEbWcZEDMj2vxUb7P2WfwTluZb/VAWxlx7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-data-structures": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/functional": "6.8.0",
+        "@solana/instructions": "6.8.0",
+        "@solana/keys": "6.8.0",
+        "@solana/nominal-types": "6.8.0",
+        "@solana/rpc-types": "6.8.0",
+        "@solana/transaction-messages": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@solana/instructions": {
@@ -5037,45 +6055,742 @@
       }
     },
     "node_modules/@solana/kit": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-5.5.1.tgz",
-      "integrity": "sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-6.8.0.tgz",
+      "integrity": "sha512-+McC1aCgcUBdM7Cd7U6k2ZHJ9OKCy5mzpb0XWrhkrgsFxT0QoRr0AcWJc85o6tIDfG6Jz7vVhbS3l8ugYz2Vzw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/accounts": "5.5.1",
-        "@solana/addresses": "5.5.1",
-        "@solana/codecs": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/functional": "5.5.1",
-        "@solana/instruction-plans": "5.5.1",
-        "@solana/instructions": "5.5.1",
-        "@solana/keys": "5.5.1",
-        "@solana/offchain-messages": "5.5.1",
-        "@solana/plugin-core": "5.5.1",
-        "@solana/programs": "5.5.1",
-        "@solana/rpc": "5.5.1",
-        "@solana/rpc-api": "5.5.1",
-        "@solana/rpc-parsed-types": "5.5.1",
-        "@solana/rpc-spec-types": "5.5.1",
-        "@solana/rpc-subscriptions": "5.5.1",
-        "@solana/rpc-types": "5.5.1",
-        "@solana/signers": "5.5.1",
-        "@solana/sysvars": "5.5.1",
-        "@solana/transaction-confirmation": "5.5.1",
-        "@solana/transaction-messages": "5.5.1",
-        "@solana/transactions": "5.5.1"
+        "@solana/accounts": "6.8.0",
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/functional": "6.8.0",
+        "@solana/instruction-plans": "6.8.0",
+        "@solana/instructions": "6.8.0",
+        "@solana/keys": "6.8.0",
+        "@solana/offchain-messages": "6.8.0",
+        "@solana/plugin-core": "6.8.0",
+        "@solana/plugin-interfaces": "6.8.0",
+        "@solana/program-client-core": "6.8.0",
+        "@solana/programs": "6.8.0",
+        "@solana/rpc": "6.8.0",
+        "@solana/rpc-api": "6.8.0",
+        "@solana/rpc-parsed-types": "6.8.0",
+        "@solana/rpc-spec-types": "6.8.0",
+        "@solana/rpc-subscriptions": "6.8.0",
+        "@solana/rpc-types": "6.8.0",
+        "@solana/signers": "6.8.0",
+        "@solana/subscribable": "6.8.0",
+        "@solana/sysvars": "6.8.0",
+        "@solana/transaction-confirmation": "6.8.0",
+        "@solana/transaction-messages": "6.8.0",
+        "@solana/transactions": "6.8.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
       }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/addresses": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.8.0.tgz",
+      "integrity": "sha512-xVlA0DNX1LVfTueVsbhxDDoqr1VxeXvgJEh2GcIN/vcJPhY3GE3AYtjTbJJmTDgPrzOccI0t6ElVb1gelJH/PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/nominal-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/assertions": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.8.0.tgz",
+      "integrity": "sha512-OU6prCq39fSvGL8xY1C/9vhghasvAkMiRlituzJxzJpZRfpVRrwhzLd6P5NPAPoQ28qKcenA50kFdw9+ZyneJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/codecs-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
+      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/codecs-data-structures": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.8.0.tgz",
+      "integrity": "sha512-lHr0F+nNwgm9c+tWQX398yzYh1qDi7QSCJpY9MQ2azW4FfY2IyPSo7bqzTaWNnJh9pmJx3ZI6jHfXBnLD5k/SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/codecs-numbers": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.8.0.tgz",
+      "integrity": "sha512-ebf4f1D19EAe0uhdUYOCEYnn5+EellsBxbJ42tM2yYEoIBVz5FoBBC0gSsq+UTNbQHFa7XagyBT3LewxXttiTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/codecs-strings": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.8.0.tgz",
+      "integrity": "sha512-Rpk5NVhbKYcPnE7wz3IpTp0GVNVs0IYKdmyzByiimgPTiII8eb8ay4wQiYHGHrpYh62hD14Qy3GiGDFgipRKqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/fast-stable-stringify": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-6.8.0.tgz",
+      "integrity": "sha512-lZa3Qnsn+9ew6rHTXkPc+uqSa3i+AWqSBhV6oYxxBc+smvuxovItU4TPIs30cTfA7lAP+j+oYAQtUDu2dLy0hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/functional": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-6.8.0.tgz",
+      "integrity": "sha512-oMSAD/8w9ujx7OplvwRWwHHFnaaxi/Xrji1XH3xAB+gzxupUpBbOmgxQ+e84x+9VN8QWk5aU3L7gmCqdTAR6OA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/instructions": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-6.8.0.tgz",
+      "integrity": "sha512-dTtykhS9IeN3npCfnd7wSS6KmKAh54+g90JRtLYy5/31L2Zvunf3AJz2QUk58vgsAGZ5fuoiMyhCxRJm4rHUBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/keys": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-6.8.0.tgz",
+      "integrity": "sha512-Wo8CnbrVfCP1Jbsb3ElMej/3dmMrl4ArPhI1mDcqIIz/O4j4HmxZYbn2BCWtnV9V/LPM638EMO2r1x6GzDNrPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/nominal-types": "6.8.0",
+        "@solana/promises": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/nominal-types": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.8.0.tgz",
+      "integrity": "sha512-mLmHr92pM4mEfe49GUmZ5Ry0RMqtMuFQqZYnxQqhDKMcl+Wtt820ezxYgwPhqcMxRzfqaQSO3ZxpSB0RlLBa/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/promises": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-6.8.0.tgz",
+      "integrity": "sha512-kIypZG83ZbADbrAq9/LS7LuWlVxlgJSzIpic75+9IuAfC3k5/KSus8LrvggBkCzfAyIslrUh70iz4JcnzUZrOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/rpc": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-6.8.0.tgz",
+      "integrity": "sha512-+jW4n9TDmBttY3bO3PdUo54GAnwFrd7UJsyfXoMgl/lWGQq5uddYDgnzQLtHOBP5zKslkR8h0RKkic0GZhMZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0",
+        "@solana/fast-stable-stringify": "6.8.0",
+        "@solana/functional": "6.8.0",
+        "@solana/rpc-api": "6.8.0",
+        "@solana/rpc-spec": "6.8.0",
+        "@solana/rpc-spec-types": "6.8.0",
+        "@solana/rpc-transformers": "6.8.0",
+        "@solana/rpc-transport-http": "6.8.0",
+        "@solana/rpc-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/rpc-api": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-6.8.0.tgz",
+      "integrity": "sha512-v8ZKWgPtKbF6HeJcfC4ciwI8mwDCizBtRLYYjjHOu+9S9IJYyefQzsQxL5P8OjJPpI4gFauT6gsjQLo76BoojA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/keys": "6.8.0",
+        "@solana/rpc-parsed-types": "6.8.0",
+        "@solana/rpc-spec": "6.8.0",
+        "@solana/rpc-transformers": "6.8.0",
+        "@solana/rpc-types": "6.8.0",
+        "@solana/transaction-messages": "6.8.0",
+        "@solana/transactions": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/rpc-parsed-types": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-6.8.0.tgz",
+      "integrity": "sha512-jYddZviBSUYbuUKqvNthet7KbJVI7me6xfRH2znv1SjIpmvhSPJcGN5QrlHVOasHdzEWSpvZa5VYDfnqH3aYvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/rpc-spec": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-6.8.0.tgz",
+      "integrity": "sha512-kE5uOspxCVFJKNUu73hlebGiAFosjfYXbbTXAbGKfksPzy84u1oJFC2IVIobLRnqUCw1x7oJcvfnX00Zs0Itpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0",
+        "@solana/rpc-spec-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/rpc-spec-types": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-6.8.0.tgz",
+      "integrity": "sha512-ebCWgiQbIgFOehU7PdRFmYCzda3Azc/qa2Y3P8gexSHSsDAO27VwS4E05XSY+a7cIL5MYmvUa1vpDynl1Rkakw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/rpc-subscriptions": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-6.8.0.tgz",
+      "integrity": "sha512-9CotreNZmKAP2z07FY1I7TPPvylKLFF5p4mujB5ZFMHQPp5JVQFVCmMIhSj5voZHAeYx7jdwJ2Kf0RDeClqJzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0",
+        "@solana/fast-stable-stringify": "6.8.0",
+        "@solana/functional": "6.8.0",
+        "@solana/promises": "6.8.0",
+        "@solana/rpc-spec-types": "6.8.0",
+        "@solana/rpc-subscriptions-api": "6.8.0",
+        "@solana/rpc-subscriptions-channel-websocket": "6.8.0",
+        "@solana/rpc-subscriptions-spec": "6.8.0",
+        "@solana/rpc-transformers": "6.8.0",
+        "@solana/rpc-types": "6.8.0",
+        "@solana/subscribable": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/rpc-subscriptions-api": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-6.8.0.tgz",
+      "integrity": "sha512-cPJOsydyoqkztW3msEH09wPDYqxJcMvO6DBlvrboq6wGu1UjeP66w2eApzQ8POoQHxhyw+CfEXl1Gbu6kKwuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/keys": "6.8.0",
+        "@solana/rpc-subscriptions-spec": "6.8.0",
+        "@solana/rpc-transformers": "6.8.0",
+        "@solana/rpc-types": "6.8.0",
+        "@solana/transaction-messages": "6.8.0",
+        "@solana/transactions": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/rpc-subscriptions-channel-websocket": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-6.8.0.tgz",
+      "integrity": "sha512-c3PpkorYwhAz1iuUfM5sLpZQi8xtZFGbaPbaPRELVeDjFSRzoa12KFnuQs4i9fbVbLy5Cnt1t23tf0bL2snZCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0",
+        "@solana/functional": "6.8.0",
+        "@solana/rpc-subscriptions-spec": "6.8.0",
+        "@solana/subscribable": "6.8.0",
+        "ws": "^8.19.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-6.8.0.tgz",
+      "integrity": "sha512-+t4L5q9qE6IVfunW3n1amA/3EswJr64pVqRF7234vCUuVUz4PgYfbqtEBV3KkA1o0NwEHHM3pXuofT63nBb8Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0",
+        "@solana/promises": "6.8.0",
+        "@solana/rpc-spec-types": "6.8.0",
+        "@solana/subscribable": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/rpc-transformers": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-6.8.0.tgz",
+      "integrity": "sha512-GzcFkllym7eXbw7grdE41MCb15CjkibrXtr7EFsf4d6LD9DRvzFj2ZRYywS2FB2ibVP0LUXXGk3vmtkZJjfajA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0",
+        "@solana/functional": "6.8.0",
+        "@solana/nominal-types": "6.8.0",
+        "@solana/rpc-spec-types": "6.8.0",
+        "@solana/rpc-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/rpc-transport-http": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-6.8.0.tgz",
+      "integrity": "sha512-jw/L0q2motGcx7yo6KvkKJd2HGVg9gvViXatFloLl1XmHbkwE7+97YYmG17WRuM5xauzI/UGYOXNW7cEB+Uaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0",
+        "@solana/rpc-spec": "6.8.0",
+        "@solana/rpc-spec-types": "6.8.0",
+        "undici-types": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/rpc-types": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.8.0.tgz",
+      "integrity": "sha512-vACMV9VR2JsZGDcgaMOFN/dwLK57CsE+erassxxtF12sSPXJooz+Vu1vyY2Yp2EkCc7mDf7BNkTKvSXajbt+Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/nominal-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/subscribable": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-6.8.0.tgz",
+      "integrity": "sha512-yj41Q97MiWrOmLj1iRFobvTdtU6H5wz5BlH5FHJg9lyapy1YQyaYF37MZx4LiUj4Ww0V3ReluIZTWWDBOJ53Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/transaction-confirmation": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-6.8.0.tgz",
+      "integrity": "sha512-R6rj8y/+kZqYJr8FR/fWxgi3Pw3eCiacUyjCPTVtdVe6i+hIiBApTGLzXrSRJmAMdpZrjYBZU1cG8C6oAb+B2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/keys": "6.8.0",
+        "@solana/promises": "6.8.0",
+        "@solana/rpc": "6.8.0",
+        "@solana/rpc-subscriptions": "6.8.0",
+        "@solana/rpc-types": "6.8.0",
+        "@solana/transaction-messages": "6.8.0",
+        "@solana/transactions": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/transaction-messages": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-6.8.0.tgz",
+      "integrity": "sha512-jsJu9mAcN1x7onKOeC4WEvYP04UVcnkOYu/9bMe+S9jqjL+3DMy9kFZpV5FBl+TPuTNJrtOqc6Gc28hUWyyp1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-data-structures": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/functional": "6.8.0",
+        "@solana/instructions": "6.8.0",
+        "@solana/nominal-types": "6.8.0",
+        "@solana/rpc-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/transactions": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-6.8.0.tgz",
+      "integrity": "sha512-Q46m+o3C1yL2EIZBAP5B8ou2VZwHN9wTi+muIS6/giCKO3jwUtnTEbWcZEDMj2vxUb7P2WfwTluZb/VAWxlx7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-data-structures": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/functional": "6.8.0",
+        "@solana/instructions": "6.8.0",
+        "@solana/keys": "6.8.0",
+        "@solana/nominal-types": "6.8.0",
+        "@solana/rpc-types": "6.8.0",
+        "@solana/transaction-messages": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/kit/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@solana/kit/node_modules/undici-types": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.1.0.tgz",
+      "integrity": "sha512-JlLXdMmH4kxyn2JPtGK/cajzKY7F15OKYG8sO5HfkIC1AC09sLUeptGFKjnMWnprDQ2EwzYDO3kgzkK3aaoHCA==",
+      "license": "MIT"
     },
     "node_modules/@solana/nominal-types": {
       "version": "5.5.1",
@@ -5095,66 +6810,437 @@
       }
     },
     "node_modules/@solana/offchain-messages": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-5.5.1.tgz",
-      "integrity": "sha512-g+xHH95prTU+KujtbOzj8wn+C7ZNoiLhf3hj6nYq3MTyxOXtBEysguc97jJveUZG0K97aIKG6xVUlMutg5yxhw==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-6.8.0.tgz",
+      "integrity": "sha512-HoniTs2uoCHGicD0dTTJ3YBhLZC9URxdXXUf0CHalLFwAidF9iNuB8dsuKk16Euu68L4/ERKKGfyC0QobBvahw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "5.5.1",
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-data-structures": "5.5.1",
-        "@solana/codecs-numbers": "5.5.1",
-        "@solana/codecs-strings": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/keys": "5.5.1",
-        "@solana/nominal-types": "5.5.1"
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-data-structures": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/keys": "6.8.0",
+        "@solana/nominal-types": "6.8.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/addresses": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.8.0.tgz",
+      "integrity": "sha512-xVlA0DNX1LVfTueVsbhxDDoqr1VxeXvgJEh2GcIN/vcJPhY3GE3AYtjTbJJmTDgPrzOccI0t6ElVb1gelJH/PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/nominal-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/assertions": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.8.0.tgz",
+      "integrity": "sha512-OU6prCq39fSvGL8xY1C/9vhghasvAkMiRlituzJxzJpZRfpVRrwhzLd6P5NPAPoQ28qKcenA50kFdw9+ZyneJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/codecs-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
+      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/codecs-data-structures": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.8.0.tgz",
+      "integrity": "sha512-lHr0F+nNwgm9c+tWQX398yzYh1qDi7QSCJpY9MQ2azW4FfY2IyPSo7bqzTaWNnJh9pmJx3ZI6jHfXBnLD5k/SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/codecs-numbers": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.8.0.tgz",
+      "integrity": "sha512-ebf4f1D19EAe0uhdUYOCEYnn5+EellsBxbJ42tM2yYEoIBVz5FoBBC0gSsq+UTNbQHFa7XagyBT3LewxXttiTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/codecs-strings": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.8.0.tgz",
+      "integrity": "sha512-Rpk5NVhbKYcPnE7wz3IpTp0GVNVs0IYKdmyzByiimgPTiII8eb8ay4wQiYHGHrpYh62hD14Qy3GiGDFgipRKqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/keys": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-6.8.0.tgz",
+      "integrity": "sha512-Wo8CnbrVfCP1Jbsb3ElMej/3dmMrl4ArPhI1mDcqIIz/O4j4HmxZYbn2BCWtnV9V/LPM638EMO2r1x6GzDNrPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/nominal-types": "6.8.0",
+        "@solana/promises": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/nominal-types": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.8.0.tgz",
+      "integrity": "sha512-mLmHr92pM4mEfe49GUmZ5Ry0RMqtMuFQqZYnxQqhDKMcl+Wtt820ezxYgwPhqcMxRzfqaQSO3ZxpSB0RlLBa/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/promises": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-6.8.0.tgz",
+      "integrity": "sha512-kIypZG83ZbADbrAq9/LS7LuWlVxlgJSzIpic75+9IuAfC3k5/KSus8LrvggBkCzfAyIslrUh70iz4JcnzUZrOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@solana/options": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/options/-/options-5.5.1.tgz",
-      "integrity": "sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-6.8.0.tgz",
+      "integrity": "sha512-T5441HHeucFaLtaMAJQJl79T7mX007oAFPunpPebBphRvCXGv+qQwQvqa4HkYct6Jf2O0aKLBL9GSe/kfdCk9A==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-data-structures": "5.5.1",
-        "@solana/codecs-numbers": "5.5.1",
-        "@solana/codecs-strings": "5.5.1",
-        "@solana/errors": "5.5.1"
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-data-structures": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/options/node_modules/@solana/codecs-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
+      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/options/node_modules/@solana/codecs-data-structures": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.8.0.tgz",
+      "integrity": "sha512-lHr0F+nNwgm9c+tWQX398yzYh1qDi7QSCJpY9MQ2azW4FfY2IyPSo7bqzTaWNnJh9pmJx3ZI6jHfXBnLD5k/SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/options/node_modules/@solana/codecs-numbers": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.8.0.tgz",
+      "integrity": "sha512-ebf4f1D19EAe0uhdUYOCEYnn5+EellsBxbJ42tM2yYEoIBVz5FoBBC0gSsq+UTNbQHFa7XagyBT3LewxXttiTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/options/node_modules/@solana/codecs-strings": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.8.0.tgz",
+      "integrity": "sha512-Rpk5NVhbKYcPnE7wz3IpTp0GVNVs0IYKdmyzByiimgPTiII8eb8ay4wQiYHGHrpYh62hD14Qy3GiGDFgipRKqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/options/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/options/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/options/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@solana/plugin-core": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-5.5.1.tgz",
-      "integrity": "sha512-VUZl30lDQFJeiSyNfzU1EjYt2QZvoBFKEwjn1lilUJw7KgqD5z7mbV7diJhT+dLFs36i0OsjXvq5kSygn8YJ3A==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-6.8.0.tgz",
+      "integrity": "sha512-kdqFIhQvJP2BDUsMOIbor35esj8u78SO33Xv0Wmo+uTRg6yKONKVK53ghw235pWrinOT4f0VnVe6MN6ciYiQVA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -5162,25 +7248,1041 @@
         }
       }
     },
-    "node_modules/@solana/programs": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-5.5.1.tgz",
-      "integrity": "sha512-7U9kn0Jsx1NuBLn5HRTFYh78MV4XN145Yc3WP/q5BlqAVNlMoU9coG5IUTJIG847TUqC1lRto3Dnpwm6T4YRpA==",
+    "node_modules/@solana/plugin-interfaces": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-interfaces/-/plugin-interfaces-6.8.0.tgz",
+      "integrity": "sha512-4olaMKGUVA7wG6BBWM5A31bQsUWBlfcL1pjhq6ZTqVEJ7vshHXGwHVlWYXYyYn9ixozGDpGSl553yaRY9jQwWw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "5.5.1",
-        "@solana/errors": "5.5.1"
+        "@solana/addresses": "6.8.0",
+        "@solana/instruction-plans": "6.8.0",
+        "@solana/keys": "6.8.0",
+        "@solana/rpc-spec": "6.8.0",
+        "@solana/rpc-subscriptions-spec": "6.8.0",
+        "@solana/rpc-types": "6.8.0",
+        "@solana/signers": "6.8.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/addresses": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.8.0.tgz",
+      "integrity": "sha512-xVlA0DNX1LVfTueVsbhxDDoqr1VxeXvgJEh2GcIN/vcJPhY3GE3AYtjTbJJmTDgPrzOccI0t6ElVb1gelJH/PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/nominal-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/assertions": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.8.0.tgz",
+      "integrity": "sha512-OU6prCq39fSvGL8xY1C/9vhghasvAkMiRlituzJxzJpZRfpVRrwhzLd6P5NPAPoQ28qKcenA50kFdw9+ZyneJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/codecs-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
+      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/codecs-numbers": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.8.0.tgz",
+      "integrity": "sha512-ebf4f1D19EAe0uhdUYOCEYnn5+EellsBxbJ42tM2yYEoIBVz5FoBBC0gSsq+UTNbQHFa7XagyBT3LewxXttiTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/codecs-strings": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.8.0.tgz",
+      "integrity": "sha512-Rpk5NVhbKYcPnE7wz3IpTp0GVNVs0IYKdmyzByiimgPTiII8eb8ay4wQiYHGHrpYh62hD14Qy3GiGDFgipRKqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/keys": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-6.8.0.tgz",
+      "integrity": "sha512-Wo8CnbrVfCP1Jbsb3ElMej/3dmMrl4ArPhI1mDcqIIz/O4j4HmxZYbn2BCWtnV9V/LPM638EMO2r1x6GzDNrPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/nominal-types": "6.8.0",
+        "@solana/promises": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/nominal-types": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.8.0.tgz",
+      "integrity": "sha512-mLmHr92pM4mEfe49GUmZ5Ry0RMqtMuFQqZYnxQqhDKMcl+Wtt820ezxYgwPhqcMxRzfqaQSO3ZxpSB0RlLBa/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/promises": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-6.8.0.tgz",
+      "integrity": "sha512-kIypZG83ZbADbrAq9/LS7LuWlVxlgJSzIpic75+9IuAfC3k5/KSus8LrvggBkCzfAyIslrUh70iz4JcnzUZrOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/rpc-spec": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-6.8.0.tgz",
+      "integrity": "sha512-kE5uOspxCVFJKNUu73hlebGiAFosjfYXbbTXAbGKfksPzy84u1oJFC2IVIobLRnqUCw1x7oJcvfnX00Zs0Itpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0",
+        "@solana/rpc-spec-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/rpc-spec-types": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-6.8.0.tgz",
+      "integrity": "sha512-ebCWgiQbIgFOehU7PdRFmYCzda3Azc/qa2Y3P8gexSHSsDAO27VwS4E05XSY+a7cIL5MYmvUa1vpDynl1Rkakw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-6.8.0.tgz",
+      "integrity": "sha512-+t4L5q9qE6IVfunW3n1amA/3EswJr64pVqRF7234vCUuVUz4PgYfbqtEBV3KkA1o0NwEHHM3pXuofT63nBb8Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0",
+        "@solana/promises": "6.8.0",
+        "@solana/rpc-spec-types": "6.8.0",
+        "@solana/subscribable": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/rpc-types": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.8.0.tgz",
+      "integrity": "sha512-vACMV9VR2JsZGDcgaMOFN/dwLK57CsE+erassxxtF12sSPXJooz+Vu1vyY2Yp2EkCc7mDf7BNkTKvSXajbt+Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/nominal-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/subscribable": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-6.8.0.tgz",
+      "integrity": "sha512-yj41Q97MiWrOmLj1iRFobvTdtU6H5wz5BlH5FHJg9lyapy1YQyaYF37MZx4LiUj4Ww0V3ReluIZTWWDBOJ53Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@solana/program-client-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/program-client-core/-/program-client-core-6.8.0.tgz",
+      "integrity": "sha512-eOZtEnwl+vdiy9x/rFF89NDtnvt+Q3H04A/0u4GoHnt+fFkQG3JS+ChWG9c77izmpmRuz5C1GptOPDGNDnIUgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "6.8.0",
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/instruction-plans": "6.8.0",
+        "@solana/instructions": "6.8.0",
+        "@solana/plugin-interfaces": "6.8.0",
+        "@solana/rpc-api": "6.8.0",
+        "@solana/signers": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/addresses": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.8.0.tgz",
+      "integrity": "sha512-xVlA0DNX1LVfTueVsbhxDDoqr1VxeXvgJEh2GcIN/vcJPhY3GE3AYtjTbJJmTDgPrzOccI0t6ElVb1gelJH/PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/nominal-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/assertions": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.8.0.tgz",
+      "integrity": "sha512-OU6prCq39fSvGL8xY1C/9vhghasvAkMiRlituzJxzJpZRfpVRrwhzLd6P5NPAPoQ28qKcenA50kFdw9+ZyneJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/codecs-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
+      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/codecs-data-structures": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.8.0.tgz",
+      "integrity": "sha512-lHr0F+nNwgm9c+tWQX398yzYh1qDi7QSCJpY9MQ2azW4FfY2IyPSo7bqzTaWNnJh9pmJx3ZI6jHfXBnLD5k/SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/codecs-numbers": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.8.0.tgz",
+      "integrity": "sha512-ebf4f1D19EAe0uhdUYOCEYnn5+EellsBxbJ42tM2yYEoIBVz5FoBBC0gSsq+UTNbQHFa7XagyBT3LewxXttiTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/codecs-strings": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.8.0.tgz",
+      "integrity": "sha512-Rpk5NVhbKYcPnE7wz3IpTp0GVNVs0IYKdmyzByiimgPTiII8eb8ay4wQiYHGHrpYh62hD14Qy3GiGDFgipRKqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/functional": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-6.8.0.tgz",
+      "integrity": "sha512-oMSAD/8w9ujx7OplvwRWwHHFnaaxi/Xrji1XH3xAB+gzxupUpBbOmgxQ+e84x+9VN8QWk5aU3L7gmCqdTAR6OA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/instructions": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-6.8.0.tgz",
+      "integrity": "sha512-dTtykhS9IeN3npCfnd7wSS6KmKAh54+g90JRtLYy5/31L2Zvunf3AJz2QUk58vgsAGZ5fuoiMyhCxRJm4rHUBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/keys": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-6.8.0.tgz",
+      "integrity": "sha512-Wo8CnbrVfCP1Jbsb3ElMej/3dmMrl4ArPhI1mDcqIIz/O4j4HmxZYbn2BCWtnV9V/LPM638EMO2r1x6GzDNrPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/nominal-types": "6.8.0",
+        "@solana/promises": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/nominal-types": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.8.0.tgz",
+      "integrity": "sha512-mLmHr92pM4mEfe49GUmZ5Ry0RMqtMuFQqZYnxQqhDKMcl+Wtt820ezxYgwPhqcMxRzfqaQSO3ZxpSB0RlLBa/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/promises": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-6.8.0.tgz",
+      "integrity": "sha512-kIypZG83ZbADbrAq9/LS7LuWlVxlgJSzIpic75+9IuAfC3k5/KSus8LrvggBkCzfAyIslrUh70iz4JcnzUZrOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/rpc-api": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-6.8.0.tgz",
+      "integrity": "sha512-v8ZKWgPtKbF6HeJcfC4ciwI8mwDCizBtRLYYjjHOu+9S9IJYyefQzsQxL5P8OjJPpI4gFauT6gsjQLo76BoojA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/keys": "6.8.0",
+        "@solana/rpc-parsed-types": "6.8.0",
+        "@solana/rpc-spec": "6.8.0",
+        "@solana/rpc-transformers": "6.8.0",
+        "@solana/rpc-types": "6.8.0",
+        "@solana/transaction-messages": "6.8.0",
+        "@solana/transactions": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/rpc-parsed-types": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-6.8.0.tgz",
+      "integrity": "sha512-jYddZviBSUYbuUKqvNthet7KbJVI7me6xfRH2znv1SjIpmvhSPJcGN5QrlHVOasHdzEWSpvZa5VYDfnqH3aYvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/rpc-spec": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-6.8.0.tgz",
+      "integrity": "sha512-kE5uOspxCVFJKNUu73hlebGiAFosjfYXbbTXAbGKfksPzy84u1oJFC2IVIobLRnqUCw1x7oJcvfnX00Zs0Itpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0",
+        "@solana/rpc-spec-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/rpc-spec-types": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-6.8.0.tgz",
+      "integrity": "sha512-ebCWgiQbIgFOehU7PdRFmYCzda3Azc/qa2Y3P8gexSHSsDAO27VwS4E05XSY+a7cIL5MYmvUa1vpDynl1Rkakw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/rpc-transformers": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-6.8.0.tgz",
+      "integrity": "sha512-GzcFkllym7eXbw7grdE41MCb15CjkibrXtr7EFsf4d6LD9DRvzFj2ZRYywS2FB2ibVP0LUXXGk3vmtkZJjfajA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0",
+        "@solana/functional": "6.8.0",
+        "@solana/nominal-types": "6.8.0",
+        "@solana/rpc-spec-types": "6.8.0",
+        "@solana/rpc-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/rpc-types": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.8.0.tgz",
+      "integrity": "sha512-vACMV9VR2JsZGDcgaMOFN/dwLK57CsE+erassxxtF12sSPXJooz+Vu1vyY2Yp2EkCc7mDf7BNkTKvSXajbt+Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/nominal-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/transaction-messages": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-6.8.0.tgz",
+      "integrity": "sha512-jsJu9mAcN1x7onKOeC4WEvYP04UVcnkOYu/9bMe+S9jqjL+3DMy9kFZpV5FBl+TPuTNJrtOqc6Gc28hUWyyp1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-data-structures": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/functional": "6.8.0",
+        "@solana/instructions": "6.8.0",
+        "@solana/nominal-types": "6.8.0",
+        "@solana/rpc-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/transactions": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-6.8.0.tgz",
+      "integrity": "sha512-Q46m+o3C1yL2EIZBAP5B8ou2VZwHN9wTi+muIS6/giCKO3jwUtnTEbWcZEDMj2vxUb7P2WfwTluZb/VAWxlx7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-data-structures": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/functional": "6.8.0",
+        "@solana/instructions": "6.8.0",
+        "@solana/keys": "6.8.0",
+        "@solana/nominal-types": "6.8.0",
+        "@solana/rpc-types": "6.8.0",
+        "@solana/transaction-messages": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@solana/programs": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-6.8.0.tgz",
+      "integrity": "sha512-8hSKGfPTLX9Sm7KGV/UtiGCeSzptT/9vcjbodE+ZGHKFefo5vES4UAW+qD01LjL7IumGtMJvnfhCWt81qT/jbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs/node_modules/@solana/addresses": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.8.0.tgz",
+      "integrity": "sha512-xVlA0DNX1LVfTueVsbhxDDoqr1VxeXvgJEh2GcIN/vcJPhY3GE3AYtjTbJJmTDgPrzOccI0t6ElVb1gelJH/PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/nominal-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs/node_modules/@solana/assertions": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.8.0.tgz",
+      "integrity": "sha512-OU6prCq39fSvGL8xY1C/9vhghasvAkMiRlituzJxzJpZRfpVRrwhzLd6P5NPAPoQ28qKcenA50kFdw9+ZyneJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs/node_modules/@solana/codecs-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
+      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs/node_modules/@solana/codecs-numbers": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.8.0.tgz",
+      "integrity": "sha512-ebf4f1D19EAe0uhdUYOCEYnn5+EellsBxbJ42tM2yYEoIBVz5FoBBC0gSsq+UTNbQHFa7XagyBT3LewxXttiTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs/node_modules/@solana/codecs-strings": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.8.0.tgz",
+      "integrity": "sha512-Rpk5NVhbKYcPnE7wz3IpTp0GVNVs0IYKdmyzByiimgPTiII8eb8ay4wQiYHGHrpYh62hD14Qy3GiGDFgipRKqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs/node_modules/@solana/nominal-types": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.8.0.tgz",
+      "integrity": "sha512-mLmHr92pM4mEfe49GUmZ5Ry0RMqtMuFQqZYnxQqhDKMcl+Wtt820ezxYgwPhqcMxRzfqaQSO3ZxpSB0RlLBa/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/programs/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@solana/promises": {
@@ -5495,31 +8597,390 @@
       }
     },
     "node_modules/@solana/signers": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-5.5.1.tgz",
-      "integrity": "sha512-FY0IVaBT2kCAze55vEieR6hag4coqcuJ31Aw3hqRH7mv6sV8oqwuJmUrx+uFwOp1gwd5OEAzlv6N4hOOple4sQ==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-6.8.0.tgz",
+      "integrity": "sha512-7E1cAXBLOcz9kmHhzWdu5m3UJlJzxfwOl8irOMLJI6NnKB2EmU0B0h4I+Mlfs9w8Bfj0WQpUei21ammbNBq39g==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "5.5.1",
-        "@solana/codecs-core": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/instructions": "5.5.1",
-        "@solana/keys": "5.5.1",
-        "@solana/nominal-types": "5.5.1",
-        "@solana/offchain-messages": "5.5.1",
-        "@solana/transaction-messages": "5.5.1",
-        "@solana/transactions": "5.5.1"
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/instructions": "6.8.0",
+        "@solana/keys": "6.8.0",
+        "@solana/nominal-types": "6.8.0",
+        "@solana/offchain-messages": "6.8.0",
+        "@solana/transaction-messages": "6.8.0",
+        "@solana/transactions": "6.8.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/addresses": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.8.0.tgz",
+      "integrity": "sha512-xVlA0DNX1LVfTueVsbhxDDoqr1VxeXvgJEh2GcIN/vcJPhY3GE3AYtjTbJJmTDgPrzOccI0t6ElVb1gelJH/PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/nominal-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/assertions": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.8.0.tgz",
+      "integrity": "sha512-OU6prCq39fSvGL8xY1C/9vhghasvAkMiRlituzJxzJpZRfpVRrwhzLd6P5NPAPoQ28qKcenA50kFdw9+ZyneJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/codecs-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
+      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/codecs-data-structures": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.8.0.tgz",
+      "integrity": "sha512-lHr0F+nNwgm9c+tWQX398yzYh1qDi7QSCJpY9MQ2azW4FfY2IyPSo7bqzTaWNnJh9pmJx3ZI6jHfXBnLD5k/SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/codecs-numbers": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.8.0.tgz",
+      "integrity": "sha512-ebf4f1D19EAe0uhdUYOCEYnn5+EellsBxbJ42tM2yYEoIBVz5FoBBC0gSsq+UTNbQHFa7XagyBT3LewxXttiTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/codecs-strings": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.8.0.tgz",
+      "integrity": "sha512-Rpk5NVhbKYcPnE7wz3IpTp0GVNVs0IYKdmyzByiimgPTiII8eb8ay4wQiYHGHrpYh62hD14Qy3GiGDFgipRKqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/functional": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-6.8.0.tgz",
+      "integrity": "sha512-oMSAD/8w9ujx7OplvwRWwHHFnaaxi/Xrji1XH3xAB+gzxupUpBbOmgxQ+e84x+9VN8QWk5aU3L7gmCqdTAR6OA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/instructions": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-6.8.0.tgz",
+      "integrity": "sha512-dTtykhS9IeN3npCfnd7wSS6KmKAh54+g90JRtLYy5/31L2Zvunf3AJz2QUk58vgsAGZ5fuoiMyhCxRJm4rHUBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/keys": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-6.8.0.tgz",
+      "integrity": "sha512-Wo8CnbrVfCP1Jbsb3ElMej/3dmMrl4ArPhI1mDcqIIz/O4j4HmxZYbn2BCWtnV9V/LPM638EMO2r1x6GzDNrPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/nominal-types": "6.8.0",
+        "@solana/promises": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/nominal-types": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.8.0.tgz",
+      "integrity": "sha512-mLmHr92pM4mEfe49GUmZ5Ry0RMqtMuFQqZYnxQqhDKMcl+Wtt820ezxYgwPhqcMxRzfqaQSO3ZxpSB0RlLBa/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/promises": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-6.8.0.tgz",
+      "integrity": "sha512-kIypZG83ZbADbrAq9/LS7LuWlVxlgJSzIpic75+9IuAfC3k5/KSus8LrvggBkCzfAyIslrUh70iz4JcnzUZrOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/rpc-types": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.8.0.tgz",
+      "integrity": "sha512-vACMV9VR2JsZGDcgaMOFN/dwLK57CsE+erassxxtF12sSPXJooz+Vu1vyY2Yp2EkCc7mDf7BNkTKvSXajbt+Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/nominal-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/transaction-messages": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-6.8.0.tgz",
+      "integrity": "sha512-jsJu9mAcN1x7onKOeC4WEvYP04UVcnkOYu/9bMe+S9jqjL+3DMy9kFZpV5FBl+TPuTNJrtOqc6Gc28hUWyyp1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-data-structures": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/functional": "6.8.0",
+        "@solana/instructions": "6.8.0",
+        "@solana/nominal-types": "6.8.0",
+        "@solana/rpc-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/transactions": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-6.8.0.tgz",
+      "integrity": "sha512-Q46m+o3C1yL2EIZBAP5B8ou2VZwHN9wTi+muIS6/giCKO3jwUtnTEbWcZEDMj2vxUb7P2WfwTluZb/VAWxlx7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-data-structures": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/functional": "6.8.0",
+        "@solana/instructions": "6.8.0",
+        "@solana/keys": "6.8.0",
+        "@solana/nominal-types": "6.8.0",
+        "@solana/rpc-types": "6.8.0",
+        "@solana/transaction-messages": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/signers/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@solana/spl-token": {
@@ -5838,26 +9299,248 @@
       }
     },
     "node_modules/@solana/sysvars": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-5.5.1.tgz",
-      "integrity": "sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-6.8.0.tgz",
+      "integrity": "sha512-pwfMpMNL6MSmm07eHQYdTdRdzmPOd+EuVCCaNLSYdWGpYcocVJiaLiNWRV3cXA5wPj/ZFkoUGtc1bo0v7H50lw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/accounts": "5.5.1",
-        "@solana/codecs": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/rpc-types": "5.5.1"
+        "@solana/accounts": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-data-structures": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/rpc-types": "6.8.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/@solana/addresses": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.8.0.tgz",
+      "integrity": "sha512-xVlA0DNX1LVfTueVsbhxDDoqr1VxeXvgJEh2GcIN/vcJPhY3GE3AYtjTbJJmTDgPrzOccI0t6ElVb1gelJH/PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/nominal-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/@solana/assertions": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.8.0.tgz",
+      "integrity": "sha512-OU6prCq39fSvGL8xY1C/9vhghasvAkMiRlituzJxzJpZRfpVRrwhzLd6P5NPAPoQ28qKcenA50kFdw9+ZyneJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/@solana/codecs-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
+      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/@solana/codecs-data-structures": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.8.0.tgz",
+      "integrity": "sha512-lHr0F+nNwgm9c+tWQX398yzYh1qDi7QSCJpY9MQ2azW4FfY2IyPSo7bqzTaWNnJh9pmJx3ZI6jHfXBnLD5k/SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/@solana/codecs-numbers": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.8.0.tgz",
+      "integrity": "sha512-ebf4f1D19EAe0uhdUYOCEYnn5+EellsBxbJ42tM2yYEoIBVz5FoBBC0gSsq+UTNbQHFa7XagyBT3LewxXttiTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/@solana/codecs-strings": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.8.0.tgz",
+      "integrity": "sha512-Rpk5NVhbKYcPnE7wz3IpTp0GVNVs0IYKdmyzByiimgPTiII8eb8ay4wQiYHGHrpYh62hD14Qy3GiGDFgipRKqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/@solana/nominal-types": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.8.0.tgz",
+      "integrity": "sha512-mLmHr92pM4mEfe49GUmZ5Ry0RMqtMuFQqZYnxQqhDKMcl+Wtt820ezxYgwPhqcMxRzfqaQSO3ZxpSB0RlLBa/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/@solana/rpc-types": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.8.0.tgz",
+      "integrity": "sha512-vACMV9VR2JsZGDcgaMOFN/dwLK57CsE+erassxxtF12sSPXJooz+Vu1vyY2Yp2EkCc7mDf7BNkTKvSXajbt+Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/nominal-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@solana/transaction-confirmation": {
@@ -17292,6 +20975,270 @@
         "viem": "^2.21.26",
         "wagmi": "^2.15.6",
         "zod": "^3.24.2"
+      }
+    },
+    "node_modules/x402/node_modules/@solana-program/token": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.9.0.tgz",
+      "integrity": "sha512-vnZxndd4ED4Fc56sw93cWZ2djEeeOFxtaPS8SPf5+a+JZjKA/EnKqzbE1y04FuMhIVrLERQ8uR8H2h72eZzlsA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^5.0"
+      }
+    },
+    "node_modules/x402/node_modules/@solana/accounts": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-5.5.1.tgz",
+      "integrity": "sha512-TfOY9xixg5rizABuLVuZ9XI2x2tmWUC/OoN556xwfDlhBHBjKfszicYYOyD6nbFmwTGYarCmyGIdteXxTXIdhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/x402/node_modules/@solana/codecs": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-5.5.1.tgz",
+      "integrity": "sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/options": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/x402/node_modules/@solana/instruction-plans": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-5.5.1.tgz",
+      "integrity": "sha512-7z3CB7YMcFKuVvgcnNY8bY6IsZ8LG61Iytbz7HpNVGX2u1RthOs1tRW8luTzSG1MPL0Ox7afyAVMYeFqSPHnaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/x402/node_modules/@solana/kit": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-5.5.1.tgz",
+      "integrity": "sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "5.5.1",
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/instruction-plans": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/offchain-messages": "5.5.1",
+        "@solana/plugin-core": "5.5.1",
+        "@solana/programs": "5.5.1",
+        "@solana/rpc": "5.5.1",
+        "@solana/rpc-api": "5.5.1",
+        "@solana/rpc-parsed-types": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-subscriptions": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/signers": "5.5.1",
+        "@solana/sysvars": "5.5.1",
+        "@solana/transaction-confirmation": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/x402/node_modules/@solana/offchain-messages": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-5.5.1.tgz",
+      "integrity": "sha512-g+xHH95prTU+KujtbOzj8wn+C7ZNoiLhf3hj6nYq3MTyxOXtBEysguc97jJveUZG0K97aIKG6xVUlMutg5yxhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/nominal-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/x402/node_modules/@solana/options": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-5.5.1.tgz",
+      "integrity": "sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/x402/node_modules/@solana/plugin-core": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-5.5.1.tgz",
+      "integrity": "sha512-VUZl30lDQFJeiSyNfzU1EjYt2QZvoBFKEwjn1lilUJw7KgqD5z7mbV7diJhT+dLFs36i0OsjXvq5kSygn8YJ3A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/x402/node_modules/@solana/programs": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-5.5.1.tgz",
+      "integrity": "sha512-7U9kn0Jsx1NuBLn5HRTFYh78MV4XN145Yc3WP/q5BlqAVNlMoU9coG5IUTJIG847TUqC1lRto3Dnpwm6T4YRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/x402/node_modules/@solana/signers": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-5.5.1.tgz",
+      "integrity": "sha512-FY0IVaBT2kCAze55vEieR6hag4coqcuJ31Aw3hqRH7mv6sV8oqwuJmUrx+uFwOp1gwd5OEAzlv6N4hOOple4sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/offchain-messages": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/x402/node_modules/@solana/sysvars": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-5.5.1.tgz",
+      "integrity": "sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "5.5.1",
+        "@solana/codecs": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
   },
   "dependencies": {
     "@privy-io/react-auth": "^3.18.0",
+    "@solana-program/memo": "^0.11.0",
+    "@solana-program/system": "^0.12.0",
+    "@solana-program/token": "^0.13.0",
+    "@solana/kit": "^6.8.0",
     "@solana/spl-token": "^0.4.14",
     "@solana/web3.js": "^1.98.4",
     "@supabase/ssr": "^0.9.0",

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -19,7 +19,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
         defaultChain: base,
         supportedChains: [base, mainnet, arbitrum],
         appearance: {
-          walletList: ["rabby_wallet", "metamask", "coinbase_wallet", "rainbow", "wallet_connect", "phantom"],
+          walletList: ["rabby_wallet", "metamask", "coinbase_wallet", "rainbow", "wallet_connect", "phantom", "backpack"],
           walletChainType: "ethereum-and-solana",
         },
         embeddedWallets: {

--- a/src/components/ui/featured-carousel.tsx
+++ b/src/components/ui/featured-carousel.tsx
@@ -4,13 +4,14 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { Megaphone, ChevronLeft, ChevronRight, ExternalLink, Sparkles, Wallet, Loader2, Check, Github, Crown } from "lucide-react";
 import { createClient } from "@/lib/supabase/client";
 import { usePrivy, useWallets } from "@privy-io/react-auth";
+import { useWallets as useSolanaWallets, useSignAndSendTransaction } from "@privy-io/react-auth/solana";
 import { encodeFunctionData, parseAbi } from "viem";
 import Image from "next/image";
 import Link from "next/link";
 import { VibeScore } from "@/components/ui/vibe-score";
 import { BadgeDisplay } from "@/components/ui/badge-display";
 import { CHAIN_CONFIGS, SUPPORTED_CHAINS, DEFAULT_CHAIN, getChainConfig, isEVMChain, isSolanaChain } from "@/lib/chains-config";
-import { buildSolanaUSDCTransfer, confirmSolanaTransaction } from "@/lib/solana-payment";
+import { buildSolanaUSDCTransfer, confirmSolanaTransaction, signatureToString } from "@/lib/solana-payment";
 
 import type { BadgeLevel } from "@/lib/types/database";
 
@@ -635,10 +636,10 @@ function PromoteForm({ onSuccess, isLoggedIn }: { onSuccess: () => void; isLogge
   const { login: privyLogin, logout: privyLogout, connectWallet, authenticated: privyAuthenticated, ready: privyReady, user: privyUser } = usePrivy();
   const { wallets } = useWallets();
   const connectedWallet = wallets[0];
-  // Solana wallet from Privy linked accounts (avoids hook crash in dev without Privy Solana context)
-  const connectedSolanaWallet = privyUser?.linkedAccounts?.find(
-    (a) => a.type === "wallet" && "chainType" in a && (a as unknown as { chainType: string }).chainType === "solana"
-  ) as { address: string } | undefined || null;
+  // Solana wallets via Privy's standard wallet interface (detects Phantom, Backpack, etc.)
+  const { wallets: solanaWallets } = useSolanaWallets();
+  const { signAndSendTransaction: privySignAndSend } = useSignAndSendTransaction();
+  const connectedSolanaWallet = solanaWallets[0] ?? null;
 
   const [prices, setPrices] = useState<bigint[]>(FALLBACK_PRICES);
   const [selectedPkg, setSelectedPkg] = useState(2); // default 7 days
@@ -696,7 +697,8 @@ function PromoteForm({ onSuccess, isLoggedIn }: { onSuccess: () => void; isLogge
     // If already authenticated with Privy but no wallet connected,
     // use connectWallet() instead of login() to avoid "already logged in" error
     if (privyAuthenticated) {
-      connectWallet();
+      const wantsSolana = isSolanaChain(getChainConfig(selectedChain));
+      connectWallet(wantsSolana ? { walletChainType: "solana-only" } : undefined);
     } else {
       privyLogin();
     }
@@ -774,16 +776,15 @@ function PromoteForm({ onSuccess, isLoggedIn }: { onSuccess: () => void; isLogge
 
     setStatus({ msg: `Sending $${(Number(price) / 1e6).toFixed(2)} USDC on Solana...`, type: "info" });
 
-    // Use window.solana (Phantom/Solflare) provider directly
-    const solanaProvider = (window as unknown as { solana?: { signAndSendTransaction: (tx: unknown) => Promise<{ signature: string }> } }).solana;
-    if (!solanaProvider) throw new Error("No Solana wallet extension found. Install Phantom or Solflare.");
-
-    const { Transaction } = await import("@solana/web3.js");
-    const tx = Transaction.from(serializedTx);
-    const { signature } = await solanaProvider.signAndSendTransaction(tx);
+    // Use Privy's standard wallet interface (works with Phantom, Backpack, Solflare, etc.)
+    const { signature } = await privySignAndSend({
+      transaction: serializedTx,
+      wallet: connectedSolanaWallet,
+      chain: "solana:mainnet",
+    });
 
     setStatus({ msg: `Confirming transaction...`, type: "info" });
-    await confirmSolanaTransaction(chainConfig.rpc, signature);
+    await confirmSolanaTransaction(chainConfig.rpc, signatureToString(signature));
   }
 
   async function handlePromote() {


### PR DESCRIPTION
## Summary

When a user selected Solana and clicked **Connect Solana Wallet**, Phantom/Backpack couldn't connect — Privy showed an "install extension" message even when the extensions were installed.

Root cause: `connectWallet()` was called without `walletChainType`, so Privy opened the EVM wallet picker. Phantom/Backpack were being offered as EVM connectors, which then failed to detect them.

- Pass `walletChainType: 'solana-only'` to `connectWallet()` when Solana is the selected chain
- Use `useWallets()` / `useSignAndSendTransaction()` from `@privy-io/react-auth/solana` instead of the `window.solana` + manual `linkedAccounts` lookup
- Add `"backpack"` to the configured `walletList`

## Test plan

- [ ] Select Solana, click **Connect Solana Wallet** → Privy modal lists Phantom + Backpack
- [ ] Connecting Phantom shows the address in the form
- [ ] Connecting Backpack shows the address in the form
- [ ] Promoting a project on Solana triggers the wallet's sign-and-send prompt and confirms on-chain
- [ ] Switching back to Base still connects an EVM wallet (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Backpack wallet support to available connection options.
  * Enhanced Solana wallet integration with improved discovery and transaction signing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->