### PR TITLE
fix: refresh Supabase auth cookie on every route

### DIFF
--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -10,12 +10,6 @@ export async function updateSession(request: NextRequest) {
     return NextResponse.next({ request });
   }
 
-  // Only run the expensive auth check on protected routes
-  const isProtectedRoute = request.nextUrl.pathname.startsWith("/dashboard");
-  if (!isProtectedRoute) {
-    return NextResponse.next({ request });
-  }
-
   let supabaseResponse = NextResponse.next({ request });
 
   const supabase = createServerClient(
@@ -39,16 +33,21 @@ export async function updateSession(request: NextRequest) {
     }
   );
 
-  // Try getUser() first (validates JWT, refreshes token if needed).
-  // Fall back to getSession() (local cookie read) if the network call fails,
-  // so we don't redirect authenticated users to login on transient errors.
+  // getUser() must run on every route so Supabase can refresh the auth cookie
+  // before it expires. Gating this on /dashboard/* used to leave the cookie
+  // stale whenever users sat on /projects, /feed, /profile, etc., and they'd
+  // get bounced to login on the next refresh.
   const {
     data: { user },
     error,
   } = await supabase.auth.getUser();
 
-  if (!user) {
-    // If getUser() failed due to a network/server error, check session locally
+  // Only protected routes redirect to login; other routes still benefit from
+  // the cookie refresh above.
+  const isProtectedRoute = request.nextUrl.pathname.startsWith("/dashboard");
+  if (isProtectedRoute && !user) {
+    // Fall back to getSession() (local cookie read) on transient network
+    // errors so we don't bounce authenticated users on flakiness.
     if (error) {
       const {
         data: { session },

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -28,6 +28,11 @@ export async function middleware(request: NextRequest) {
   return await updateSession(request);
 }
 
+// Run middleware on every non-static route so Supabase can refresh the auth
+// cookie on each navigation. Restricting this to "/" and "/dashboard/*"
+// caused sessions to silently expire on other pages.
 export const config = {
-  matcher: ["/", "/dashboard/:path*"],
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)$).*)",
+  ],
 };


### PR DESCRIPTION
## Summary

- Session-refresh middleware only ran on `/` and `/dashboard/*`. If a user sat on any other page (`/projects`, `/feed`, `/profile`, `/settings`, etc.) long enough for the JWT to expire (~1h), the cookie went stale and the next page refresh bounced them to `/auth/login`.
- `updateSession()` now runs `getUser()` on every non-static route so Supabase can rotate the auth cookie on each navigation. The redirect-to-login behavior stays gated on `/dashboard/*` so public pages remain public.
- Matcher broadened to everything except `_next/static`, `_next/image`, `favicon.ico`, and common static asset extensions.

## Test plan

- [ ] Log in, navigate to `/projects` or `/feed`, wait for JWT expiry (or shorten token lifetime in Supabase to test faster), refresh → user stays logged in
- [ ] Log out, hit `/dashboard` → still redirects to `/auth/login`
- [ ] Hit a public page logged out (`/`, `/explore`, `/feed`) → no redirect
- [ ] OAuth login flow via `/auth/callback` still works end-to-end
- [ ] No regression in the "Vibe Talent" logo / home navigation behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication session handling to refresh credentials more frequently, reducing the likelihood of unexpected logouts.
  * Enhanced middleware routing to cover additional pages, ensuring consistent authentication status checks across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->