### PR TITLE
refactor: centralize siteUrl + getSiteUrl() helper (PR-A)

### DIFF
--- a/src/app/.well-known/ai-plugin.json/route.ts
+++ b/src/app/.well-known/ai-plugin.json/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { getSiteUrl } from "@/lib/seo";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -7,8 +8,7 @@ const corsHeaders = {
 };
 
 export async function GET() {
-  const siteUrl =
-    process.env.NEXT_PUBLIC_SITE_URL || "https://www.vibetalent.work";
+  const siteUrl = getSiteUrl();
 
   const manifest = {
     schema_version: "v1",

--- a/src/app/api/cron/daily/route.ts
+++ b/src/app/api/cron/daily/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getSiteUrl } from "@/lib/seo";
 
 /**
  * Daily orchestrator cron — fans out to individual cron job routes.
@@ -16,7 +17,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://www.vibetalent.work";
+  const siteUrl = getSiteUrl();
   const headers = { authorization: `Bearer ${cronSecret}` };
 
   const jobs = [

--- a/src/app/api/hire/route.ts
+++ b/src/app/api/hire/route.ts
@@ -78,23 +78,23 @@ export async function POST(req: NextRequest) {
     // Fire-and-forget: send email notification to builder
     const serviceClient = createAdminClient();
     serviceClient.auth.admin.getUserById(builder_id).then(({ data: userData }) => {
-      if (userData?.user?.email) {
-        // Look up the builder's username
-        serviceClient
-          .from("users")
-          .select("username")
-          .eq("id", builder_id)
-          .single()
-          .then(({ data: builderData }) => {
-            sendHireNotification({
-              builderEmail: userData.user!.email!,
-              builderUsername: builderData?.username || "builder",
-              senderName: nameClean,
-              message: msgClean,
-              requestId: data.id,
-            }).catch(console.error);
-          });
-      }
+      const builderEmail = userData?.user?.email;
+      if (!builderEmail) return;
+      // Look up the builder's username
+      serviceClient
+        .from("users")
+        .select("username")
+        .eq("id", builder_id)
+        .single()
+        .then(({ data: builderData }) => {
+          sendHireNotification({
+            builderEmail,
+            builderUsername: builderData?.username || "builder",
+            senderName: nameClean,
+            message: msgClean,
+            requestId: data.id,
+          }).catch(console.error);
+        });
     }).catch(console.error);
 
     return NextResponse.json({ success: true, id: data.id });

--- a/src/app/api/hire/route.ts
+++ b/src/app/api/hire/route.ts
@@ -86,15 +86,18 @@ export async function POST(req: NextRequest) {
         .select("username")
         .eq("id", builder_id)
         .single()
-        .then(({ data: builderData }) => {
-          sendHireNotification({
-            builderEmail,
-            builderUsername: builderData?.username || "builder",
-            senderName: nameClean,
-            message: msgClean,
-            requestId: data.id,
-          }).catch(console.error);
-        });
+        .then(
+          ({ data: builderData }) => {
+            sendHireNotification({
+              builderEmail,
+              builderUsername: builderData?.username || "builder",
+              senderName: nameClean,
+              message: msgClean,
+              requestId: data.id,
+            }).catch(console.error);
+          },
+          console.error
+        );
     }).catch(console.error);
 
     return NextResponse.json({ success: true, id: data.id });

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -305,15 +305,18 @@ export async function POST(req: NextRequest) {
         .select("username")
         .eq("id", builder_id)
         .single()
-        .then(({ data: builderData }) => {
-          sendReviewNotificationEmail({
-            email: builderEmail,
-            username: builderData?.username || "builder",
-            reviewerName: nameClean,
-            rating: ratingNum,
-            comment: commentClean,
-          }).catch(console.error);
-        });
+        .then(
+          ({ data: builderData }) => {
+            sendReviewNotificationEmail({
+              email: builderEmail,
+              username: builderData?.username || "builder",
+              reviewerName: nameClean,
+              rating: ratingNum,
+              comment: commentClean,
+            }).catch(console.error);
+          },
+          console.error
+        );
     }).catch(console.error);
 
     return NextResponse.json({ success: true, id: data.id });

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -298,22 +298,22 @@ export async function POST(req: NextRequest) {
     // Fire-and-forget: email notification to the builder
     const adminSb = createAdminClient();
     adminSb.auth.admin.getUserById(builder_id).then(({ data: userData }) => {
-      if (userData?.user?.email) {
-        adminSb
-          .from("users")
-          .select("username")
-          .eq("id", builder_id)
-          .single()
-          .then(({ data: builderData }) => {
-            sendReviewNotificationEmail({
-              email: userData.user!.email!,
-              username: builderData?.username || "builder",
-              reviewerName: nameClean,
-              rating: ratingNum,
-              comment: commentClean,
-            }).catch(console.error);
-          });
-      }
+      const builderEmail = userData?.user?.email;
+      if (!builderEmail) return;
+      adminSb
+        .from("users")
+        .select("username")
+        .eq("id", builder_id)
+        .single()
+        .then(({ data: builderData }) => {
+          sendReviewNotificationEmail({
+            email: builderEmail,
+            username: builderData?.username || "builder",
+            reviewerName: nameClean,
+            rating: ratingNum,
+            comment: commentClean,
+          }).catch(console.error);
+        });
     }).catch(console.error);
 
     return NextResponse.json({ success: true, id: data.id });

--- a/src/app/api/v1/hire/route.ts
+++ b/src/app/api/v1/hire/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { getSiteUrl } from "@/lib/seo";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -121,9 +122,7 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const siteUrl =
-      process.env.NEXT_PUBLIC_SITE_URL || "https://www.vibetalent.work";
-    const chatUrl = `${siteUrl}/hire/${data.id}/chat`;
+    const chatUrl = `${getSiteUrl()}/hire/${data.id}/chat`;
 
     return NextResponse.json(
       {

--- a/src/app/api/v1/openapi/route.ts
+++ b/src/app/api/v1/openapi/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { getSiteUrl } from "@/lib/seo";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -7,8 +8,7 @@ const corsHeaders = {
 };
 
 export async function GET() {
-  const siteUrl =
-    process.env.NEXT_PUBLIC_SITE_URL || "https://www.vibetalent.work";
+  const siteUrl = getSiteUrl();
 
   const spec = {
     openapi: "3.0.0",

--- a/src/app/auth/__tests__/callback.test.ts
+++ b/src/app/auth/__tests__/callback.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeNext } from "../callback/route";
+
+describe("sanitizeNext (auth callback open-redirect guard)", () => {
+  it("falls back to /dashboard for null", () => {
+    expect(sanitizeNext(null)).toBe("/dashboard");
+  });
+
+  it("falls back to /dashboard for empty string", () => {
+    expect(sanitizeNext("")).toBe("/dashboard");
+  });
+
+  it("accepts a simple relative path", () => {
+    expect(sanitizeNext("/dashboard")).toBe("/dashboard");
+    expect(sanitizeNext("/settings?tab=emails")).toBe("/settings?tab=emails");
+    expect(sanitizeNext("/profile/abhi")).toBe("/profile/abhi");
+  });
+
+  it("rejects missing-slash inputs that enable subdomain takeover", () => {
+    // ".evil.com" + origin would produce "https://www.vibetalent.work.evil.com"
+    expect(sanitizeNext(".evil.com")).toBe("/dashboard");
+    expect(sanitizeNext("dashboard")).toBe("/dashboard");
+    expect(sanitizeNext("evil.com")).toBe("/dashboard");
+  });
+
+  it("rejects protocol-relative URLs", () => {
+    expect(sanitizeNext("//evil.com")).toBe("/dashboard");
+    expect(sanitizeNext("//evil.com/path")).toBe("/dashboard");
+  });
+
+  it("rejects backslash tricks (Windows-style paths browsers may normalize)", () => {
+    expect(sanitizeNext("/\\evil.com")).toBe("/dashboard");
+    expect(sanitizeNext("/path\\evil.com")).toBe("/dashboard");
+  });
+
+  it("rejects embedded control characters (CR/LF header injection)", () => {
+    expect(sanitizeNext("/dashboard\r\nLocation: https://evil.com")).toBe("/dashboard");
+    expect(sanitizeNext("/dashboard\nevil")).toBe("/dashboard");
+    expect(sanitizeNext("/dashboard\tevil")).toBe("/dashboard");
+    expect(sanitizeNext("/dashboard\x00")).toBe("/dashboard");
+    expect(sanitizeNext("/dashboard\x7F")).toBe("/dashboard");
+  });
+
+  it("rejects leading whitespace or control chars", () => {
+    expect(sanitizeNext(" /dashboard")).toBe("/dashboard");
+    expect(sanitizeNext("\t/dashboard")).toBe("/dashboard");
+    expect(sanitizeNext("\n/dashboard")).toBe("/dashboard");
+  });
+
+  it("rejects absolute https URLs", () => {
+    expect(sanitizeNext("https://evil.com")).toBe("/dashboard");
+    expect(sanitizeNext("http://evil.com")).toBe("/dashboard");
+  });
+});

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -3,10 +3,23 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 
+// Only allow same-origin relative paths. Rejects:
+//   - missing/empty leading slash ("dashboard", ".evil.com")
+//   - protocol-relative URLs ("//evil.com")
+//   - backslash tricks browsers may normalize to "/" ("/\evil.com")
+//   - embedded schemes
+function sanitizeNext(raw: string | null): string {
+  if (!raw) return "/dashboard";
+  if (!raw.startsWith("/")) return "/dashboard";
+  if (raw.startsWith("//") || raw.startsWith("/\\")) return "/dashboard";
+  if (raw.includes("\\")) return "/dashboard";
+  return raw;
+}
+
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
-  const next = searchParams.get("next") ?? "/dashboard";
+  const next = sanitizeNext(searchParams.get("next"));
 
   if (code) {
     const cookieStore = await cookies();

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -8,8 +8,12 @@ import { cookies } from "next/headers";
 //   - protocol-relative URLs ("//evil.com")
 //   - backslash tricks browsers may normalize to "/" ("/\evil.com")
 //   - embedded schemes
-function sanitizeNext(raw: string | null): string {
+//   - any ASCII control chars (U+0000–U+001F, U+007F) including CR/LF — blocks
+//     header-injection shapes like "/dashboard\r\nLocation: https://evil.com"
+const CONTROL_CHARS = /[\x00-\x1F\x7F]/;
+export function sanitizeNext(raw: string | null): string {
   if (!raw) return "/dashboard";
+  if (CONTROL_CHARS.test(raw)) return "/dashboard";
   if (!raw.startsWith("/")) return "/dashboard";
   if (raw.startsWith("//") || raw.startsWith("/\\")) return "/dashboard";
   if (raw.includes("\\")) return "/dashboard";

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import Image from "next/image";
 import { createClient } from "@/lib/supabase/client";
 import { fetchStreakLogs } from "@/lib/supabase/queries";
+import { siteUrl } from "@/lib/seo";
 import { BadgeDisplay } from "@/components/ui/badge-display";
 import type { UserWithSocials } from "@/lib/types/database";
 import { StreakCounter } from "@/components/ui/streak-counter";
@@ -1416,7 +1417,6 @@ export default function DashboardPage() {
 
         <div className="flex flex-col gap-2">
           {(() => {
-            const siteUrl = "https://www.vibetalent.work";
             const encodedName = encodeURIComponent(user.username);
             const badgeImgUrl = `${siteUrl}/api/badge/${encodedName}`;
             const profileUrl = `${siteUrl}/profile/${encodedName}`;

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -368,7 +368,7 @@ export default function DashboardPage() {
   };
 
   const handleGithubSync = async () => {
-    if (syncingGithub) return;
+    if (syncingGithub || !user) return;
     setSyncingGithub(true);
     setGithubSyncResult(null);
     try {
@@ -380,7 +380,7 @@ export default function DashboardPage() {
         setGithubSyncResult(`\u2713 Synced! Found ${data.events_found} events, logged ${data.dates_logged} day(s).`);
         await reloadUser();
         // Update heatmap
-        const streakData = await fetchStreakLogs(user!.id);
+        const streakData = await fetchStreakLogs(user.id);
         setHeatmapData(streakData);
       } else if (data.error) {
         setGithubSyncResult(`\u26A0 ${data.error}`);

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -1,5 +1,6 @@
 import { fetchAllUsersCached } from "@/lib/supabase/server-queries";
 import { ExploreContent } from "@/components/explore/explore-content";
+import { siteUrl } from "@/lib/seo";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -7,12 +8,12 @@ export const metadata: Metadata = {
   description:
     "Discover talented vibe coders. Filter by badge level, streak, tech stack, and more to find the perfect builder for your project.",
   alternates: {
-    canonical: "https://www.vibetalent.work/explore",
+    canonical: `${siteUrl}/explore`,
   },
   openGraph: {
     title: "Explore Vibe Coders — VibeTalent",
     description: "Browse developers by streak, skills, and vibe score. Find the perfect builder for your project.",
-    url: "https://www.vibetalent.work/explore",
+    url: `${siteUrl}/explore`,
     siteName: "VibeTalent",
     type: "website",
   },
@@ -39,8 +40,8 @@ export default async function ExplorePage() {
       {
         "@type": "BreadcrumbList",
         itemListElement: [
-          { "@type": "ListItem", position: 1, name: "Home", item: "https://www.vibetalent.work" },
-          { "@type": "ListItem", position: 2, name: "Explore Talent", item: "https://www.vibetalent.work/explore" },
+          { "@type": "ListItem", position: 1, name: "Home", item: siteUrl },
+          { "@type": "ListItem", position: 2, name: "Explore Talent", item: `${siteUrl}/explore` },
         ],
       },
       {
@@ -52,7 +53,7 @@ export default async function ExplorePage() {
           "@type": "ListItem",
           position: i + 1,
           name: user.username,
-          url: `https://www.vibetalent.work/profile/${user.username}`,
+          url: `${siteUrl}/profile/${user.username}`,
         })),
       },
     ],

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -1,6 +1,6 @@
 import { fetchAllUsersCached } from "@/lib/supabase/server-queries";
 import { ExploreContent } from "@/components/explore/explore-content";
-import { siteUrl } from "@/lib/seo";
+import { siteUrl, buildBreadcrumbList } from "@/lib/seo";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -37,13 +37,10 @@ export default async function ExplorePage() {
   const jsonLd = {
     "@context": "https://schema.org",
     "@graph": [
-      {
-        "@type": "BreadcrumbList",
-        itemListElement: [
-          { "@type": "ListItem", position: 1, name: "Home", item: siteUrl },
-          { "@type": "ListItem", position: 2, name: "Explore Talent", item: `${siteUrl}/explore` },
-        ],
-      },
+      buildBreadcrumbList([
+        { name: "Home", path: "/" },
+        { name: "Explore Talent", path: "/explore" },
+      ]),
       {
         "@type": "ItemList",
         name: "VibeTalent Builders",

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,6 +1,6 @@
 import { fetchAllUsersCached } from "@/lib/supabase/server-queries";
 import { LeaderboardContent } from "@/components/leaderboard/leaderboard-content";
-import { siteUrl } from "@/lib/seo";
+import { siteUrl, buildBreadcrumbList } from "@/lib/seo";
 import { Trophy } from "lucide-react";
 import type { Metadata } from "next";
 
@@ -38,13 +38,10 @@ export default async function LeaderboardPage() {
   const jsonLd = {
     "@context": "https://schema.org",
     "@graph": [
-      {
-        "@type": "BreadcrumbList",
-        itemListElement: [
-          { "@type": "ListItem", position: 1, name: "Home", item: siteUrl },
-          { "@type": "ListItem", position: 2, name: "Leaderboard", item: `${siteUrl}/leaderboard` },
-        ],
-      },
+      buildBreadcrumbList([
+        { name: "Home", path: "/" },
+        { name: "Leaderboard", path: "/leaderboard" },
+      ]),
       {
         "@type": "ItemList",
         name: "VibeTalent Leaderboard",

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,5 +1,6 @@
 import { fetchAllUsersCached } from "@/lib/supabase/server-queries";
 import { LeaderboardContent } from "@/components/leaderboard/leaderboard-content";
+import { siteUrl } from "@/lib/seo";
 import { Trophy } from "lucide-react";
 import type { Metadata } from "next";
 
@@ -8,12 +9,12 @@ export const metadata: Metadata = {
   description:
     "See the top vibe coders ranked by vibe score, streak, and projects shipped. The most consistent builders on the platform.",
   alternates: {
-    canonical: "https://www.vibetalent.work/leaderboard",
+    canonical: `${siteUrl}/leaderboard`,
   },
   openGraph: {
     title: "Top Vibe Coders — VibeTalent Leaderboard",
     description: "See the top developers ranked by vibe score, coding streak, and projects shipped.",
-    url: "https://www.vibetalent.work/leaderboard",
+    url: `${siteUrl}/leaderboard`,
     siteName: "VibeTalent",
     type: "website",
   },
@@ -40,8 +41,8 @@ export default async function LeaderboardPage() {
       {
         "@type": "BreadcrumbList",
         itemListElement: [
-          { "@type": "ListItem", position: 1, name: "Home", item: "https://www.vibetalent.work" },
-          { "@type": "ListItem", position: 2, name: "Leaderboard", item: "https://www.vibetalent.work/leaderboard" },
+          { "@type": "ListItem", position: 1, name: "Home", item: siteUrl },
+          { "@type": "ListItem", position: 2, name: "Leaderboard", item: `${siteUrl}/leaderboard` },
         ],
       },
       {
@@ -53,7 +54,7 @@ export default async function LeaderboardPage() {
           "@type": "ListItem",
           position: i + 1,
           name: user.username,
-          url: `https://www.vibetalent.work/profile/${user.username}`,
+          url: `${siteUrl}/profile/${user.username}`,
         })),
       },
     ],

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import { ProjectCard } from "@/components/ui/project-card";
 import { HeroCTA } from "@/components/ui/hero-cta";
 import { TestimonialScroll } from "@/components/ui/testimonial-scroll";
 import { fetchHomepageDataCached } from "@/lib/supabase/server-queries";
+import { siteUrl } from "@/lib/seo";
 import { Flame, TrendingUp, Award, Zap, ArrowRight, Code2, Target, Users } from "lucide-react";
 
 export const revalidate = 60;
@@ -65,26 +66,26 @@ export default async function HomePage() {
             "@graph": [
               {
                 "@type": "WebSite",
-                "@id": "https://www.vibetalent.work/#website",
+                "@id": `${siteUrl}/#website`,
                 name: "VibeTalent",
-                url: "https://www.vibetalent.work",
+                url: siteUrl,
                 description:
                   "The marketplace for vibe coders who ship consistently. Find developers based on streaks, shipped projects, and vibe scores.",
-                publisher: { "@id": "https://www.vibetalent.work/#organization" },
+                publisher: { "@id": `${siteUrl}/#organization` },
                 potentialAction: {
                   "@type": "SearchAction",
-                  target: "https://www.vibetalent.work/explore?q={search_term_string}",
+                  target: `${siteUrl}/explore?q={search_term_string}`,
                   "query-input": "required name=search_term_string",
                 },
               },
               {
                 "@type": "Organization",
-                "@id": "https://www.vibetalent.work/#organization",
+                "@id": `${siteUrl}/#organization`,
                 name: "VibeTalent",
-                url: "https://www.vibetalent.work",
+                url: siteUrl,
                 logo: {
                   "@type": "ImageObject",
-                  url: "https://www.vibetalent.work/og-image-v2.jpg",
+                  url: `${siteUrl}/og-image-v2.jpg`,
                   width: 1200,
                   height: 630,
                 },

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from "next";
+import { siteUrl } from "@/lib/seo";
 
 export const metadata: Metadata = {
   title: "Privacy Policy",
   description: "VibeTalent privacy policy — how we collect, use, and protect your data.",
-  alternates: { canonical: "https://www.vibetalent.work/privacy" },
+  alternates: { canonical: `${siteUrl}/privacy` },
 };
 
 export default function PrivacyPolicyPage() {
@@ -11,8 +12,8 @@ export default function PrivacyPolicyPage() {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
     itemListElement: [
-      { "@type": "ListItem", position: 1, name: "Home", item: "https://www.vibetalent.work" },
-      { "@type": "ListItem", position: 2, name: "Privacy Policy", item: "https://www.vibetalent.work/privacy" },
+      { "@type": "ListItem", position: 1, name: "Home", item: siteUrl },
+      { "@type": "ListItem", position: 2, name: "Privacy Policy", item: `${siteUrl}/privacy` },
     ],
   };
 

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { siteUrl } from "@/lib/seo";
+import { siteUrl, buildBreadcrumbList } from "@/lib/seo";
 
 export const metadata: Metadata = {
   title: "Privacy Policy",
@@ -10,11 +10,10 @@ export const metadata: Metadata = {
 export default function PrivacyPolicyPage() {
   const breadcrumbLd = {
     "@context": "https://schema.org",
-    "@type": "BreadcrumbList",
-    itemListElement: [
-      { "@type": "ListItem", position: 1, name: "Home", item: siteUrl },
-      { "@type": "ListItem", position: 2, name: "Privacy Policy", item: `${siteUrl}/privacy` },
-    ],
+    ...buildBreadcrumbList([
+      { name: "Home", path: "/" },
+      { name: "Privacy Policy", path: "/privacy" },
+    ]),
   };
 
   return (

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,5 +1,6 @@
 import { fetchAllProjectsCached } from "@/lib/supabase/server-queries";
 import { ProjectsContent } from "@/components/projects/projects-content";
+import { siteUrl } from "@/lib/seo";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -7,12 +8,12 @@ export const metadata: Metadata = {
   description:
     "Browse all projects shipped by vibe coders. Filter by tech stack, quality score, and more to discover what builders are shipping.",
   alternates: {
-    canonical: "https://www.vibetalent.work/projects",
+    canonical: `${siteUrl}/projects`,
   },
   openGraph: {
     title: "All Projects — VibeTalent",
     description: "Browse all projects shipped by vibe coders. Discover what builders are shipping.",
-    url: "https://www.vibetalent.work/projects",
+    url: `${siteUrl}/projects`,
     siteName: "VibeTalent",
     type: "website",
   },
@@ -37,8 +38,8 @@ export default async function ProjectsPage() {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
     itemListElement: [
-      { "@type": "ListItem", position: 1, name: "Home", item: "https://www.vibetalent.work" },
-      { "@type": "ListItem", position: 2, name: "Projects", item: "https://www.vibetalent.work/projects" },
+      { "@type": "ListItem", position: 1, name: "Home", item: siteUrl },
+      { "@type": "ListItem", position: 2, name: "Projects", item: `${siteUrl}/projects` },
     ],
   };
 

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,6 +1,6 @@
 import { fetchAllProjectsCached } from "@/lib/supabase/server-queries";
 import { ProjectsContent } from "@/components/projects/projects-content";
-import { siteUrl } from "@/lib/seo";
+import { siteUrl, buildBreadcrumbList } from "@/lib/seo";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -36,11 +36,10 @@ export default async function ProjectsPage() {
 
   const jsonLd = {
     "@context": "https://schema.org",
-    "@type": "BreadcrumbList",
-    itemListElement: [
-      { "@type": "ListItem", position: 1, name: "Home", item: siteUrl },
-      { "@type": "ListItem", position: 2, name: "Projects", item: `${siteUrl}/projects` },
-    ],
+    ...buildBreadcrumbList([
+      { name: "Home", path: "/" },
+      { name: "Projects", path: "/projects" },
+    ]),
   };
 
   return (

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { useSearchParams } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { validateDisplayName, containsProfanity } from "@/lib/profanity";
+import { siteUrl } from "@/lib/seo";
 import type { UserWithSocials } from "@/lib/types/database";
 import { EmailPreferences } from "@/components/dashboard/email-preferences";
 import {
@@ -585,7 +586,7 @@ export default function SettingsPage() {
           <input
             type="text"
             readOnly
-            value={`${typeof window !== "undefined" ? window.location.origin : "https://www.vibetalent.work"}/auth/signup?ref=${user.username}`}
+            value={`${typeof window !== "undefined" ? window.location.origin : siteUrl}/auth/signup?ref=${user.username}`}
             className="input-brutal flex-1 text-sm font-mono"
           />
           <button

--- a/src/app/skill.md/route.ts
+++ b/src/app/skill.md/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
+import { getSiteUrl } from "@/lib/seo";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://www.vibetalent.work";
+const SITE_URL = getSiteUrl();
 
 const SKILL_MD = `# VibeTalent Skill
 

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from "next";
+import { siteUrl } from "@/lib/seo";
 
 export const metadata: Metadata = {
   title: "Terms of Service",
   description: "VibeTalent terms of service — rules and guidelines for using the platform.",
-  alternates: { canonical: "https://www.vibetalent.work/terms" },
+  alternates: { canonical: `${siteUrl}/terms` },
 };
 
 export default function TermsOfServicePage() {
@@ -11,8 +12,8 @@ export default function TermsOfServicePage() {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
     itemListElement: [
-      { "@type": "ListItem", position: 1, name: "Home", item: "https://www.vibetalent.work" },
-      { "@type": "ListItem", position: 2, name: "Terms of Service", item: "https://www.vibetalent.work/terms" },
+      { "@type": "ListItem", position: 1, name: "Home", item: siteUrl },
+      { "@type": "ListItem", position: 2, name: "Terms of Service", item: `${siteUrl}/terms` },
     ],
   };
 

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { siteUrl } from "@/lib/seo";
+import { siteUrl, buildBreadcrumbList } from "@/lib/seo";
 
 export const metadata: Metadata = {
   title: "Terms of Service",
@@ -10,11 +10,10 @@ export const metadata: Metadata = {
 export default function TermsOfServicePage() {
   const breadcrumbLd = {
     "@context": "https://schema.org",
-    "@type": "BreadcrumbList",
-    itemListElement: [
-      { "@type": "ListItem", position: 1, name: "Home", item: siteUrl },
-      { "@type": "ListItem", position: 2, name: "Terms of Service", item: `${siteUrl}/terms` },
-    ],
+    ...buildBreadcrumbList([
+      { name: "Home", path: "/" },
+      { name: "Terms of Service", path: "/terms" },
+    ]),
   };
 
   return (

--- a/src/components/ui/featured-carousel.tsx
+++ b/src/components/ui/featured-carousel.tsx
@@ -269,9 +269,9 @@ export function FeaturedCarousel() {
                         )}
 
                         {/* Tech stack */}
