### PR TITLE
fix: scroll to top when clicking logo on home page

### DIFF
--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -170,7 +170,18 @@ export function Navbar() {
       }}
     >
       <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6">
-        <Link href="/" className="flex items-center gap-2.5">
+        <Link
+          href="/"
+          className="flex items-center gap-2.5"
+          onClick={(e) => {
+            // Next's <Link> is a no-op when the href matches the current
+            // route, so clicking the logo on "/" wouldn't scroll back up.
+            if (pathname === "/") {
+              e.preventDefault();
+              window.scrollTo({ top: 0, behavior: "smooth" });
+            }
+          }}
+        >
           <Image src="/logo.png" alt="VibeTalent" width={36} height={36} className="object-contain" />
           <span className="text-lg font-extrabold uppercase tracking-tight" style={{ color: "var(--foreground)" }}>
             Vibe Talent


### PR DESCRIPTION
## Summary

- Clicking the **Vibe Talent** logo / wordmark in the navbar while already on `/` did nothing — Next's `<Link>` no-ops when the href matches the current route, so there was no navigation and no scroll.
- Added an `onClick` that calls `e.preventDefault()` and `window.scrollTo({ top: 0, behavior: "smooth" })` when `pathname === "/"`.
- Navigations from every other route are unchanged — Next's default scroll-restore on route change still handles them.

## Test plan

- [ ] Land on `/`, scroll down, click the logo → smooth scroll to top
- [ ] Land on `/`, scroll down, click the "VIBE TALENT" wordmark → smooth scroll to top
- [ ] From `/feed` (or any non-home route), click the logo → navigates to `/` and lands at top (unchanged)
- [ ] Mobile: logo on `/` still triggers scroll-to-top (same Link element is used)

🤖 Generated with [Claude Code](https://claude.com/claude-code)