### PR TITLE
fix: detect Phantom/Backpack (Wallet Standard connectors in PrivyProvider)

### DIFF
--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { PrivyProvider } from "@privy-io/react-auth";
+import { toSolanaWalletConnectors } from "@privy-io/react-auth/solana";
 import { base, mainnet, arbitrum } from "viem/chains";
+
+// Wallet Standard connectors for Solana. Without this, Privy has no way to
+// detect installed Solana wallets and falls back to sending users to the
+// wallet's download page (e.g. clicking "phantom" opens phantom.app instead
+// of the installed extension).
+const solanaConnectors = toSolanaWalletConnectors();
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   const appId = process.env.NEXT_PUBLIC_PRIVY_APP_ID;
@@ -19,8 +26,28 @@ export default function Providers({ children }: { children: React.ReactNode }) {
         defaultChain: base,
         supportedChains: [base, mainnet, arbitrum],
         appearance: {
-          walletList: ["rabby_wallet", "metamask", "coinbase_wallet", "rainbow", "wallet_connect", "phantom", "backpack"],
+          walletList: [
+            "rabby_wallet",
+            "metamask",
+            "coinbase_wallet",
+            "rainbow",
+            "wallet_connect",
+            // Catch-all for any other installed EVM wallet (Frame, Trust, OKX,
+            // etc.) detected via EIP-6963.
+            "detected_ethereum_wallets",
+            // Explicit Solana wallets (shown in this order in the modal)
+            "phantom",
+            "backpack",
+            "solflare",
+            "jupiter",
+            // Catch-all for any other installed Solana wallet (Glow, Coin98,
+            // Exodus, etc.) detected via the Wallet Standard.
+            "detected_solana_wallets",
+          ],
           walletChainType: "ethereum-and-solana",
+        },
+        externalWallets: {
+          solana: { connectors: solanaConnectors },
         },
         embeddedWallets: {
           ethereum: {


### PR DESCRIPTION
## Summary
- Wires up `toSolanaWalletConnectors()` in PrivyProvider → installed Phantom/Backpack/Solflare extensions now open instead of redirecting to phantom.app
- Follow-up to #127 (which routed the Solana-only modal correctly) — #127 was necessary but not sufficient; the Wallet Standard detection layer was still missing
- Expanded `walletList` with explicit `solflare`, `jupiter` + `detected_solana_wallets` / `detected_ethereum_wallets` catch-alls so less-common wallets (Glow, Coin98, Exodus, Frame, Trust, OKX, …) also appear in the modal

## Why the redirect happened
Privy has two separate detection layers:
- **EVM** — auto-wired via EIP-6963. That's why Rabby/MetaMask worked.
- **Solana** — requires opting into the Wallet Standard layer via `externalWallets.solana.connectors: toSolanaWalletConnectors()`. Without that, clicking `phantom` in the modal falls back to the "not detected" path → phantom.app download page.

## Test plan
- [ ] Select Solana chain in the Promote form
- [ ] Click "Connect Solana Wallet"
- [ ] Verify the modal opens the installed Phantom/Backpack/Solflare extension (not a redirect to phantom.app)
- [ ] Select Base chain → verify Rabby/MetaMask still work (no EVM regression)
- [ ] `npx tsc --noEmit` passes (done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Solana wallet integration with support for Phantom, Backpack, Solflare, and Jupiter wallets.
  * Enhanced wallet discovery to automatically detect additional installed wallets across EVM and Solana networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->