-                        {(promo.project?.tech_stack ?? []).length > 0 && (
+                        {promo.project?.tech_stack && promo.project.tech_stack.length > 0 && (
                           <div className="mt-3 flex flex-wrap gap-1.5">
-                            {promo.project!.tech_stack.slice(0, 5).map((tech) => (
+                            {promo.project.tech_stack.slice(0, 5).map((tech) => (
                               <span
                                 key={tech}
                                 className="px-2 py-0.5 text-[10px] font-bold uppercase text-[var(--text-tertiary)]"

--- a/src/lib/__tests__/seo.test.ts
+++ b/src/lib/__tests__/seo.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { getSiteUrl, siteUrl, buildBreadcrumbList } from "../seo";
+
+const ORIGINAL_ENV = process.env.NEXT_PUBLIC_SITE_URL;
+
+afterEach(() => {
+  if (ORIGINAL_ENV === undefined) {
+    delete process.env.NEXT_PUBLIC_SITE_URL;
+  } else {
+    process.env.NEXT_PUBLIC_SITE_URL = ORIGINAL_ENV;
+  }
+});
+
+describe("getSiteUrl", () => {
+  it("falls back to canonical siteUrl when env is unset", () => {
+    delete process.env.NEXT_PUBLIC_SITE_URL;
+    expect(getSiteUrl()).toBe(siteUrl);
+  });
+
+  it("falls back for empty string", () => {
+    process.env.NEXT_PUBLIC_SITE_URL = "";
+    expect(getSiteUrl()).toBe(siteUrl);
+  });
+
+  it("falls back for whitespace-only string", () => {
+    process.env.NEXT_PUBLIC_SITE_URL = "   ";
+    expect(getSiteUrl()).toBe(siteUrl);
+  });
+
+  it("falls back for non-URL garbage", () => {
+    process.env.NEXT_PUBLIC_SITE_URL = "not-a-url";
+    expect(getSiteUrl()).toBe(siteUrl);
+  });
+
+  it("falls back for non-http(s) protocols (ftp, javascript, file)", () => {
+    for (const bad of ["ftp://example.com", "javascript:alert(1)", "file:///etc/passwd"]) {
+      process.env.NEXT_PUBLIC_SITE_URL = bad;
+      expect(getSiteUrl()).toBe(siteUrl);
+    }
+  });
+
+  it("accepts a valid https URL and returns origin unchanged", () => {
+    process.env.NEXT_PUBLIC_SITE_URL = "https://staging.example.com";
+    expect(getSiteUrl()).toBe("https://staging.example.com");
+  });
+
+  it("strips trailing slash via .origin", () => {
+    process.env.NEXT_PUBLIC_SITE_URL = "https://staging.example.com/";
+    expect(getSiteUrl()).toBe("https://staging.example.com");
+  });
+
+  it("strips embedded path via .origin", () => {
+    process.env.NEXT_PUBLIC_SITE_URL = "https://staging.example.com/some/path";
+    expect(getSiteUrl()).toBe("https://staging.example.com");
+  });
+
+  it("accepts http URLs for local dev", () => {
+    process.env.NEXT_PUBLIC_SITE_URL = "http://localhost:3000";
+    expect(getSiteUrl()).toBe("http://localhost:3000");
+  });
+
+  it("trims surrounding whitespace before parsing", () => {
+    process.env.NEXT_PUBLIC_SITE_URL = "  https://staging.example.com  ";
+    expect(getSiteUrl()).toBe("https://staging.example.com");
+  });
+});
+
+describe("buildBreadcrumbList", () => {
+  it("builds a standalone BreadcrumbList with siteUrl for path '/'", () => {
+    const result = buildBreadcrumbList([
+      { name: "Home", path: "/" },
+      { name: "Privacy Policy", path: "/privacy" },
+    ]);
+
+    expect(result).toEqual({
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: "Home", item: siteUrl },
+        { "@type": "ListItem", position: 2, name: "Privacy Policy", item: `${siteUrl}/privacy` },
+      ],
+    });
+  });
+
+  it("positions items starting from 1 in order", () => {
+    const result = buildBreadcrumbList([
+      { name: "A", path: "/a" },
+      { name: "B", path: "/b" },
+      { name: "C", path: "/c" },
+    ]);
+
+    expect(result.itemListElement.map((i) => i.position)).toEqual([1, 2, 3]);
+  });
+
+  it("returns an empty itemListElement array for empty input", () => {
+    expect(buildBreadcrumbList([]).itemListElement).toEqual([]);
+  });
+});

--- a/src/lib/__tests__/seo.test.ts
+++ b/src/lib/__tests__/seo.test.ts
@@ -94,4 +94,19 @@ describe("buildBreadcrumbList", () => {
   it("returns an empty itemListElement array for empty input", () => {
     expect(buildBreadcrumbList([]).itemListElement).toEqual([]);
   });
+
+  it("prepends a leading slash when a caller passes path without one", () => {
+    const result = buildBreadcrumbList([{ name: "Privacy", path: "privacy" }]);
+    expect(result.itemListElement[0].item).toBe(`${siteUrl}/privacy`);
+  });
+
+  it("treats empty path as root siteUrl", () => {
+    const result = buildBreadcrumbList([{ name: "Home", path: "" }]);
+    expect(result.itemListElement[0].item).toBe(siteUrl);
+  });
+
+  it("trims surrounding whitespace in path", () => {
+    const result = buildBreadcrumbList([{ name: "Privacy", path: "  /privacy  " }]);
+    expect(result.itemListElement[0].item).toBe(`${siteUrl}/privacy`);
+  });
 });

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,4 +1,5 @@
 import { Resend } from "resend";
+import { getSiteUrl } from "@/lib/seo";
 
 let resend: Resend | null = null;
 
@@ -21,10 +22,6 @@ function getResend(): Resend | null {
 
 const FROM = "VibeTalent <notifications@vibetalent.work>";
 const REPLY_TO = "hello@vibetalent.work";
-
-function getSiteUrl() {
-  return process.env.NEXT_PUBLIC_SITE_URL || "https://www.vibetalent.work";
-}
 
 function unsubUrl(email: string) {
   return `${getSiteUrl()}/settings?tab=emails&ref=unsubscribe&email=${encodeURIComponent(email)}`;

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -31,17 +31,23 @@ export type BreadcrumbItem = { name: string; path: string };
 /**
  * Build a Schema.org BreadcrumbList JSON-LD object. Use standalone with
  * `"@context": "https://schema.org"`, or embed inside an "@graph" array.
- * `path` of "/" resolves to the bare siteUrl (no trailing slash).
+ * `path` of "/" resolves to the bare siteUrl (no trailing slash). Paths without
+ * a leading slash get one prepended, so callers can't accidentally produce
+ * malformed URLs like "https://www.vibetalent.workprivacy".
  */
 export function buildBreadcrumbList(items: BreadcrumbItem[]) {
   return {
     "@type": "BreadcrumbList",
-    itemListElement: items.map((item, i) => ({
-      "@type": "ListItem",
-      position: i + 1,
-      name: item.name,
-      item: item.path === "/" ? siteUrl : `${siteUrl}${item.path}`,
-    })),
+    itemListElement: items.map((item, i) => {
+      const path = item.path.trim();
+      const normalized = path === "/" || path === "" ? "" : path.startsWith("/") ? path : `/${path}`;
+      return {
+        "@type": "ListItem",
+        position: i + 1,
+        name: item.name,
+        item: normalized ? `${siteUrl}${normalized}` : siteUrl,
+      };
+    }),
   };
 }
 

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,8 +1,16 @@
 import type { Metadata } from "next";
 
-// Always use www — Vercel redirects non-www with 307 which breaks social media crawlers
+// Canonical site URL — always use www; Vercel redirects non-www with 307 which breaks social media crawlers
 export const siteUrl = "https://www.vibetalent.work";
 const siteName = "VibeTalent";
+
+/**
+ * Env-overridable site URL for server code (emails, API manifests, cron fan-out)
+ * that may run under a preview/staging origin. Falls back to the canonical siteUrl.
+ */
+export function getSiteUrl(): string {
+  return process.env.NEXT_PUBLIC_SITE_URL || siteUrl;
+}
 
 export function createMetadata(options: {
   title: string;

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -6,10 +6,24 @@ const siteName = "VibeTalent";
 
 /**
  * Env-overridable site URL for server code (emails, API manifests, cron fan-out)
- * that may run under a preview/staging origin. Falls back to the canonical siteUrl.
+ * that may run under a preview/staging origin.
+ *
+ * Validates NEXT_PUBLIC_SITE_URL: trims whitespace, requires http(s) protocol
+ * and a hostname, and returns .origin (strips trailing slash/path). Falls back
+ * to the canonical siteUrl on any parse failure or invalid input, so a mis-set
+ * env var can never leak garbage into outbound emails or JSON manifests.
  */
 export function getSiteUrl(): string {
-  return process.env.NEXT_PUBLIC_SITE_URL || siteUrl;
+  const envUrl = process.env.NEXT_PUBLIC_SITE_URL?.trim();
+  if (!envUrl) return siteUrl;
+  try {
+    const parsed = new URL(envUrl);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return siteUrl;
+    if (!parsed.hostname) return siteUrl;
+    return parsed.origin;
+  } catch {
+    return siteUrl;
+  }
 }
 
 export type BreadcrumbItem = { name: string; path: string };

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -12,6 +12,25 @@ export function getSiteUrl(): string {
   return process.env.NEXT_PUBLIC_SITE_URL || siteUrl;
 }
 
+export type BreadcrumbItem = { name: string; path: string };
+
+/**
+ * Build a Schema.org BreadcrumbList JSON-LD object. Use standalone with
+ * `"@context": "https://schema.org"`, or embed inside an "@graph" array.
+ * `path` of "/" resolves to the bare siteUrl (no trailing slash).
+ */
+export function buildBreadcrumbList(items: BreadcrumbItem[]) {
+  return {
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: item.name,
+      item: item.path === "/" ? siteUrl : `${siteUrl}${item.path}`,
+    })),
+  };
+}
+
 export function createMetadata(options: {
   title: string;
   description: string;


### PR DESCRIPTION
## Summary
Bundled cleanup PR from our tech-debt audit. **3 commits, each reviewable on its own.** User asked for all audit fixes to land in this PR instead of split across many.

## Commits

### 1. `0e5540a` refactor: centralize siteUrl + getSiteUrl() helper
Replaces 30+ hardcoded `https://www.vibetalent.work` literals and 6 duplicate `process.env.NEXT_PUBLIC_SITE_URL` env-fallback patterns with a single import from [`lib/seo`](src/lib/seo.ts). **Zero runtime behavior change.** 15 files touched.

### 2. `7bbd93e` fix(security): close auth open-redirect + harden 4 non-null assertions
- **Security fix**: [auth/callback/route.ts](src/app/auth/callback/route.ts) `sanitizeNext()` rejects `.evil.com`, `//evil.com`, `/\evil.com`, and backslash tricks. Was vulnerable because `${origin}${next}` with `next=.evil.com` produces `vibetalent.work.evil.com` (attacker-controlled subdomain).
- **Defensive**: replaced `user!.email!` pattern in [api/reviews/route.ts](src/app/api/reviews/route.ts), [api/hire/route.ts](src/app/api/hire/route.ts) with local capture after null guard (TS narrowing doesn't flow through nested `.then()` callbacks). Added `!user` early-return in [dashboard/page.tsx](src/app/dashboard/page.tsx) handleGithubSync. Replaced `promo.project!` with narrowed guard in [featured-carousel.tsx](src/components/ui/featured-carousel.tsx).

### 3. `3183482` refactor: extract buildBreadcrumbList() helper
Dedupes 5 hand-rolled Schema.org BreadcrumbList JSON-LD literals (terms, privacy, projects, leaderboard, explore) into a single helper in [lib/seo](src/lib/seo.ts). Helper returns the inner object so callers can spread it into either a standalone block or an `@graph` array. Zero behavior change.

## Deferred (honest notes)
Two audit items I couldn't land safely in this PR:

- **Supabase `as any` cleanup** — requires running `supabase gen types typescript --project-id <id>` with your project credentials. I attempted the minimum (adding `<Database>` generic to the public client) and it cascaded into 14 type errors because Supabase can't parse runtime `select()` strings against the schema. Reverted. Needs its own PR with the CLI + credentials.
- **Scoring constants extraction** ([agent-scoring.ts](src/lib/agent-scoring.ts), [streak.ts](src/lib/streak.ts)) — 20+ magic numbers woven through 4 functions. Audit specifically flagged this as "needs a snapshot test first" and it still does. One wrong placement silently changes every user's vibe score. Refused to ship without a test.

## Also investigated and marked no-op
- **15 empty catch blocks** (audit claim): actual count is 2 (one in layout.tsx inline theme script, one in dashboard JSON-parse fallback). Both intentional. Audit overcounted by catching all `catch` blocks including ones with real handlers.

## Verification
- [x] `grep https://www\.vibetalent\.work src/` → only `seo.ts:4` + `llms*.txt` content (intentional)
- [x] `grep NEXT_PUBLIC_SITE_URL src/` → only `seo.ts:12`
- [x] `npx tsc --noEmit` → 0 errors in src/
- [x] `npm run lint` → 0 errors/warnings in src/

## Test plan (post-merge)
- [ ] Spot-check live JSON-LD: `curl https://www.vibetalent.work | grep '@id'` should still contain `vibetalent.work/#website` etc.
- [ ] Hit `/auth/callback?code=<real>&next=.evil.com` → should redirect to `/dashboard` not `vibetalent.work.evil.com`
- [ ] Trigger daily cron on Vercel — jobs still fan out
- [ ] Send a test hire request, confirm notification email link still works
- [ ] GitHub-sync button in dashboard still works

## Next up (separate PRs)
- Supabase type regeneration
- Scoring constants with snapshot test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized site URL configuration across all pages and API routes for consistent domain handling and environment-based updates.
  * Standardized JSON-LD breadcrumb generation using shared SEO helpers for improved consistency.

* **Bug Fixes**
  * Enhanced email notification handling with improved null-safety checks.
  * Improved authentication callback redirect validation to prevent unsafe redirects.
  * Fixed carousel tech stack rendering with explicit existence checks.

* **Tests**
  * Added comprehensive test suite for SEO helper functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->