### PR TITLE
fix: quality-score popover stacking + dashboard dot not clearing after log

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -303,8 +303,11 @@ html {
 }
 
 /* Stagger children */
+/* Why: `backwards` (not `both`) clears the transform after the animation ends, so
+   cards don't retain `translateY(0)` — which would create a stacking context and
+   trap popovers (e.g. quality-score info) behind later siblings. */
 .stagger-children > * {
-  animation: fadeInUp 0.25s ease-out both;
+  animation: fadeInUp 0.25s ease-out backwards;
 }
 .stagger-children > *:nth-child(1) { animation-delay: 0ms; }
 .stagger-children > *:nth-child(2) { animation-delay: 30ms; }

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -129,9 +129,15 @@ export function Navbar() {
     };
     window.addEventListener("profile-updated", handleProfileUpdated);
 
+    // Refresh the Dashboard-link dot when notifications change (e.g. after
+    // the user logs activity, which marks streak_warning notifications read).
+    // Without this, the dot only clears on a hard refresh.
+    window.addEventListener("notifications-updated", checkUnread);
+
     return () => {
       subscription.unsubscribe();
       window.removeEventListener("profile-updated", handleProfileUpdated);
+      window.removeEventListener("notifications-updated", checkUnread);
     };
   }, [checkUnread]);
 


### PR DESCRIPTION
## Summary
- **Quality-score popover going behind adjacent cards on the home page:** `.stagger-children > *` used `animation-fill-mode: both`, which retained `transform: translateY(0)` after the fade-in. Any non-`none` transform creates a new stacking context, so each card became its own context and the popover's `z-50` could not escape. Switched fill-mode to `backwards` — the intro animation still runs, but the transform clears when it ends.
- **Dashboard dot not clearing after logging activity:** the dashboard already marks `streak_warning` notifications read and dispatches a `notifications-updated` window event. `NotificationBell` listened for it; `Navbar` did not, so its `hasUnreadNotifications` stayed stale until a hard refresh. Added the same listener (and cleanup) to the Navbar effect.

## Test plan
- [x] Home page → click the `i` icon on a featured project card → popover renders on top of adjacent cards (verified via `elementFromPoint` + visual check)
- [ ] As a logged-in user with an unread `streak_warning` notification: visit `/dashboard` → dot shows on the Dashboard nav link → click **Log Activity** → dot disappears instantly without refresh
- [ ] Regression: stagger fade-in animation on home-page cards still looks right

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed staggered animation rendering for improved visual consistency
  * Notification indicator now updates automatically when new notifications arrive

<!-- end of auto-generated comment: release notes by coderabbit.ai -->