### PR TITLE
fix: cap project description at 500 chars + show-more toggle

### DIFF
--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -55,8 +55,8 @@ export async function POST(request: NextRequest) {
     if (title.length > 100) {
       return NextResponse.json({ error: "title must be 100 characters or less" }, { status: 400 });
     }
-    if (description.length > 2000) {
-      return NextResponse.json({ error: "description must be 2000 characters or less" }, { status: 400 });
+    if (description.length > 500) {
+      return NextResponse.json({ error: "description must be 500 characters or less" }, { status: 400 });
     }
 
     // live_url is required and must be HTTPS
@@ -75,7 +75,7 @@ export async function POST(request: NextRequest) {
     const { data, error } = await (supabase as any).from("projects").insert({
       user_id: user.id,
       title: title.trim().slice(0, 100),
-      description: description.trim().slice(0, 2000),
+      description: description.trim().slice(0, 500),
       tech_stack: Array.isArray(tech_stack) ? tech_stack.slice(0, 20).map((t: string) => String(t).trim().slice(0, 50)) : [],
       live_url: live_url || null,
       github_url: github_url || null,

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -610,6 +610,10 @@ export default function DashboardPage() {
       setProjectError("Description must be at least 10 characters.");
       return;
     }
+    if (projectForm.description.length > 500) {
+      setProjectError("Description must be 500 characters or less.");
+      return;
+    }
     if (!projectForm.live_url || !projectForm.live_url.trim()) {
       setProjectError("Live URL is required. Every project must have a deployed link.");
       return;
@@ -725,6 +729,10 @@ export default function DashboardPage() {
 
     if (projectForm.description.length < 10) {
       setProjectError("Description must be at least 10 characters.");
+      return;
+    }
+    if (projectForm.description.length > 500) {
+      setProjectError("Description must be 500 characters or less.");
       return;
     }
     if (!projectForm.live_url || !projectForm.live_url.trim()) {
@@ -1079,13 +1087,19 @@ export default function DashboardPage() {
                 onChange={(e) => setProjectForm({ ...projectForm, title: e.target.value })}
                 className="input-brutal"
               />
-              <textarea
-                placeholder="Description"
-                value={projectForm.description}
-                onChange={(e) => setProjectForm({ ...projectForm, description: e.target.value })}
-                rows={2}
-                className="input-brutal resize-none"
-              />
+              <div>
+                <textarea
+                  placeholder="Description"
+                  value={projectForm.description}
+                  onChange={(e) => setProjectForm({ ...projectForm, description: e.target.value })}
+                  rows={2}
+                  maxLength={500}
+                  className="input-brutal resize-none"
+                />
+                <div className="mt-1 text-right text-xs font-bold text-[var(--text-muted)]">
+                  {projectForm.description.length}/500
+                </div>
+              </div>
               <input
                 type="text"
                 placeholder="Tech stack (comma separated)"

--- a/src/components/profile/profile-project-card.tsx
+++ b/src/components/profile/profile-project-card.tsx
@@ -37,7 +37,9 @@ export function ProfileProjectCard({ project, verified = false, isOwner = false 
   const [showReportMenu, setShowReportMenu] = useState(false);
   const [reported, setReported] = useState(() => !!getReportData(project.id));
   const [undoing, setUndoing] = useState(false);
+  const [expanded, setExpanded] = useState(false);
   const reportRef = useRef<HTMLDivElement>(null);
+  const isLongDescription = (project.description?.length ?? 0) > 280;
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
@@ -188,7 +190,20 @@ export function ProfileProjectCard({ project, verified = false, isOwner = false 
         </div>
       </div>
 
-      <p className="text-[0.9rem] text-[var(--text-secondary)] font-medium flex-grow">{project.description}</p>
+      <div className="flex-grow">
+        <p className={`text-[0.9rem] text-[var(--text-secondary)] font-medium ${isLongDescription && !expanded ? "line-clamp-4" : ""}`}>
+          {project.description}
+        </p>
+        {isLongDescription && (
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); setExpanded(!expanded); }}
+            className="mt-1 text-xs font-bold uppercase text-[var(--accent)] hover:underline"
+          >
+            {expanded ? "Show less" : "Show more"}
+          </button>
+        )}
+      </div>
 
       <div className="mt-2">
         <EndorseButton projectId={project.id} initialCount={project.endorsement_count} isOwner={isOwner} />


### PR DESCRIPTION
## Summary
- Lower server-side description cap from 2000 → 500 chars on `POST /api/projects`
- Add client-side guard + `maxLength={500}` + live `N/500` counter on the dashboard add/edit form
- Profile card now clamps descriptions > 280 chars to 4 lines with a "Show more / Show less" toggle

## Why
One verbose project (e.g. ObsiFlow, 1298 chars) was stretching a card to ~3× the height of its neighbors and breaking the grid row. Existing long descriptions stay in the DB intact — they just collapse by default.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` passes on changed files
- [x] Profile page renders: short descriptions unchanged, 289-char card clamps + shows toggle, click expands/collapses correctly
- [ ] Dashboard form: typing past 500 chars is blocked by `maxLength`; paste > 500 triggers the guard
- [ ] Create a new project with a 600-char description via API → 400 with "description must be 500 characters or less"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Project description maximum length reduced to 500 characters (previously 2000).

* **New Features**
  * Added character counter displaying real-time character usage for project descriptions.
  * Added "Show more"/"Show less" toggle for long project descriptions in project cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->