### PR TITLE
feat: top-of-site promo billboard + rename streak label to 'vibed'

### DIFF
--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -93,6 +93,9 @@ export async function GET(request: NextRequest) {
       const key = user.username + "|" + log.activity_date;
       if (coveredDates.has(key)) continue;
       coveredDates.add(key);
+      // No `message` — the UI derives the label ("vibed") from `type === "streak"`.
+      // Keeping this field empty avoids coupling the client-side grouping
+      // sentinels (src/app/feed/page.tsx) to a specific user-visible string.
       feed.push({
         id: `streak-${log.id}`,
         type: "streak",
@@ -103,7 +106,6 @@ export async function GET(request: NextRequest) {
         streak: user.streak,
         github_verified: user.github_verified,
         date: log.activity_date,
-        message: "logged a day of coding",
       });
     }
 

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -40,12 +40,12 @@ function groupFeedItems(items: FeedItem[]): GroupedItem[] {
     );
     if (existing) {
       existing.count++;
-      if (item.message && item.message !== "pushed code" && item.message !== "logged a day of coding" && item.message !== "opened a pull request" && !existing.messages.includes(item.message)) {
+      if (item.message && item.message !== "pushed code" && item.message !== "opened a pull request" && !existing.messages.includes(item.message)) {
         existing.messages.push(item.message);
       }
     } else {
       const messages: string[] = [];
-      if (item.message && item.message !== "pushed code" && item.message !== "logged a day of coding" && item.message !== "opened a pull request") messages.push(item.message);
+      if (item.message && item.message !== "pushed code" && item.message !== "opened a pull request") messages.push(item.message);
       grouped.push({ ...item, count: 1, messages });
     }
   }
@@ -69,7 +69,7 @@ function actionText(item: GroupedItem): string {
   if (item.type === "pr") return item.count > 1 ? `merged ${item.count} PRs into` : "merged PR into";
   if (item.type === "create") return "created branch in";
   if (item.type === "issue") return item.count > 1 ? `opened ${item.count} issues in` : "opened issue in";
-  if (item.type === "streak") return "logged a day of coding";
+  if (item.type === "streak") return "vibed";
   if (item.type === "joined") return "joined VibeTalent";
   return item.count > 1 ? `pushed ${item.count} commits to` : "pushed to";
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import Script from "next/script";
 import { Space_Grotesk, JetBrains_Mono } from "next/font/google";
 import { Navbar } from "@/components/layout/navbar";
 import { Footer } from "@/components/layout/footer";
+import { PromoBillboard } from "@/components/ui/promo-billboard";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import Providers from "@/components/providers";
 import { siteUrl } from "@/lib/seo";
@@ -103,6 +104,7 @@ export default function RootLayout({
         className={`${spaceGrotesk.variable} ${jetbrainsMono.variable} antialiased`}
       >
         <Providers>
+          <PromoBillboard />
           <Navbar />
           <ErrorBoundary>
             <main className="min-h-screen">{children}</main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -105,9 +105,9 @@ export default async function HomePage() {
 
       {/* Hero */}
       <section className="relative">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 pt-24 pb-20 text-center">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 pt-14 pb-10 text-center">
           <div
-            className="inline-flex items-center gap-2 px-4 py-1.5 text-sm font-bold uppercase tracking-wide text-[var(--foreground)] mb-8"
+            className="inline-flex items-center gap-2 px-4 py-1.5 text-sm font-bold uppercase tracking-wide text-[var(--foreground)] mb-6"
             style={{
               backgroundColor: "var(--bg-surface)",
               border: "2px solid var(--border-hard)",
@@ -125,12 +125,12 @@ export default async function HomePage() {
             </span>
           </h1>
 
-          <p className="mx-auto mt-6 max-w-2xl text-lg text-[var(--text-secondary)] font-medium">
+          <p className="mx-auto mt-5 max-w-2xl text-lg text-[var(--text-secondary)] font-medium">
             A marketplace built on consistency and proof of work. No resumes. No portfolios.
             Just streaks, shipped projects, and vibe scores.
           </p>
 
-          <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
+          <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-4">
             <HeroCTA />
             <Link
               href="/explore"
@@ -141,7 +141,7 @@ export default async function HomePage() {
           </div>
 
           {/* Stats */}
-          <div className="mt-16 grid grid-cols-2 sm:grid-cols-4 gap-4 max-w-3xl mx-auto stagger-children">
+          <div className="mt-10 grid grid-cols-2 sm:grid-cols-4 gap-3 max-w-3xl mx-auto stagger-children">
             {[
               { label: "Active Builders", value: String(totalBuilders), icon: Users },
               { label: "Projects Shipped", value: String(totalProjects), icon: Code2 },
@@ -150,16 +150,16 @@ export default async function HomePage() {
             ].map((stat) => (
               <div
                 key={stat.label}
-                className="text-center p-4"
+                className="text-center p-3"
                 style={{
                   backgroundColor: "var(--bg-surface)",
                   border: "2px solid var(--border-hard)",
                   boxShadow: "var(--shadow-brutal-sm)",
                 }}
               >
-                <stat.icon size={20} className="mx-auto text-[var(--accent)] mb-2" />
-                <div className="text-2xl font-extrabold text-[var(--foreground)] font-mono">{stat.value}</div>
-                <div className="text-xs font-bold uppercase tracking-wide text-[var(--text-muted)] mt-1">{stat.label}</div>
+                <stat.icon size={18} className="mx-auto text-[var(--accent)] mb-1.5" />
+                <div className="text-xl font-extrabold text-[var(--foreground)] font-mono">{stat.value}</div>
+                <div className="text-[10px] font-bold uppercase tracking-wide text-[var(--text-muted)] mt-0.5">{stat.label}</div>
               </div>
             ))}
           </div>

--- a/src/components/ui/featured-carousel.tsx
+++ b/src/components/ui/featured-carousel.tsx
@@ -12,8 +12,7 @@ import { VibeScore } from "@/components/ui/vibe-score";
 import { BadgeDisplay } from "@/components/ui/badge-display";
 import { CHAIN_CONFIGS, SUPPORTED_CHAINS, DEFAULT_CHAIN, getChainConfig, isEVMChain, isSolanaChain } from "@/lib/chains-config";
 import { buildSolanaUSDCTransfer, confirmSolanaTransaction, signatureToString } from "@/lib/solana-payment";
-
-import type { BadgeLevel } from "@/lib/types/database";
+import { fetchPromotions, enrichPromotions, type EnrichedPromotion } from "@/lib/featured-promotions";
 
 // Base chain defaults (for fetching promotions — always read from Base contract)
 const BASE_CONFIG = CHAIN_CONFIGS.base;
@@ -26,7 +25,6 @@ const PRIVY_CONFIGURED = !!process.env.NEXT_PUBLIC_PRIVY_APP_ID;
 
 // Function selectors (keccak256 of signature, first 4 bytes) — read-only calls
 const SEL = {
-  getActivePromotions: "0x5fd2d522",
   getPrices: "0xbd9a548b",
 };
 
@@ -38,129 +36,6 @@ const PACKAGES = [
   { label: "Lifetime", value: 4 },
 ] as const;
 
-type Promotion = {
-  id: number;
-  promoter: string;
-  projectId: string;
-  projectName: string;
-  expiresAt: number;
-  paidAmount: number;
-};
-
-type EnrichedProject = {
-  id: string;
-  title: string;
-  description: string;
-  tech_stack: string[];
-  live_url: string | null;
-  github_url: string | null;
-  image_url: string | null;
-  verified: boolean;
-  quality_score: number;
-  endorsement_count: number;
-};
-
-type EnrichedAuthor = {
-  username: string;
-  display_name: string | null;
-  avatar_url: string | null;
-  vibe_score: number;
-  streak: number;
-  badge_level: BadgeLevel;
-};
-
-type EnrichedPromotion = Promotion & {
-  project: EnrichedProject | null;
-  author: EnrichedAuthor | null;
-};
-
-async function enrichPromotions(promotions: Promotion[]): Promise<EnrichedPromotion[]> {
-  if (promotions.length === 0) return [];
-  try {
-    const supabase = createClient();
-    const projectIds = [...new Set(promotions.map((p) => p.projectId))];
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { data: projects } = await (supabase as any)
-      .from("projects")
-      .select("id, title, description, tech_stack, live_url, github_url, image_url, verified, quality_score, endorsement_count, user_id")
-      .in("id", projectIds);
-
-    const projectMap = new Map<string, EnrichedProject & { user_id: string }>();
-    for (const p of projects || []) {
-      projectMap.set(p.id, p);
-    }
-
-    const userIds = [...new Set((projects || []).map((p: { user_id: string }) => p.user_id))];
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { data: users } = await (supabase as any)
-      .from("users")
-      .select("id, username, display_name, avatar_url, vibe_score, streak, badge_level")
-      .in("id", userIds);
-
-    const userMap = new Map<string, EnrichedAuthor>();
-    for (const u of users || []) {
-      userMap.set(u.id, u);
-    }
-
-    return promotions.map((promo) => {
-      const proj = projectMap.get(promo.projectId) || null;
-      const author = proj ? userMap.get(proj.user_id) || null : null;
-      return { ...promo, project: proj, author };
-    });
-  } catch {
-    // Graceful fallback — show basic promotion data
-    return promotions.map((promo) => ({ ...promo, project: null, author: null }));
-  }
-}
-
-function decodeAddress(hex: string): string {
-  return "0x" + hex.slice(24);
-}
-
-function decodeUint256(hex: string): number {
-  return parseInt(hex, 16);
-}
-
-function decodeStringArray(data: string, arrayWordOffset: number): string[] {
-  // arrayWordOffset points to the word that contains the offset to the array
-  const arrayDataOffset = decodeUint256(data.slice(arrayWordOffset * 64, arrayWordOffset * 64 + 64)) * 2;
-  const count = decodeUint256(data.slice(arrayDataOffset, arrayDataOffset + 64));
-  const strings: string[] = [];
-  for (let i = 0; i < count; i++) {
-    const strRelOffset = decodeUint256(data.slice(arrayDataOffset + 64 + i * 64, arrayDataOffset + 64 + i * 64 + 64)) * 2;
-    const strAbsOffset = arrayDataOffset + 64 + strRelOffset;
-    const strLen = decodeUint256(data.slice(strAbsOffset, strAbsOffset + 64));
-    const strBytes = data.slice(strAbsOffset + 64, strAbsOffset + 64 + strLen * 2);
-    let s = "";
-    for (let j = 0; j < strBytes.length; j += 2) {
-      s += String.fromCharCode(parseInt(strBytes.slice(j, j + 2), 16));
-    }
-    strings.push(s);
-  }
-  return strings;
-}
-
-function decodeUint256Array(data: string, arrayWordOffset: number): number[] {
-  const arrayDataOffset = decodeUint256(data.slice(arrayWordOffset * 64, arrayWordOffset * 64 + 64)) * 2;
-  const count = decodeUint256(data.slice(arrayDataOffset, arrayDataOffset + 64));
-  const nums: number[] = [];
-  for (let i = 0; i < count; i++) {
-    nums.push(decodeUint256(data.slice(arrayDataOffset + 64 + i * 64, arrayDataOffset + 64 + i * 64 + 64)));
-  }
-  return nums;
-}
-
-function decodeAddressArray(data: string, arrayWordOffset: number): string[] {
-  const arrayDataOffset = decodeUint256(data.slice(arrayWordOffset * 64, arrayWordOffset * 64 + 64)) * 2;
-  const count = decodeUint256(data.slice(arrayDataOffset, arrayDataOffset + 64));
-  const addrs: string[] = [];
-  for (let i = 0; i < count; i++) {
-    addrs.push(decodeAddress(data.slice(arrayDataOffset + 64 + i * 64, arrayDataOffset + 64 + i * 64 + 64)));
-  }
-  return addrs;
-}
-
 // Fallback prices matching contract defaults (in USDC 6 decimals)
 const FALLBACK_PRICES: bigint[] = [
   BigInt(500000),   // $0.50
@@ -169,47 +44,6 @@ const FALLBACK_PRICES: bigint[] = [
   BigInt(5000000),  // $5.00
   BigInt(15000000), // $15.00
 ];
-
-async function fetchPromotions(): Promise<Promotion[]> {
-  try {
-    const res = await fetch(BASE_RPC, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: 1,
-        method: "eth_call",
-        params: [{ to: CONTRACT_ADDR, data: SEL.getActivePromotions }, "latest"],
-      }),
-    });
-    const json = await res.json();
-    if (!json.result || json.result === "0x" || json.result.length < 10) return [];
-
-    const data = json.result.slice(2); // strip 0x
-    if (data.length < 384) return []; // minimum 6 offset words = 6*64 chars
-
-    // Return type: (uint256[] ids, address[] promoters, string[] projectIds, string[] projectNames, uint256[] expiresAts, uint256[] paidAmounts)
-    const ids = decodeUint256Array(data, 0);
-    if (ids.length === 0) return [];
-
-    const promoters = decodeAddressArray(data, 1);
-    const projectIds = decodeStringArray(data, 2);
-    const projectNames = decodeStringArray(data, 3);
-    const expiresAts = decodeUint256Array(data, 4);
-    const paidAmounts = decodeUint256Array(data, 5);
-
-    return ids.map((id, i) => ({
-      id,
-      promoter: promoters[i],
-      projectId: projectIds[i],
-      projectName: projectNames[i],
-      expiresAt: expiresAts[i],
-      paidAmount: paidAmounts[i],
-    }));
-  } catch {
-    return [];
-  }
-}
 
 // ── ABI definitions for viem encoding ──
 

--- a/src/components/ui/live-activity-feed.tsx
+++ b/src/components/ui/live-activity-feed.tsx
@@ -50,7 +50,7 @@ function actionText(item: GroupedItem): string {
   if (item.type === "project") return "shipped";
   if (item.type === "pr") return item.count > 1 ? `${item.count} PRs` : "PR";
   if (item.type === "create") return "created";
-  if (item.type === "streak") return "coded";
+  if (item.type === "streak") return "vibed";
   return item.count > 1 ? `${item.count} commits` : "pushed";
 }
 

--- a/src/components/ui/promo-billboard.tsx
+++ b/src/components/ui/promo-billboard.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+// Thin single-line infinite-marquee billboard rendered at the very top of
+// every page. Auto-fetches on-chain paid promotions and scrolls them
+// horizontally so sponsored projects get above-the-fold visibility across the
+// entire site (not just the homepage carousel).
+//
+// All styling is inline / in a scoped <style> block because Tailwind v4's
+// compile pipeline was dropping custom classes we added to globals.css — this
+// makes the component self-contained and immune to that issue.
+
+import { useState, useEffect } from "react";
+import { Flame, ExternalLink } from "lucide-react";
+import { fetchPromotions, enrichPromotions, type EnrichedPromotion } from "@/lib/featured-promotions";
+
+// Pad the promo list up to this count so the marquee row feels full even when
+// only 1-2 projects are currently promoted. Each copy is rendered once per
+// "lap" (we render two laps back-to-back to make the loop seamless).
+const MIN_ITEMS_PER_LAP = 6;
+
+// Scoped CSS — injected once. Keyframes + hover pause + reduced-motion guard.
+const SCOPED_CSS = `
+@keyframes promo-billboard-scroll {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+.promo-billboard-marquee:hover .promo-billboard-track {
+  animation-play-state: paused;
+}
+@media (prefers-reduced-motion: reduce) {
+  .promo-billboard-track {
+    animation: none !important;
+  }
+}
+`;
+
+function sortPromos(promos: EnrichedPromotion[]): EnrichedPromotion[] {
+  return [...promos].sort((a, b) => {
+    if (a.expiresAt === 0 && b.expiresAt !== 0) return -1;
+    if (b.expiresAt === 0 && a.expiresAt !== 0) return 1;
+    return b.paidAmount - a.paidAmount;
+  });
+}
+
+export function PromoBillboard() {
+  const [promos, setPromos] = useState<EnrichedPromotion[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchPromotions()
+      .then(enrichPromotions)
+      .then((enriched) => {
+        if (cancelled) return;
+        setPromos(sortPromos(enriched));
+        setLoaded(true);
+      })
+      .catch(() => { if (!cancelled) setLoaded(true); });
+    return () => { cancelled = true; };
+  }, []);
+
+  // Reserve the 36px of vertical space even while promos are loading so the
+  // rest of the page doesn't reflow when the billboard pops in (avoids CLS).
+  // When no promos are active, we collapse to null so the bar doesn't occupy
+  // space unnecessarily.
+  if (!loaded) {
+    return (
+      <div
+        aria-hidden
+        style={{
+          height: 36,
+          backgroundColor: "var(--accent)",
+          borderBottom: "2px solid var(--border-hard)",
+        }}
+      />
+    );
+  }
+
+  if (promos.length === 0) return null;
+
+  const lap: EnrichedPromotion[] = [];
+  while (lap.length < MIN_ITEMS_PER_LAP) {
+    lap.push(...promos);
+  }
+
+  return (
+    <div
+      className="promo-billboard-marquee"
+      style={{
+        backgroundColor: "var(--accent)",
+        borderBottom: "2px solid var(--border-hard)",
+        overflow: "hidden",
+        position: "relative",
+        height: 36,
+      }}
+      role="region"
+      aria-label="Sponsored projects"
+    >
+      <style dangerouslySetInnerHTML={{ __html: SCOPED_CSS }} />
+
+      {/* Anchored SPONSORED tag — stays pinned left while the marquee scrolls underneath */}
+      <div
+        style={{
+          position: "absolute",
+          left: 0,
+          top: 0,
+          bottom: 0,
+          zIndex: 2,
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          padding: "0 12px 0 14px",
+          backgroundColor: "var(--accent)",
+          color: "#0F0F0F",
+          fontSize: 10,
+          fontWeight: 800,
+          textTransform: "uppercase",
+          letterSpacing: "0.05em",
+          borderRight: "2px solid var(--border-hard)",
+          whiteSpace: "nowrap",
+        }}
+      >
+        <Flame size={12} />
+        <span>Sponsored</span>
+      </div>
+
+      {/* Marquee track — two copies side-by-side, translated -50% for a seamless loop */}
+      <div
+        className="promo-billboard-track"
+        style={{
+          display: "flex",
+          width: "max-content",
+          height: "100%",
+          paddingLeft: 112, // clears the anchored SPONSORED tag
+          animation: "promo-billboard-scroll 45s linear infinite",
+          willChange: "transform",
+        }}
+      >
+        <PromoLap items={lap} />
+        <PromoLap items={lap} ariaHidden />
+      </div>
+    </div>
+  );
+}
+
+function PromoLap({ items, ariaHidden = false }: { items: EnrichedPromotion[]; ariaHidden?: boolean }) {
+  return (
+    <ul
+      aria-hidden={ariaHidden}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 28,
+        margin: 0,
+        padding: "0 28px 0 0",
+        listStyle: "none",
+        whiteSpace: "nowrap",
+        height: "100%",
+      }}
+    >
+      {items.map((promo, idx) => (
+        <PromoItem key={`${promo.id}-${idx}`} promo={promo} />
+      ))}
+    </ul>
+  );
+}
+
+function PromoItem({ promo }: { promo: EnrichedPromotion }) {
+  const title = promo.project?.title || promo.projectName;
+  const href = promo.project?.live_url
+    ?? (promo.author ? `/profile/${promo.author.username}` : `/explore?q=${encodeURIComponent(promo.projectName)}`);
+  const isExternal = !!promo.project?.live_url;
+
+  const byline = promo.author ? `by @${promo.author.username}` : "sponsored";
+
+  const linkStyle: React.CSSProperties = {
+    color: "#0F0F0F",
+    textDecoration: "none",
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 8,
+    fontSize: 12,
+    fontWeight: 700,
+    textTransform: "uppercase",
+    letterSpacing: "0.02em",
+  };
+
+  const inner = (
+    <>
+      <span style={{ fontWeight: 900 }}>{title}</span>
+      <span style={{ opacity: 0.7, fontWeight: 600 }}>{byline}</span>
+      <span
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 4,
+          fontWeight: 900,
+          textDecoration: "underline",
+          textUnderlineOffset: 3,
+        }}
+      >
+        View Live <ExternalLink size={11} />
+      </span>
+    </>
+  );
+
+  return (
+    <li style={{ display: "inline-flex", alignItems: "center" }}>
+      {isExternal ? (
+        <a href={href} target="_blank" rel="noopener noreferrer" style={linkStyle}>
+          {inner}
+        </a>
+      ) : (
+        <a href={href} style={linkStyle}>{inner}</a>
+      )}
+    </li>
+  );
+}

--- a/src/lib/featured-promotions.ts
+++ b/src/lib/featured-promotions.ts
@@ -1,0 +1,184 @@
+// Shared fetchers & types for on-chain Featured promotions.
+// Used by both the full <FeaturedCarousel /> and the compact <HeroFeaturedStrip />
+// so both components render the same promo data without duplicating contract
+// decoding or Supabase enrichment.
+
+import { createClient } from "@/lib/supabase/client";
+import { CHAIN_CONFIGS } from "@/lib/chains-config";
+import { isEVMChain } from "@/lib/chains-config";
+import type { BadgeLevel } from "@/lib/types/database";
+
+// Base chain defaults — promotions are always read from the Base contract.
+const BASE_CONFIG = CHAIN_CONFIGS.base;
+const CONTRACT_ADDR = isEVMChain(BASE_CONFIG) ? BASE_CONFIG.contractAddr : "";
+const BASE_RPC = isEVMChain(BASE_CONFIG) ? BASE_CONFIG.rpc : "";
+
+// Function selectors (keccak256 of signature, first 4 bytes) — read-only calls
+const SEL = {
+  getActivePromotions: "0x5fd2d522",
+};
+
+export type Promotion = {
+  id: number;
+  promoter: string;
+  projectId: string;
+  projectName: string;
+  expiresAt: number;
+  paidAmount: number;
+};
+
+export type EnrichedProject = {
+  id: string;
+  title: string;
+  description: string;
+  tech_stack: string[];
+  live_url: string | null;
+  github_url: string | null;
+  image_url: string | null;
+  verified: boolean;
+  quality_score: number;
+  endorsement_count: number;
+};
+
+export type EnrichedAuthor = {
+  username: string;
+  display_name: string | null;
+  avatar_url: string | null;
+  vibe_score: number;
+  streak: number;
+  badge_level: BadgeLevel;
+};
+
+export type EnrichedPromotion = Promotion & {
+  project: EnrichedProject | null;
+  author: EnrichedAuthor | null;
+};
+
+// ── ABI-free hex decoders for getActivePromotions return tuple ──
+
+function decodeAddress(hex: string): string {
+  return "0x" + hex.slice(24);
+}
+
+function decodeUint256(hex: string): number {
+  return parseInt(hex, 16);
+}
+
+function decodeStringArray(data: string, arrayWordOffset: number): string[] {
+  const arrayDataOffset = decodeUint256(data.slice(arrayWordOffset * 64, arrayWordOffset * 64 + 64)) * 2;
+  const count = decodeUint256(data.slice(arrayDataOffset, arrayDataOffset + 64));
+  const strings: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const strRelOffset = decodeUint256(data.slice(arrayDataOffset + 64 + i * 64, arrayDataOffset + 64 + i * 64 + 64)) * 2;
+    const strAbsOffset = arrayDataOffset + 64 + strRelOffset;
+    const strLen = decodeUint256(data.slice(strAbsOffset, strAbsOffset + 64));
+    const strBytes = data.slice(strAbsOffset + 64, strAbsOffset + 64 + strLen * 2);
+    let s = "";
+    for (let j = 0; j < strBytes.length; j += 2) {
+      s += String.fromCharCode(parseInt(strBytes.slice(j, j + 2), 16));
+    }
+    strings.push(s);
+  }
+  return strings;
+}
+
+function decodeUint256Array(data: string, arrayWordOffset: number): number[] {
+  const arrayDataOffset = decodeUint256(data.slice(arrayWordOffset * 64, arrayWordOffset * 64 + 64)) * 2;
+  const count = decodeUint256(data.slice(arrayDataOffset, arrayDataOffset + 64));
+  const nums: number[] = [];
+  for (let i = 0; i < count; i++) {
+    nums.push(decodeUint256(data.slice(arrayDataOffset + 64 + i * 64, arrayDataOffset + 64 + i * 64 + 64)));
+  }
+  return nums;
+}
+
+function decodeAddressArray(data: string, arrayWordOffset: number): string[] {
+  const arrayDataOffset = decodeUint256(data.slice(arrayWordOffset * 64, arrayWordOffset * 64 + 64)) * 2;
+  const count = decodeUint256(data.slice(arrayDataOffset, arrayDataOffset + 64));
+  const addrs: string[] = [];
+  for (let i = 0; i < count; i++) {
+    addrs.push(decodeAddress(data.slice(arrayDataOffset + 64 + i * 64, arrayDataOffset + 64 + i * 64 + 64)));
+  }
+  return addrs;
+}
+
+export async function fetchPromotions(): Promise<Promotion[]> {
+  try {
+    const res = await fetch(BASE_RPC, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "eth_call",
+        params: [{ to: CONTRACT_ADDR, data: SEL.getActivePromotions }, "latest"],
+      }),
+    });
+    const json = await res.json();
+    if (!json.result || json.result === "0x" || json.result.length < 10) return [];
+
+    const data = json.result.slice(2); // strip 0x
+    if (data.length < 384) return []; // minimum 6 offset words = 6*64 chars
+
+    // Return type: (uint256[] ids, address[] promoters, string[] projectIds, string[] projectNames, uint256[] expiresAts, uint256[] paidAmounts)
+    const ids = decodeUint256Array(data, 0);
+    if (ids.length === 0) return [];
+
+    const promoters = decodeAddressArray(data, 1);
+    const projectIds = decodeStringArray(data, 2);
+    const projectNames = decodeStringArray(data, 3);
+    const expiresAts = decodeUint256Array(data, 4);
+    const paidAmounts = decodeUint256Array(data, 5);
+
+    return ids.map((id, i) => ({
+      id,
+      promoter: promoters[i],
+      projectId: projectIds[i],
+      projectName: projectNames[i],
+      expiresAt: expiresAts[i],
+      paidAmount: paidAmounts[i],
+    }));
+  } catch {
+    return [];
+  }
+}
+
+export async function enrichPromotions(promotions: Promotion[]): Promise<EnrichedPromotion[]> {
+  if (promotions.length === 0) return [];
+  try {
+    const supabase = createClient();
+    const projectIds = [...new Set(promotions.map((p) => p.projectId))];
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: projects } = await (supabase as any)
+      .from("projects")
+      .select("id, title, description, tech_stack, live_url, github_url, image_url, verified, quality_score, endorsement_count, user_id")
+      .in("id", projectIds);
+
+    const projectMap = new Map<string, EnrichedProject & { user_id: string }>();
+    for (const p of projects || []) {
+      projectMap.set(p.id, p);
+    }
+
+    const userIds = [...new Set((projects || []).map((p: { user_id: string }) => p.user_id))];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: users } = await (supabase as any)
+      .from("users")
+      .select("id, username, display_name, avatar_url, vibe_score, streak, badge_level")
+      .in("id", userIds);
+
+    const userMap = new Map<string, EnrichedAuthor>();
+    for (const u of users || []) {
+      userMap.set(u.id, u);
+    }
+
+    return promotions.map((promo) => {
+      const proj = projectMap.get(promo.projectId) || null;
+      const author = proj ? userMap.get(proj.user_id) || null : null;
+      return { ...promo, project: proj, author };
+    });
+  } catch {
+    // Graceful fallback — show basic promotion data
+    return promotions.map((promo) => ({ ...promo, project: null, author: null }));
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a slim **infinite-marquee billboard** at the very top of every page so paid promotions get above-the-fold visibility site-wide (not just homepage). The sponsored carousel was at ~1688px on desktop — effectively invisible to most visitors.
- Renames the Live Activity streak label from `coded` → `vibed`. "Coded" implied a commit happened; streak entries are just "was active today," and "vibed" fits the brand vocabulary (VibeTalent, Vibe Score, Top Vibers) while being a single word.
- Extracts `fetchPromotions` / `enrichPromotions` / types to a shared `lib/featured-promotions.ts` so the billboard and the existing `FeaturedCarousel` share one data path (-168 lines from `featured-carousel.tsx`).
- Minor hero padding tightening on `/` (`pt-24 pb-20 → pt-14 pb-10`) so the fold sits closer to the content.

## How the billboard behaves
- **Single horizontal row**, 36px tall, auto-scrolls right-to-left
- **Pauses on hover**, respects `prefers-reduced-motion`
- **Reserves 36px while loading** → no CLS when promos pop in
- **Collapses to `null` when no active promos** — clean hero for the zero-state
- Duplicates the lap for a seamless `translateX(-50%)` loop; duplicate is `aria-hidden` so screen readers don't double-announce
- Each item links to the project's `live_url` (target=_blank) or the author profile as fallback

## "vibed" rename — made end-to-end consistent
The audit caught that `api/feed/route.ts` was still emitting `message: "logged a day of coding"` as a payload, and `feed/page.tsx` was using that exact string as a grouping-dedup sentinel. The rename was UI-only, but the sentinel would silently break if the API payload ever changed. Fix: drop the `message` field from streak items entirely (the UI derives the label from `type === "streak"`), and remove the matching sentinel from the client grouping logic.

## Why inline styles in `PromoBillboard`
Tailwind v4's compile pipeline was dropping the custom classes we added to `globals.css` — `.promo-billboard-track` showed up in source but never landed in the emitted stylesheet, which made the two marquee laps stack vertically instead of side-by-side. Making the component fully self-contained (all styles inline + a scoped `<style>` block for the keyframes / hover-pause / reduced-motion rules) sidesteps the issue and keeps the component portable. Noted as a pattern-level follow-up in the code audit.

## Files
- `src/components/ui/promo-billboard.tsx` (new) — the marquee component
- `src/lib/featured-promotions.ts` (new) — shared fetch + enrich + types
- `src/app/layout.tsx` — mounts `<PromoBillboard />` above `<Navbar />`
- `src/app/page.tsx` — hero padding tightening (order of LiveActivityFeed → FeaturedCarousel preserved)
- `src/components/ui/featured-carousel.tsx` — imports from the shared lib, no JSX changes
- `src/components/ui/live-activity-feed.tsx` — `"coded"` → `"vibed"`
- `src/app/feed/page.tsx` — `"logged a day of coding"` → `"vibed"` + sentinel cleanup
- `src/app/api/feed/route.ts` — stopped emitting the redundant `message` field for streak items

## Test plan
- [ ] Billboard renders at the very top of `/`, `/explore`, `/leaderboard`, any profile page
- [ ] Auto-scrolls horizontally right-to-left, pauses on hover
- [ ] Clicking a promo item opens the project's live URL in a new tab
- [ ] Reserved 36px on first paint → no layout shift when promos load
- [ ] With zero active promos the billboard is not visible at all
- [ ] Homepage Live Activity shows "vibed" (not "coded") for streak entries
- [ ] `/feed` page shows "vibed" and doesn't double-count messages inside grouped items
- [ ] `prefers-reduced-motion: reduce` → animation disabled, content still readable
- [ ] `npx tsc --noEmit` clean (done)

## Follow-ups (not in this PR)
- Cache `fetchPromotions` across navigations (currently re-fires on every layout mount; noted in the audit)
- Replace the hand-rolled ABI hex decoders in `featured-promotions.ts` with viem's `decodeAbiParameters`

🤖 Generated with [Claude Code](https://claude.com/claude-code)