### PR TITLE
fix: stop promo marquee on expiry + filter wallet modal by chain

### DIFF
--- a/src/components/ui/featured-carousel.tsx
+++ b/src/components/ui/featured-carousel.tsx
@@ -548,13 +548,19 @@ function PromoteForm({ onSuccess, isLoggedIn }: { onSuccess: () => void; isLogge
       window.location.href = "/auth/login?redirect=/&reason=promote";
       return;
     }
-    // If already authenticated with Privy but no wallet connected,
-    // use connectWallet() instead of login() to avoid "already logged in" error
+    // Filter the Privy wallet modal to the chain the user has selected, so
+    // picking SOLANA surfaces Phantom/Backpack/Solflare first (and ONLY),
+    // and picking BASE surfaces EVM wallets only. Both login() and
+    // connectWallet() accept walletChainType for this purpose.
+    const wantsSolana = isSolanaChain(getChainConfig(selectedChain));
+    const walletChainType = wantsSolana ? "solana-only" : "ethereum-only";
+
     if (privyAuthenticated) {
-      const wantsSolana = isSolanaChain(getChainConfig(selectedChain));
-      connectWallet(wantsSolana ? { walletChainType: "solana-only" } : undefined);
+      // Already have a Privy session but no wallet connected — use
+      // connectWallet() instead of login() to avoid "already logged in" error.
+      connectWallet({ walletChainType });
     } else {
-      privyLogin();
+      privyLogin({ walletChainType });
     }
   }
 

--- a/src/components/ui/featured-carousel.tsx
+++ b/src/components/ui/featured-carousel.tsx
@@ -12,7 +12,7 @@ import { VibeScore } from "@/components/ui/vibe-score";
 import { BadgeDisplay } from "@/components/ui/badge-display";
 import { CHAIN_CONFIGS, SUPPORTED_CHAINS, DEFAULT_CHAIN, getChainConfig, isEVMChain, isSolanaChain } from "@/lib/chains-config";
 import { buildSolanaUSDCTransfer, confirmSolanaTransaction, signatureToString } from "@/lib/solana-payment";
-import { fetchPromotions, enrichPromotions, type EnrichedPromotion } from "@/lib/featured-promotions";
+import { fetchPromotions, enrichPromotions, msUntilNextExpiry, type EnrichedPromotion } from "@/lib/featured-promotions";
 
 // Base chain defaults (for fetching promotions — always read from Base contract)
 const BASE_CONFIG = CHAIN_CONFIGS.base;
@@ -109,12 +109,19 @@ export function FeaturedCarousel() {
     });
   }, []);
 
