### PR TITLE
fix: don't crash homepage when NEXT_PUBLIC_PRIVY_APP_ID is unset

### DIFF
--- a/src/components/ui/featured-carousel.tsx
+++ b/src/components/ui/featured-carousel.tsx
@@ -20,6 +20,10 @@ const BASE_CONFIG = CHAIN_CONFIGS.base;
 const CONTRACT_ADDR = isEVMChain(BASE_CONFIG) ? BASE_CONFIG.contractAddr : "";
 const BASE_RPC = isEVMChain(BASE_CONFIG) ? BASE_CONFIG.rpc : "";
 
+// Privy must be configured for PromoteForm to mount — its hooks require PrivyProvider.
+// Providers.tsx bails out when this is unset, so rendering PromoteForm would crash.
+const PRIVY_CONFIGURED = !!process.env.NEXT_PUBLIC_PRIVY_APP_ID;
+
 // Function selectors (keccak256 of signature, first 4 bytes) — read-only calls
 const SEL = {
   getActivePromotions: "0x5fd2d522",
@@ -619,8 +623,24 @@ export function FeaturedCarousel() {
           </div>
         )}
 
-        {/* Promote Form */}
-        <PromoteForm onSuccess={refreshPromotions} isLoggedIn={isLoggedIn} />
+        {/* Promote Form — gated on Privy config; PromoteForm's hooks require PrivyProvider */}
+        {PRIVY_CONFIGURED ? (
+          <PromoteForm onSuccess={refreshPromotions} isLoggedIn={isLoggedIn} />
+        ) : process.env.NODE_ENV !== "production" ? (
+          <div
+            className="mt-6 p-4 text-sm font-medium"
+            style={{
+              backgroundColor: "var(--bg-surface)",
+              border: "2px dashed var(--border-hard)",
+              color: "var(--text-secondary)",
+            }}
+          >
+            <strong className="uppercase text-[var(--foreground)]">Promote form disabled</strong>
+            <span className="ml-2">
+              Set <code>NEXT_PUBLIC_PRIVY_APP_ID</code> in <code>.env.local</code> to enable wallet-based promotions.
+            </span>
+          </div>
+        ) : null}
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- Fixes a homepage **500 crash** that hits any contributor running the app without \`NEXT_PUBLIC_PRIVY_APP_ID\` in \`.env.local\`.
- Root cause: \`Providers.tsx\` skips mounting \`<PrivyProvider>\` when the env var is missing, but \`FeaturedCarousel\`'s \`PromoteForm\` unconditionally calls \`usePrivy\` / \`useWallets\` / \`useSolanaWallets\`. With no provider, those hooks throw \`Cannot read properties of null (reading 'connectors')\` and the root \`error.tsx\` renders the 500 page.
- Gates \`PromoteForm\` rendering on a module-level \`PRIVY_CONFIGURED\` flag. In dev, replaces it with a dashed-border hint naming the missing env var. In production (where the key is expected to be set), behavior is unchanged.

## Before / after
- **Before:** fresh clone → \`npm run dev\` → visit \`/\` → red 500 page, console shows \`useWallets was called outside the PrivyProvider component\`.
- **After (dev, no key):** homepage renders normally, with a small hint box under the carousel telling the dev to set \`NEXT_PUBLIC_PRIVY_APP_ID\`.
- **After (prod, key set):** no visible change — \`PromoteForm\` renders as before.

## Test plan
- [ ] Unset \`NEXT_PUBLIC_PRIVY_APP_ID\` locally → homepage loads, dashed hint appears, no console errors from PromoteForm.
- [ ] Set the key → homepage loads, PromoteForm renders, promotion flow still works.
- [ ] \`npm run build\` passes; \`next build\` doesn't complain about missing env (it's read at runtime from \`process.env\`, inlined by Next for client bundles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)