### PR TITLE
fix: profile setup crash — .rpc().catch is not a function

### DIFF
--- a/src/app/auth/profile-setup/page.tsx
+++ b/src/app/auth/profile-setup/page.tsx
@@ -220,9 +220,13 @@ export default function ProfileSetupPage() {
       );
 
       if (dbError) throw dbError;
-      // Ensure baseline vibe score is set for new users
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await (supabase as any).rpc("update_user_streak", { p_user_id: userId }).catch(() => {});
+      // Ensure baseline vibe score is set for new users (non-fatal)
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (supabase as any).rpc("update_user_streak", { p_user_id: userId });
+      } catch {
+        // Don't block onboarding if streak RPC fails
+      }
       setStep(2);
     } catch (err: unknown) {
       const message =


### PR DESCRIPTION
## Summary
- Fixes `TypeError: U.rpc(...).catch is not a function` that blocked new users on step 1 of `/auth/profile-setup`.
- Root cause: supabase-js's `.rpc()` returns a `PostgrestFilterBuilder` — a thenable with `.then()` but no `.catch()` method. Calling `.catch(() => {})` on it throws synchronously, before the RPC even executes.
- Wraps the awaited RPC in `try/catch` to keep the original intent (streak failure shouldn't block onboarding) without the crash.

## Repro (before fix)
1. Sign up via OAuth
2. Fill in username, display name, bio on step 1
3. Click **Next** → red error box shows `U.rpc(...).catch is not a function` and the user is stuck.

## Test plan
- [ ] Sign up a fresh user, complete step 1, confirm advance to step 2 with no error.
- [ ] Simulate RPC failure (e.g. rename the SQL function locally) — confirm onboarding still advances (failure is non-fatal by design).
- [ ] Regression check: streak baseline still gets set for users on a working DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling reliability during profile setup initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->