### PR TITLE
fix: log activity reverting on refresh (UTC/local date mismatch)

### DIFF
--- a/src/app/api/streak/route.ts
+++ b/src/app/api/streak/route.ts
@@ -20,7 +20,30 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const today = new Date().toISOString().split("T")[0];
+    // Accept the client's local YYYY-MM-DD so the stored date matches what
+    // the dashboard queries (also local). Defaulting to UTC here caused
+    // evening-timezone users to log for tomorrow's UTC date, and on refresh
+    // the dashboard's local-date query wouldn't find the row — the UI would
+    // revert to "Log Activity" even though the row was in the DB.
+    const body = await request.json().catch(() => ({}));
+    const clientDate =
+      typeof (body as { date?: unknown })?.date === "string"
+        ? (body as { date: string }).date
+        : null;
+
+    let activityDate = new Date().toISOString().split("T")[0];
+    if (clientDate && /^\d{4}-\d{2}-\d{2}$/.test(clientDate)) {
+      const clientMs = new Date(`${clientDate}T00:00:00Z`).getTime();
+      const utcMidnight = new Date();
+      utcMidnight.setUTCHours(0, 0, 0, 0);
+      const dayDiff = Math.abs(clientMs - utcMidnight.getTime()) / 86_400_000;
+      // Accept only when within 1 day of server UTC — that window covers
+      // every real-world timezone (UTC-12 to UTC+14) and caps clock-spoofing
+      // backfill to a single adjacent day.
+      if (!Number.isNaN(dayDiff) && dayDiff <= 1) {
+        activityDate = clientDate;
+      }
+    }
 
     // Use admin client for the insert: user is already authenticated above, and
     // we pin user_id to user.id so there's no privilege escalation. Admin client
@@ -29,7 +52,7 @@ export async function POST(request: NextRequest) {
     const admin = createAdminClient() as any;
     const { error } = await admin
       .from("streak_logs")
-      .upsert({ user_id: user.id, activity_date: today }, { onConflict: "user_id,activity_date" });
+      .upsert({ user_id: user.id, activity_date: activityDate }, { onConflict: "user_id,activity_date" });
 
     if (error) {
       console.error("Failed to log streak:", error);
@@ -38,7 +61,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({
       success: true,
-      activity_date: today,
+      activity_date: activityDate,
       message: "Activity logged successfully",
     });
   } catch (err) {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -570,6 +570,7 @@ export default function DashboardPage() {
       res = await fetch("/api/streak", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ date: today }),
       });
     } catch (err) {
       console.error("Failed to log activity (network):", err);


### PR DESCRIPTION
## Summary

Clicking **Log Activity** on `/dashboard` updated the UI (streak bumped, "DONE FOR TODAY" card shown) but a page refresh silently reverted everything — the big "Log Activity" button came back and the streak snapped to its previous value. This is what the user was reporting when they said "it tells me to log activity again" after refresh.

## Root cause

The write and read were using different date reference frames:

- **Write** — [src/app/api/streak/route.ts:23](src/app/api/streak/route.ts) used `new Date().toISOString().split("T")[0]` → always **UTC** day.
- **Read** — [src/app/dashboard/page.tsx:525-526](src/app/dashboard/page.tsx#L525-L526) built `YYYY-MM-DD` from `getFullYear()/getMonth()/getDate()` → **local** day.

Anyone logging activity in their local evening (when UTC has already rolled over) stored a row for "tomorrow's" UTC date. On refresh, the local-today query didn't find it, so `setTodayLogged(true)` never fired and the UI reverted. The streak number also snapped back because the +1 was only optimistic client state — the server `calculateStreak` call hadn't seen the new row yet under the local-date lens.

## Fix

- Client now includes its local `YYYY-MM-DD` in the POST body.
- Server accepts it when it parses cleanly **and** is within ±1 day of server UTC. That window covers every real-world timezone (UTC-12 to UTC+14) while capping any clock-spoofing backfill to a single adjacent day.
- When the body is missing/invalid, we still fall back to server UTC, so any existing callers keep working.

## Test plan

- [ ] Log in, go to `/dashboard`, click **Log Activity** → card flips to "DONE FOR TODAY"
- [ ] **Refresh the page** → stays on "DONE FOR TODAY", streak does not revert ← the bug this fixes
- [ ] Log again (same calendar day) → upsert no-ops, no error, no duplicate row
- [ ] At local midnight, card flips back to "Log Activity" (countdown `useEffect` already handles this)
- [ ] Clicking after midnight writes a new row for the new local day

## Notes

- I can't simulate a logged-in dashboard session in the local preview, so the end-to-end "log → refresh → state persists" check has to happen on the preview deploy. TypeScript + the local-date logic match on both sides — confident the mismatch is gone.
- This is a **separate, real** bug from [PR #139](https://github.com/unknownking07/vibe-talent/pull/139). I initially misread the user report as an auth issue and shipped the cookie-refresh fix first; that one is still a valid fix but not what was causing the log-activity revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)