+  const expiryTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
   const refreshPromotions = useCallback(() => {
     fetchPromotions()
       .then((raw) => enrichPromotions(raw))
       .then((enriched) => {
         setPromotions(enriched);
         setLoading(false);
+        // Re-fetch when the soonest promotion expires so the carousel drops
+        // back to its empty state without a manual refresh.
+        if (expiryTimerRef.current) clearTimeout(expiryTimerRef.current);
+        const delay = msUntilNextExpiry(enriched);
+        if (delay !== null) expiryTimerRef.current = setTimeout(refreshPromotions, delay);
       })
       .catch(() => {
         setPromotions([]);
@@ -125,6 +132,9 @@ export function FeaturedCarousel() {
   useEffect(() => {
     if (!authChecked) return;
     refreshPromotions();
+    return () => {
+      if (expiryTimerRef.current) clearTimeout(expiryTimerRef.current);
+    };
   }, [authChecked, refreshPromotions]);
 
   // Auto-advance every 8s, pause on hover

--- a/src/components/ui/featured-carousel.tsx
+++ b/src/components/ui/featured-carousel.tsx
@@ -109,19 +109,12 @@ export function FeaturedCarousel() {
     });
   }, []);
 
-  const expiryTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-
   const refreshPromotions = useCallback(() => {
     fetchPromotions()
       .then((raw) => enrichPromotions(raw))
       .then((enriched) => {
         setPromotions(enriched);
         setLoading(false);
-        // Re-fetch when the soonest promotion expires so the carousel drops
-        // back to its empty state without a manual refresh.
-        if (expiryTimerRef.current) clearTimeout(expiryTimerRef.current);
-        const delay = msUntilNextExpiry(enriched);
-        if (delay !== null) expiryTimerRef.current = setTimeout(refreshPromotions, delay);
       })
       .catch(() => {
         setPromotions([]);
@@ -132,10 +125,16 @@ export function FeaturedCarousel() {
   useEffect(() => {
     if (!authChecked) return;
     refreshPromotions();
-    return () => {
-      if (expiryTimerRef.current) clearTimeout(expiryTimerRef.current);
-    };
   }, [authChecked, refreshPromotions]);
+
+  // Re-fetch at the moment the soonest promotion expires so the carousel
+  // drops back to its empty state without a manual refresh.
+  useEffect(() => {
+    const delay = msUntilNextExpiry(promotions);
+    if (delay === null) return;
+    const timer = setTimeout(refreshPromotions, delay);
+    return () => clearTimeout(timer);
+  }, [promotions, refreshPromotions]);
 
   // Auto-advance every 8s, pause on hover
   useEffect(() => {

--- a/src/components/ui/promo-billboard.tsx
+++ b/src/components/ui/promo-billboard.tsx
@@ -11,7 +11,7 @@
 
 import { useState, useEffect } from "react";
 import { Flame, ExternalLink } from "lucide-react";
-import { fetchPromotions, enrichPromotions, type EnrichedPromotion } from "@/lib/featured-promotions";
+import { fetchPromotions, enrichPromotions, msUntilNextExpiry, type EnrichedPromotion } from "@/lib/featured-promotions";
 
 // Pad the promo list up to this count so the marquee row feels full even when
 // only 1-2 projects are currently promoted. Each copy is rendered once per
@@ -48,15 +48,28 @@ export function PromoBillboard() {
 
   useEffect(() => {
     let cancelled = false;
-    fetchPromotions()
-      .then(enrichPromotions)
-      .then((enriched) => {
-        if (cancelled) return;
-        setPromos(sortPromos(enriched));
-        setLoaded(true);
-      })
-      .catch(() => { if (!cancelled) setLoaded(true); });
-    return () => { cancelled = true; };
+    let expiryTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const load = () => {
+      fetchPromotions()
+        .then(enrichPromotions)
+        .then((enriched) => {
+          if (cancelled) return;
+          setPromos(sortPromos(enriched));
+          setLoaded(true);
+          // Re-fetch the moment the soonest promotion expires so the marquee
+          // disappears without requiring a page refresh.
+          const delay = msUntilNextExpiry(enriched);
+          if (delay !== null) expiryTimer = setTimeout(load, delay);
+        })
+        .catch(() => { if (!cancelled) setLoaded(true); });
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+      if (expiryTimer) clearTimeout(expiryTimer);
+    };
   }, []);
 
   // Reserve the 36px of vertical space even while promos are loading so the

--- a/src/lib/featured-promotions.ts
+++ b/src/lib/featured-promotions.ts
@@ -130,17 +130,38 @@ export async function fetchPromotions(): Promise<Promotion[]> {
     const expiresAts = decodeUint256Array(data, 4);
     const paidAmounts = decodeUint256Array(data, 5);
 
-    return ids.map((id, i) => ({
-      id,
-      promoter: promoters[i],
-      projectId: projectIds[i],
-      projectName: projectNames[i],
-      expiresAt: expiresAts[i],
-      paidAmount: paidAmounts[i],
-    }));
+    // Drop anything the contract still lists but that has already expired.
+    // expiresAt === 0 means lifetime; otherwise it's a Unix timestamp in seconds.
+    const nowSec = Math.floor(Date.now() / 1000);
+
+    return ids
+      .map((id, i) => ({
+        id,
+        promoter: promoters[i],
+        projectId: projectIds[i],
+        projectName: projectNames[i],
+        expiresAt: expiresAts[i],
+        paidAmount: paidAmounts[i],
+      }))
+      .filter((p) => p.expiresAt === 0 || p.expiresAt > nowSec);
   } catch {
     return [];
   }
+}
+
+// Milliseconds until the earliest non-lifetime promotion expires, plus a 1s
+// buffer so the re-fetch runs *after* the expiry clock has rolled over.
+// Returns null if every promotion is lifetime or already expired.
+// Capped at ~23 days to stay well under setTimeout's 2^31-1 ms ceiling —
+// callers that outlive the cap will simply re-schedule on the next tick.
+export function msUntilNextExpiry(promos: Pick<Promotion, "expiresAt">[]): number | null {
+  const nowMs = Date.now();
+  const future = promos
+    .filter((p) => p.expiresAt !== 0)
+    .map((p) => p.expiresAt * 1000)
+    .filter((ms) => ms > nowMs);
+  if (future.length === 0) return null;
+  return Math.min(Math.min(...future) - nowMs + 1000, 2_000_000_000);
 }
 
 export async function enrichPromotions(promotions: Promotion[]): Promise<EnrichedPromotion[]> {


### PR DESCRIPTION
## Summary

Two small but product-visible fixes bundled together:

**1. Stop the top-of-site promo marquee animation when the promotion expires** (commit 2)
- `getActivePromotions()` on the contract can return rows past their `expiresAt`. Added a client-side filter in `fetchPromotions` that drops anything with `expiresAt <= now` (lifetime = `expiresAt === 0` still passes).
- Both `PromoBillboard` and `FeaturedCarousel` previously fetched once on mount — if a user stayed on the page past expiry, the marquee kept scrolling. Both now schedule a re-fetch at the soonest expiry via `msUntilNextExpiry()`, so the marquee auto-vanishes and the carousel flips to its empty state with no page refresh needed.

**2. Filter the Privy wallet modal by the selected chain** (commit 1)
- Picking **SOLANA** now surfaces Phantom/Backpack/Solflare only.
- Picking **BASE** surfaces EVM wallets only.
- Works both on first login and on subsequent `connectWallet()` calls when a Privy session already exists (previously the first-login path didn't pass `walletChainType`).

## Test plan

- [ ] With an active promo on-chain, open `/` — marquee and carousel both show it (baseline).
- [ ] Switch system clock forward past the promo's `expiresAt` (or wait) — marquee disappears and carousel shows "No active promotions yet — be the first!" without reloading.
- [ ] On the Promote form, pick **Solana** → Connect Wallet → modal only shows Phantom/Backpack/Solflare.
- [ ] Pick **Base** → Connect Wallet → modal only shows EVM wallets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Promotions now automatically refresh when they expire.

* **Bug Fixes**
  * Expired promotions are filtered out from displays.

* **Improvements**
  * Enhanced wallet connection logic with improved chain type detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->