### PR TITLE
fix: bust profile cache on endorsement so vibe_score updates instantly

### DIFF
--- a/src/app/api/endorsements/route.ts
+++ b/src/app/api/endorsements/route.ts
@@ -1,7 +1,28 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath, revalidateTag } from "next/cache";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { endorsementsLimiter, getIP, checkRateLimit } from "@/lib/rate-limit";
 import { createAdminClient } from "@/lib/supabase/admin";
+
+// Bust cached profile data for the project owner so their new vibe_score
+// shows up immediately instead of waiting for the 60s/1h cache to expire.
+async function revalidateOwnerProfile(ownerId: string) {
+  try {
+    const adminSb = createAdminClient();
+    const { data: owner } = await adminSb
+      .from("users")
+      .select("username")
+      .eq("id", ownerId)
+      .single();
+
+    if (owner?.username) {
+      revalidateTag(`user-${owner.username}`, { expire: 0 });
+      revalidatePath(`/profile/${owner.username}`);
+    }
+  } catch (err) {
+    console.error("Failed to revalidate owner profile:", err);
+  }
+}
 
 /**
  * Project Endorsements API
@@ -207,6 +228,9 @@ export async function POST(req: NextRequest) {
         console.error("Failed to update endorsement cache:", updateErr);
       }
 
+      // Invalidate the owner's profile cache so the +5 vibe_score shows up right away
+      await revalidateOwnerProfile(project.user_id);
+
       return NextResponse.json({ success: true, count: count || 0 });
     }
   } catch {
@@ -253,6 +277,17 @@ export async function DELETE(req: NextRequest) {
 
       if (updateErr) {
         console.error("Failed to update endorsement cache:", updateErr);
+      }
+
+      // Look up the project owner so we can bust their profile cache
+      const { data: project } = await adminSb
+        .from("projects")
+        .select("user_id")
+        .eq("id", project_id)
+        .single();
+
+      if (project?.user_id) {
+        await revalidateOwnerProfile(project.user_id);
       }
 
       return NextResponse.json({ success: true, count: count || 0 });

--- a/src/lib/supabase/server-queries.ts
+++ b/src/lib/supabase/server-queries.ts
@@ -229,7 +229,7 @@ export const fetchUserByUsernameCached = (username: string) =>
   unstable_cache(
     () => _fetchUserByUsername(username),
     [`user-${username}`],
-    { revalidate: 60 }
+    { revalidate: 60, tags: [`user-${username}`] }
   )();
 
 export const fetchStreakLogsCached = (userId: string) =>


### PR DESCRIPTION
## Summary

Endorsing a project correctly triggers the Postgres trigger that recalculates the project owner's `vibe_score` (+5 per endorsement), but the profile page continued to show the old score for up to **1 hour** after an endorsement.

Two caching layers were stacking:

1. **Profile page ISR**: `export const revalidate = 3600` (1 hour) on `src/app/profile/[username]/page.tsx`
2. **`unstable_cache` on `fetchUserByUsernameCached`**: `revalidate: 60` with no tags, so impossible to invalidate by tag

Neither was busted by the endorsement API — it just wrote to the DB and returned.

## Fix

- Add `tags: ['user-<username>']` to `fetchUserByUsernameCached` so the data cache can be targeted
- In `POST /api/endorsements` and `DELETE /api/endorsements`, look up the project owner's username and call:
  - `revalidateTag('user-<username>', { expire: 0 })` → busts the data cache
  - `revalidatePath('/profile/<username>')` → busts the full route cache

## Test plan

- [ ] After merge + deploy, endorse someone's project
- [ ] Their profile should show `vibe_score + 5` on the very next page load
- [ ] Remove the endorsement → score drops by 5 immediately
- [ ] Self-endorsement / duplicate endorsement error paths still return correct status codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved cache invalidation for user profiles to ensure profile information updates reliably when endorsements are created or removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->