### PR TITLE
fix: streak freezes actually preserve the streak chain

### DIFF
--- a/src/app/api/cron/reset-freezes/route.ts
+++ b/src/app/api/cron/reset-freezes/route.ts
@@ -5,6 +5,12 @@ import { createAdminClient } from "@/lib/supabase/admin";
  * Cron job: Reset streak freezes for all users on the 1st of every month.
  * Restores each user's freeze allowance to 2 and resets the used counter.
  *
+ * This route is pulled in by the daily orchestrator, so we gate it to the 1st
+ * of the month here. Without the gate, freezes would reset every day and the
+ * "2 per month" allowance would effectively be unlimited.
+ *
+ * Override the date check with ?force=1 for one-off manual resets.
+ *
  * Protected by CRON_SECRET to prevent unauthorized access.
  */
 export async function GET(req: NextRequest) {
@@ -14,6 +20,15 @@ export async function GET(req: NextRequest) {
     if (authHeader !== `Bearer ${cronSecret}`) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
+  }
+
+  const force = req.nextUrl.searchParams.get("force") === "1";
+  const dayOfMonth = new Date().getUTCDate();
+  if (!force && dayOfMonth !== 1) {
+    return NextResponse.json({
+      message: `Skipped — freezes only reset on the 1st of the month (today is day ${dayOfMonth}). Pass ?force=1 to override.`,
+      count: 0,
+    });
   }
 
   const supabase = createAdminClient();

--- a/src/app/api/cron/reset-freezes/route.ts
+++ b/src/app/api/cron/reset-freezes/route.ts
@@ -15,6 +15,13 @@ import { createAdminClient } from "@/lib/supabase/admin";
  */
 export async function GET(req: NextRequest) {
   const cronSecret = process.env.CRON_SECRET;
+  // Fail closed: in production a missing CRON_SECRET would otherwise make this
+  // route unauthenticated and any caller could wipe everyone's freeze counters
+  // (especially via ?force=1).
+  if (!cronSecret && process.env.NODE_ENV === "production") {
+    console.error("CRON_SECRET is not configured");
+    return NextResponse.json({ error: "Cron secret not configured" }, { status: 500 });
+  }
   if (cronSecret) {
     const authHeader = req.headers.get("authorization");
     if (authHeader !== `Bearer ${cronSecret}`) {

--- a/src/app/api/cron/reset-streaks/route.ts
+++ b/src/app/api/cron/reset-streaks/route.ts
@@ -73,13 +73,35 @@ export async function GET(req: NextRequest) {
       (u: { streak_freezes_remaining: number }) => (u.streak_freezes_remaining ?? 0) <= 0
     );
 
-    // Consume a freeze for users who have freezes remaining
+    // Consume a freeze for users who have freezes remaining.
+    // CRITICAL: the user's `streak` column is recomputed from `streak_logs` by
+    // the AFTER INSERT trigger on that table. Decrementing the freeze counter
+    // alone doesn't preserve the streak — the chain still has a gap, and the
+    // very next streak_log insert (or project add) will recompute streak to
+    // the broken value. So we also upsert a synthetic streak_log for yesterday
+    // so `update_user_streak()` sees an unbroken chain.
     if (usersToFreeze.length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const syntheticLogs = usersToFreeze.map((u: any) => ({
+        user_id: u.id,
+        activity_date: yesterdayStr,
+      }));
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { error: logsInsertError } = await (supabase as any)
+        .from("streak_logs")
+        .upsert(syntheticLogs, { onConflict: "user_id,activity_date", ignoreDuplicates: true });
+
+      if (logsInsertError) {
+        console.error("Failed to insert synthetic freeze logs:", logsInsertError);
+        return NextResponse.json({ error: "Failed to preserve streak chain" }, { status: 500 });
+      }
+
       for (const u of usersToFreeze) {
         const { error: freezeError } = await supabase
           .from("users")
           .update({
-            streak_freezes_remaining: (u.streak_freezes_remaining ?? 2) - 1,
+            streak_freezes_remaining: Math.max(0, (u.streak_freezes_remaining ?? 2) - 1),
             streak_freezes_used: (u.streak_freezes_used ?? 0) + 1,
           })
           .eq("id", u.id);

--- a/src/app/api/cron/reset-streaks/route.ts
+++ b/src/app/api/cron/reset-streaks/route.ts
@@ -11,8 +11,14 @@ import { createAdminClient } from "@/lib/supabase/admin";
  * Protected by CRON_SECRET to prevent unauthorized access.
  */
 export async function GET(req: NextRequest) {
-  // Verify cron secret (skip in development)
+  // Verify cron secret (skip in development). Fail closed in production so a
+  // missing CRON_SECRET doesn't leave this route unauthenticated — it mutates
+  // streak state and returns usernames.
   const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret && process.env.NODE_ENV === "production") {
+    console.error("CRON_SECRET is not configured");
+    return NextResponse.json({ error: "Cron secret not configured" }, { status: 500 });
+  }
   if (cronSecret) {
     const authHeader = req.headers.get("authorization");
     if (authHeader !== `Bearer ${cronSecret}`) {
@@ -80,6 +86,14 @@ export async function GET(req: NextRequest) {
     // very next streak_log insert (or project add) will recompute streak to
     // the broken value. So we also upsert a synthetic streak_log for yesterday
     // so `update_user_streak()` sees an unbroken chain.
+    //
+    // We only want to consume a freeze for users who actually needed the
+    // synthetic log — if a user logged activity in the race window between the
+    // SELECT and the upsert, the insert would be ignored and we'd still burn
+    // their freeze for nothing. Using .select() on the upsert returns only the
+    // rows that were actually inserted (ignoreDuplicates skips the rest), so
+    // we use that as the authoritative set to decrement.
+    const frozenUsernames: string[] = [];
     if (usersToFreeze.length > 0) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const syntheticLogs = usersToFreeze.map((u: any) => ({
@@ -88,16 +102,22 @@ export async function GET(req: NextRequest) {
       }));
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { error: logsInsertError } = await (supabase as any)
+      const { data: insertedLogs, error: logsInsertError } = await (supabase as any)
         .from("streak_logs")
-        .upsert(syntheticLogs, { onConflict: "user_id,activity_date", ignoreDuplicates: true });
+        .upsert(syntheticLogs, { onConflict: "user_id,activity_date", ignoreDuplicates: true })
+        .select("user_id");
 
       if (logsInsertError) {
         console.error("Failed to insert synthetic freeze logs:", logsInsertError);
         return NextResponse.json({ error: "Failed to preserve streak chain" }, { status: 500 });
       }
 
+      const actuallyFrozenIds = new Set(
+        (insertedLogs || []).map((l: { user_id: string }) => l.user_id)
+      );
+
       for (const u of usersToFreeze) {
+        if (!actuallyFrozenIds.has(u.id)) continue;
         const { error: freezeError } = await supabase
           .from("users")
           .update({
@@ -108,12 +128,13 @@ export async function GET(req: NextRequest) {
 
         if (freezeError) {
           console.error(`Failed to consume freeze for ${u.username}:`, freezeError);
+          continue;
         }
+        frozenUsernames.push(u.username);
       }
-      console.log(
-        `Consumed streak freezes for ${usersToFreeze.length} users:`,
-        usersToFreeze.map((u: { username: string }) => u.username)
-      );
+      if (frozenUsernames.length > 0) {
+        console.log(`Consumed streak freezes for ${frozenUsernames.length} users:`, frozenUsernames);
+      }
     }
 
     // Reset streaks to 0 for users without freezes
@@ -136,11 +157,11 @@ export async function GET(req: NextRequest) {
     }
 
     return NextResponse.json({
-      message: `Reset ${usersToReset.length} stale streaks, froze ${usersToFreeze.length} streaks`,
+      message: `Reset ${usersToReset.length} stale streaks, froze ${frozenUsernames.length} streaks`,
       reset: usersToReset.length,
-      froze: usersToFreeze.length,
+      froze: frozenUsernames.length,
       resetUsers: usersToReset.map((u: { username: string }) => u.username),
-      frozeUsers: usersToFreeze.map((u: { username: string }) => u.username),
+      frozeUsers: frozenUsernames,
     });
   } catch (error) {
     console.error("Cron job error:", error);


### PR DESCRIPTION
## Summary

Two independent bugs made the \"2 freezes per month\" promise meaningless:

### Bug 1 — `reset-streaks` consumed the freeze but broke the chain
The cron decremented \`streak_freezes_remaining\` but never wrote a \`streak_logs\` row for the missed day. The \`users.streak\` column isn't authoritative — it's recomputed by \`update_user_streak()\` from \`streak_logs\` on every insert (via the \`on_streak_log_insert\` trigger). So the very next time the user logged activity (or a project-related trigger fired), the chain still had a gap and the streak reset to 1.

**Fix:** when consuming a freeze, also upsert a synthetic \`streak_log\` for yesterday so \`update_user_streak()\` sees an unbroken chain. Upsert with \`ignoreDuplicates: true\` in case a log slipped in after the SELECT.

### Bug 2 — `reset-freezes` ran every day, not monthly
\`/api/cron/reset-freezes\` is pulled in unconditionally by the daily orchestrator and it reset every user to \`2/0\` every morning. That made the allowance effectively unlimited, which, combined with Bug 1, meant freezes were both never exhausted *and* never actually protected a streak.

**Fix:** gate the actual reset to UTC day-of-month == 1. Added \`?force=1\` query param for manual overrides.

## Test plan
- [ ] Skip a day with 2 freezes available → next log continues the streak, \`streak_freezes_remaining\` drops to 1, a synthetic \`streak_logs\` row exists for the missed day
- [ ] Skip a day with 0 freezes remaining → streak resets to 0
- [ ] Hit `/api/cron/reset-freezes` on any day ≠ the 1st → returns \"Skipped\", no changes
- [ ] Hit `/api/cron/reset-freezes?force=1` → resets all users
- [ ] Hit `/api/cron/reset-freezes` on the 1st of the month → resets all users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced streak freeze handling with improved counter logic to prevent invalid states
  * Added comprehensive activity logging for streak freezes to ensure accurate user records

<!-- end of auto-generated comment: release notes by coderabbit.ai -->