### PR TITLE
refactor(scoring): extract magic numbers to scoring-config + snapshot tests (PR-F)

### DIFF
--- a/src/lib/__tests__/__snapshots__/scoring-baseline.test.ts.snap
+++ b/src/lib/__tests__/__snapshots__/scoring-baseline.test.ts.snap
@@ -1,0 +1,158 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`calculateVibeScore numeric baseline > beginner — 5 streak, 1 unverified, no badge 1`] = `21`;
+
+exports[`calculateVibeScore numeric baseline > diamond with endorsements + review bonus 1`] = `951`;
+
+exports[`calculateVibeScore numeric baseline > flagged project contributes zero 1`] = `35`;
+
+exports[`calculateVibeScore numeric baseline > high-score — 200 streak, 3 projects with quality scores, gold 1`] = `461`;
+
+exports[`calculateVibeScore numeric baseline > legacy path — count-based scoring, no project detail 1`] = `97`;
+
+exports[`calculateVibeScore numeric baseline > shipper — 45 streak, 3 verified projects, bronze 1`] = `125`;
+
+exports[`evaluateUser numeric baseline (locks before refactor) > beginner persona — low streak, 1 unverified project 1`] = `
+{
+  "badge_level": "none",
+  "dimensions": {
+    "activity_recency": 62,
+    "client_outcomes": 0,
+    "consistency": 19,
+    "project_quality": 2,
+    "reputation": 3,
+    "tech_breadth": 36,
+  },
+  "overall_score": 15,
+  "risks_count": 4,
+  "strengths_count": 2,
+  "username": "beginner",
+}
+`;
+
+exports[`evaluateUser numeric baseline (locks before refactor) > diamond persona — top-tier across all dimensions 1`] = `
+{
+  "badge_level": "diamond",
+  "dimensions": {
+    "activity_recency": 100,
+    "client_outcomes": 0,
+    "consistency": 100,
+    "project_quality": 100,
+    "reputation": 100,
+    "tech_breadth": 36,
+  },
+  "overall_score": 70,
+  "risks_count": 1,
+  "strengths_count": 6,
+  "username": "diamond",
+}
+`;
+
+exports[`evaluateUser numeric baseline (locks before refactor) > high-score gold persona — long streak + quality metrics 1`] = `
+{
+  "badge_level": "gold",
+  "dimensions": {
+    "activity_recency": 100,
+    "client_outcomes": 0,
+    "consistency": 100,
+    "project_quality": 93,
+    "reputation": 100,
+    "tech_breadth": 36,
+  },
+  "overall_score": 69,
+  "risks_count": 1,
+  "strengths_count": 6,
+  "username": "highscore",
+}
+`;
+
+exports[`evaluateUser numeric baseline (locks before refactor) > inactive persona — zero current streak but past activity 1`] = `
+{
+  "badge_level": "bronze",
+  "dimensions": {
+    "activity_recency": 20,
+    "client_outcomes": 0,
+    "consistency": 49,
+    "project_quality": 2,
+    "reputation": 27,
+    "tech_breadth": 36,
+  },
+  "overall_score": 19,
+  "risks_count": 4,
+  "strengths_count": 2,
+  "username": "inactive",
+}
+`;
+
+exports[`evaluateUser numeric baseline (locks before refactor) > shipper persona — bronze badge, 3 verified projects 1`] = `
+{
+  "badge_level": "bronze",
+  "dimensions": {
+    "activity_recency": 78,
+    "client_outcomes": 0,
+    "consistency": 100,
+    "project_quality": 100,
+    "reputation": 38,
+    "tech_breadth": 36,
+  },
+  "overall_score": 59,
+  "risks_count": 1,
+  "strengths_count": 4,
+  "username": "shipper",
+}
+`;
+
+exports[`matchUsers numeric baseline > orders and scores across 5 personas deterministically 1`] = `
+[
+  {
+    "match_score": 79,
+    "matched_skills": [
+      "React",
+      "Typescript",
+    ],
+    "reasons_count": 4,
+    "recommended_for": "MVP development",
+    "username": "highscore",
+  },
+  {
+    "match_score": 79,
+    "matched_skills": [
+      "React",
+      "Typescript",
+    ],
+    "reasons_count": 4,
+    "recommended_for": "MVP development",
+    "username": "diamond",
+  },
+  {
+    "match_score": 74,
+    "matched_skills": [
+      "React",
+      "Typescript",
+    ],
+    "reasons_count": 4,
+    "recommended_for": "MVP development",
+    "username": "shipper",
+  },
+  {
+    "match_score": 50,
+    "matched_skills": [
+      "React",
+      "Typescript",
+    ],
+    "reasons_count": 2,
+    "recommended_for": "MVP development",
+    "username": "inactive",
+  },
+  {
+    "match_score": 49,
+    "matched_skills": [
+      "React",
+      "Typescript",
+    ],
+    "reasons_count": 1,
+    "recommended_for": "MVP development",
+    "username": "beginner",
+  },
+]
+`;

--- a/src/lib/__tests__/scoring-baseline.test.ts
+++ b/src/lib/__tests__/scoring-baseline.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Baseline / snapshot tests for scoring logic.
+ *
+ * Purpose: lock current numeric outputs of evaluateUser/matchUsers and
+ * calculateVibeScore/calculateProjectScore/calculateReviewBonus so that
+ * extracting scoring magic numbers into a SCORING config CANNOT silently
+ * drift any user's score. If any output here changes, the refactor is
+ * wrong — investigate immediately.
+ *
+ * These are intentionally narrow (just numbers + short flags), not full
+ * object snapshots, because evaluated_at is time-sensitive and summary
+ * text is generated from string templates we aren't refactoring.
+ */
+import { describe, it, expect } from "vitest";
+import { evaluateUser, matchUsers } from "../agent-scoring";
+import {
+  calculateVibeScore,
+  calculateProjectScore,
+  calculateReviewBonus,
+  getBadgeLevel,
+} from "../streak";
+import type { UserWithSocials, Project } from "../types/database";
+import type { TaskRequest } from "../types/agent";
+
+const projectDefaults: Pick<Project, "quality_score" | "quality_metrics" | "live_url_ok" | "endorsement_count"> = {
+  quality_score: 0,
+  quality_metrics: null,
+  live_url_ok: null,
+  endorsement_count: 0,
+};
+
+function mkProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: "p-1",
+    user_id: "u-1",
+    title: "Project",
+    description: "A comprehensive test project description with many features and good documentation",
+    tech_stack: ["React", "TypeScript", "Node.js"],
+    live_url: "https://example.com",
+    github_url: "https://github.com/x/y",
+    image_url: null,
+    build_time: null,
+    tags: [],
+    verified: true,
+    created_at: "2025-01-01T00:00:00Z",
+    ...projectDefaults,
+    ...overrides,
+  };
+}
+
+function mkUser(overrides: Partial<UserWithSocials> = {}): UserWithSocials {
+  return {
+    id: "u-1",
+    username: "alice",
+    display_name: null,
+    bio: null,
+    avatar_url: null,
+    github_username: null,
+    streak: 10,
+    longest_streak: 20,
+    vibe_score: 50,
+    badge_level: "none",
+    streak_freezes_remaining: 0,
+    streak_freezes_used: 0,
+    referral_count: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    social_links: null,
+    projects: [],
+    ...overrides,
+  };
+}
+
+// ---- Personas: representative across the scoring space ----
+
+const beginner = mkUser({
+  username: "beginner",
+  streak: 5,
+  longest_streak: 10,
+  vibe_score: 30,
+  badge_level: "none",
+  projects: [mkProject({ verified: false, description: "short" })],
+});
+
+const shipperBronze = mkUser({
+  username: "shipper",
+  streak: 45,
+  longest_streak: 60,
+  vibe_score: 250,
+  badge_level: "bronze",
+  projects: [mkProject(), mkProject({ id: "p-2" }), mkProject({ id: "p-3" })],
+});
+
+const highScoreGold = mkUser({
+  username: "highscore",
+  streak: 200,
+  longest_streak: 200,
+  vibe_score: 650,
+  badge_level: "gold",
+  projects: [
+    mkProject({ quality_score: 80, quality_metrics: { has_tests: true, has_ci: true } as unknown as Project["quality_metrics"], live_url_ok: true, endorsement_count: 3 }),
+    mkProject({ id: "p-2", quality_score: 70, live_url_ok: true, endorsement_count: 2 }),
+    mkProject({ id: "p-3", quality_score: 60 }),
+  ],
+});
+
+const zeroStreakInactive = mkUser({
+  username: "inactive",
+  streak: 0,
+  longest_streak: 45,
+  vibe_score: 150,
+  badge_level: "bronze",
+  projects: [mkProject({ verified: false })],
+});
+
+const diamondBadge = mkUser({
+  username: "diamond",
+  streak: 400,
+  longest_streak: 400,
+  vibe_score: 900,
+  badge_level: "diamond",
+  projects: [
+    mkProject({ quality_score: 90, live_url_ok: true, endorsement_count: 5 }),
+    mkProject({ id: "p-2", quality_score: 85, live_url_ok: true, endorsement_count: 4 }),
+    mkProject({ id: "p-3", quality_score: 75, live_url_ok: true, endorsement_count: 2 }),
+    mkProject({ id: "p-4", quality_score: 70 }),
+  ],
+});
+
+// Extract just the numeric, deterministic parts
+function snap(user: UserWithSocials) {
+  const r = evaluateUser(user);
+  return {
+    username: r.username,
+    overall_score: r.overall_score,
+    dimensions: r.dimensions,
+    badge_level: r.badge_level,
+    strengths_count: r.strengths.length,
+    risks_count: r.risks.length,
+  };
+}
+
+// ---- evaluateUser baseline locks ----
+
+describe("evaluateUser numeric baseline (locks before refactor)", () => {
+  it("beginner persona — low streak, 1 unverified project", () => {
+    expect(snap(beginner)).toMatchSnapshot();
+  });
+
+  it("shipper persona — bronze badge, 3 verified projects", () => {
+    expect(snap(shipperBronze)).toMatchSnapshot();
+  });
+
+  it("high-score gold persona — long streak + quality metrics", () => {
+    expect(snap(highScoreGold)).toMatchSnapshot();
+  });
+
+  it("inactive persona — zero current streak but past activity", () => {
+    expect(snap(zeroStreakInactive)).toMatchSnapshot();
+  });
+
+  it("diamond persona — top-tier across all dimensions", () => {
+    expect(snap(diamondBadge)).toMatchSnapshot();
+  });
+});
+
+// ---- matchUsers baseline locks ----
+
+describe("matchUsers numeric baseline", () => {
+  const task: TaskRequest = {
+    description: "Build a SaaS dashboard with React and TypeScript",
+    project_type: "mvp",
+    tech_stack: ["React", "TypeScript"],
+    budget: "2k_5k",
+    timeline: "1_month",
+  };
+
+  it("orders and scores across 5 personas deterministically", () => {
+    const results = matchUsers(
+      [beginner, shipperBronze, highScoreGold, zeroStreakInactive, diamondBadge],
+      task
+    );
+    const shape = results.map((r) => ({
+      username: r.user.username,
+      match_score: r.match_score,
+      matched_skills: r.matched_skills,
+      reasons_count: r.match_reasons.length,
+      recommended_for: r.recommended_for,
+    }));
+    expect(shape).toMatchSnapshot();
+  });
+});
+
+// ---- streak.ts calculateVibeScore baseline ----
+
+describe("calculateVibeScore numeric baseline", () => {
+  it("beginner — 5 streak, 1 unverified, no badge", () => {
+    expect(
+      calculateVibeScore(5, 1, "none", 0, [
+        { verified: false },
+      ])
+    ).toMatchSnapshot();
+  });
+
+  it("shipper — 45 streak, 3 verified projects, bronze", () => {
+    expect(
+      calculateVibeScore(45, 3, "bronze", 3, [
+        { verified: true, quality_score: 0 },
+        { verified: true, quality_score: 0 },
+        { verified: true, quality_score: 0 },
+      ])
+    ).toMatchSnapshot();
+  });
+
+  it("high-score — 200 streak, 3 projects with quality scores, gold", () => {
+    expect(
+      calculateVibeScore(200, 3, "gold", 3, [
+        { verified: true, quality_score: 80 },
+        { verified: true, quality_score: 70 },
+        { verified: true, quality_score: 60 },
+      ])
+    ).toMatchSnapshot();
+  });
+
+  it("diamond with endorsements + review bonus", () => {
+    expect(
+      calculateVibeScore(
+        400,
+        4,
+        "diamond",
+        4,
+        [
+          { verified: true, quality_score: 90 },
+          { verified: true, quality_score: 85 },
+          { verified: true, quality_score: 75 },
+          { verified: true, quality_score: 70 },
+        ],
+        30, // reviewBonus
+        8  // endorsementCount
+      )
+    ).toMatchSnapshot();
+  });
+
+  it("legacy path — count-based scoring, no project detail", () => {
+    expect(calculateVibeScore(30, 5, "bronze", 3)).toMatchSnapshot();
+  });
+
+  it("flagged project contributes zero", () => {
+    expect(
+      calculateVibeScore(10, 2, "none", 2, [
+        { verified: true, quality_score: 50, flagged: true },
+        { verified: true, quality_score: 50 },
+      ])
+    ).toMatchSnapshot();
+  });
+});
+
+// ---- calculateProjectScore baseline ----
+
+describe("calculateProjectScore numeric baseline", () => {
+  it("unverified project → 1", () => {
+    expect(
+      calculateProjectScore({
+        verified: false,
+        live_url: null,
+        github_url: null,
+        description: "",
+        image_url: null,
+        tech_stack: [],
+      })
+    ).toBe(1);
+  });
+
+  it("verified with all signals → 15", () => {
+    expect(
+      calculateProjectScore({
+        verified: true,
+        live_url: "https://x.com",
+        github_url: "https://github.com/x/y",
+        description: "A description that is clearly longer than fifty characters for the bonus",
+        image_url: "https://img.com/x.png",
+        tech_stack: ["a", "b", "c", "d"],
+      })
+    ).toBe(15);
+  });
+
+  it("verified with only base → 5", () => {
+    expect(
+      calculateProjectScore({
+        verified: true,
+        live_url: null,
+        github_url: null,
+        description: "",
+        image_url: null,
+        tech_stack: [],
+      })
+    ).toBe(5);
+  });
+
+  it("verified with live + github only → 10", () => {
+    expect(
+      calculateProjectScore({
+        verified: true,
+        live_url: "https://x.com",
+        github_url: "https://github.com/x/y",
+        description: "",
+        image_url: null,
+        tech_stack: [],
+      })
+    ).toBe(10);
+  });
+});
+
+// ---- calculateReviewBonus baseline ----
+
+describe("calculateReviewBonus numeric baseline", () => {
+  it("no reviews → 0", () => {
+    expect(calculateReviewBonus(5, 0)).toBe(0);
+  });
+
+  it("5-star × 3 reviews → 30", () => {
+    expect(calculateReviewBonus(5, 3)).toBe(30);
+  });
+
+  it("caps at 50 for very high rating × count", () => {
+    expect(calculateReviewBonus(5, 20)).toBe(50);
+  });
+
+  it("rounds mid-values correctly", () => {
+    expect(calculateReviewBonus(4.5, 2)).toBe(18);
+  });
+});
+
+// ---- Badge thresholds baseline (integer boundaries) ----
+
+describe("getBadgeLevel thresholds", () => {
+  const cases: [number, string][] = [
+    [0, "none"],
+    [29, "none"],
+    [30, "bronze"],
+    [89, "bronze"],
+    [90, "silver"],
+    [179, "silver"],
+    [180, "gold"],
+    [364, "gold"],
+    [365, "diamond"],
+    [1000, "diamond"],
+  ];
+
+  it.each(cases)("longestStreak=%i → %s", (streak, expected) => {
+    expect(getBadgeLevel(streak)).toBe(expected);
+  });
+});

--- a/src/lib/agent-scoring.ts
+++ b/src/lib/agent-scoring.ts
@@ -1,14 +1,15 @@
 import type { UserWithSocials } from "./types/database";
 import type { EvaluationResult, EvaluationDimensions, MatchResult, TaskRequest } from "./types/agent";
+import { AGENT_EVAL, MATCH } from "./scoring-config";
 
 function clamp(min: number, max: number, value: number): number {
   return Math.min(max, Math.max(min, value));
 }
 
 function evaluateDimensions(user: UserWithSocials): EvaluationDimensions {
-  // Consistency: based on streak and longest_streak
+  const C = AGENT_EVAL.consistency;
   const consistency = clamp(0, 100,
-    (user.streak * 0.6 + user.longest_streak * 0.4) / 3.65 * 10
+    (user.streak * C.streakWeight + user.longest_streak * C.longestStreakWeight) / C.normalizer * C.scale
   );
 
   // Project Quality: use GitHub quality scores when available, fallback to heuristics
@@ -21,48 +22,51 @@ function evaluateDimensions(user: UserWithSocials): EvaluationDimensions {
   const scoredProjects = verifiedProjects.filter(p => p.quality_metrics != null);
   let project_quality: number;
   if (scoredProjects.length > 0) {
-    // Average quality score of analyzed projects (weighted heavily)
+    const PQ = AGENT_EVAL.projectQuality;
     const avgQuality = scoredProjects.reduce((sum, p) => sum + p.quality_score, 0) / scoredProjects.length;
-    // Bonus for quantity of quality projects + live URLs
-    const quantityBonus = Math.min(20, scoredProjects.length * 5);
-    const liveBonus = Math.min(15, withLiveUrl * 5);
-    const liveSiteOkBonus = verifiedProjects.filter(p => p.live_url_ok === true).length * 5;
+    const quantityBonus = Math.min(PQ.quantityBonusMax, scoredProjects.length * PQ.quantityBonusPerProject);
+    const liveBonus = Math.min(PQ.liveBonusMax, withLiveUrl * PQ.liveBonusPerProject);
+    const liveSiteOkBonus = verifiedProjects.filter(p => p.live_url_ok === true).length * PQ.liveSiteOkPerProject;
     project_quality = clamp(0, 100,
-      avgQuality * 0.6 + quantityBonus + liveBonus + liveSiteOkBonus + unverifiedProjects.length * 1
+      avgQuality * PQ.avgWeight + quantityBonus + liveBonus + liveSiteOkBonus + unverifiedProjects.length * PQ.unverifiedPointsPer
     );
   } else {
-    // Fallback: original heuristic scoring
+    const PQF = AGENT_EVAL.projectQualityFallback;
     const avgDescLen = verifiedProjects.length > 0
       ? verifiedProjects.reduce((sum, p) => sum + p.description.length, 0) / verifiedProjects.length
       : 0;
     project_quality = clamp(0, 100,
-      verifiedProjects.length * 15 + unverifiedProjects.length * 2 +
-      withLiveUrl * 10 + withGithub * 5 + (avgDescLen > 50 ? 10 : 0)
+      verifiedProjects.length * PQF.verifiedPer + unverifiedProjects.length * PQF.unverifiedPer +
+      withLiveUrl * PQF.liveUrlPer + withGithub * PQF.githubPer + (avgDescLen > PQF.longDescThreshold ? PQF.longDescBonus : 0)
     );
   }
 
   // Tech Breadth: unique technologies
   const allTech = new Set((user.projects ?? []).flatMap(p => (p.tech_stack ?? []).map(t => t.toLowerCase())));
-  const tech_breadth = clamp(0, 100, allTech.size * 12);
+  const tech_breadth = clamp(0, 100, allTech.size * AGENT_EVAL.techBreadth.perUniqueTech);
 
   // Activity Recency: based on active streak
+  const AR = AGENT_EVAL.activityRecency;
   const activity_recency = user.streak > 0
-    ? clamp(0, 100, 60 + Math.min(40, user.streak * 0.4))
-    : 20;
+    ? clamp(0, 100, AR.activeBase + Math.min(AR.activeMaxBonus, user.streak * AR.perStreakDay))
+    : AR.inactiveScore;
 
   // Endorsements bonus: peer-validated projects boost quality
   const totalEndorsements = (user.projects ?? []).reduce((sum, p) => sum + (p.endorsement_count || 0), 0);
-  const endorsementBonus = Math.min(15, totalEndorsements * 3);
+  const endorsementBonus = Math.min(
+    AGENT_EVAL.projectQuality.endorsementBonusMax,
+    totalEndorsements * AGENT_EVAL.projectQuality.endorsementBonusPer
+  );
   project_quality = clamp(0, 100, project_quality + endorsementBonus);
 
   // Reputation: based on vibe_score, badge, and client reviews
-  const badgeBonus = { none: 0, bronze: 10, silver: 20, gold: 35, diamond: 50 };
+  const REP = AGENT_EVAL.reputation;
   const reviews = (user as unknown as Record<string, unknown>).reviews as Array<{ rating: number }> | undefined;
   const reviewBonus = reviews && reviews.length > 0
-    ? Math.min(25, Math.round((reviews.reduce((sum, r) => sum + r.rating, 0) / reviews.length) * reviews.length * 1.5))
+    ? Math.min(REP.reviewCap, Math.round((reviews.reduce((sum, r) => sum + r.rating, 0) / reviews.length) * reviews.length * REP.reviewMultiplier))
     : 0;
   const reputation = clamp(0, 100,
-    (user.vibe_score / 9) + (badgeBonus[user.badge_level] || 0) + reviewBonus
+    (user.vibe_score / REP.vibeScoreDivisor) + (AGENT_EVAL.badgeBonuses[user.badge_level] || 0) + reviewBonus
   );
 
   // Client Outcomes: real hire completions, trusted reviews, repeat clients
@@ -132,7 +136,7 @@ function extractStrengths(user: UserWithSocials, dims: EvaluationDimensions): st
   }
   const totalEndorsements = (user.projects ?? []).reduce((sum, p) => sum + (p.endorsement_count || 0), 0);
   if (totalEndorsements >= 5) strengths.push(`${totalEndorsements} peer endorsements across projects`);
-  return strengths.slice(0, 6);
+  return strengths.slice(0, AGENT_EVAL.maxStrengths);
 }
 
 function extractRisks(user: UserWithSocials, dims: EvaluationDimensions): string[] {
@@ -157,7 +161,7 @@ function extractRisks(user: UserWithSocials, dims: EvaluationDimensions): string
       risks.push("Slow to respond (> 3 days avg)");
     }
   }
-  return risks.slice(0, 5);
+  return risks.slice(0, AGENT_EVAL.maxRisks);
 }
 
 export function evaluateUser(user: UserWithSocials): EvaluationResult {
@@ -165,13 +169,14 @@ export function evaluateUser(user: UserWithSocials): EvaluationResult {
 
   // Weights: quality and client outcomes are heaviest (hardest to fake)
   // Consistency is lowest weight (easiest to fake with daily commits)
+  const W = AGENT_EVAL.overallWeights;
   const overall = Math.round(
-    dims.project_quality * 0.25 +
-    dims.client_outcomes * 0.20 +
-    dims.consistency * 0.15 +
-    dims.tech_breadth * 0.15 +
-    dims.activity_recency * 0.10 +
-    dims.reputation * 0.15
+    dims.project_quality * W.projectQuality +
+    dims.client_outcomes * W.clientOutcomes +
+    dims.consistency * W.consistency +
+    dims.tech_breadth * W.techBreadth +
+    dims.activity_recency * W.activityRecency +
+    dims.reputation * W.reputation
   );
 
   return {
@@ -201,29 +206,30 @@ export function matchUsers(users: UserWithSocials[], task: TaskRequest): MatchRe
     const userTechSet = new Set(userTech);
     const userTags = (user.projects ?? []).flatMap(p => (p.tags ?? []).map(t => t.toLowerCase()));
 
-    // Skill overlap (40%)
+    // Skill overlap
     const matchedSkills = requestedTech.filter(t => userTechSet.has(t));
     const skillScore = requestedTech.length > 0
       ? (matchedSkills.length / requestedTech.length) * 100
-      : 50;
+      : MATCH.defaultSkillScore;
 
-    // Evaluation score (30%)
+    // Evaluation score
     const evalResult = evaluateUser(user);
     const evalScore = evalResult.overall_score;
 
-    // Tag relevance (15%)
+    // Tag relevance
     const descWords = task.description.toLowerCase().split(/\s+/);
     const tagMatches = userTags.filter(t => descWords.some(w => t.includes(w) || w.includes(t)));
-    const tagScore = tagMatches.length > 0 ? 80 : 20;
+    const tagScore = tagMatches.length > 0 ? MATCH.tagMatchScore : MATCH.tagNoMatchScore;
 
-    // Availability proxy (15%)
-    const availScore = user.streak > 0 ? Math.min(100, user.streak * 2) : 10;
+    // Availability proxy
+    const A = MATCH.availability;
+    const availScore = user.streak > 0 ? Math.min(A.activeCap, user.streak * A.activeMultiplier) : A.inactiveScore;
 
     const match_score = Math.round(
-      skillScore * 0.40 +
-      evalScore * 0.30 +
-      tagScore * 0.15 +
-      availScore * 0.15
+      skillScore * MATCH.weights.skill +
+      evalScore * MATCH.weights.evaluation +
+      tagScore * MATCH.weights.tag +
+      availScore * MATCH.weights.availability
     );
 
     const match_reasons: string[] = [];
@@ -243,13 +249,13 @@ export function matchUsers(users: UserWithSocials[], task: TaskRequest): MatchRe
     return {
       user,
       match_score,
-      match_reasons: match_reasons.slice(0, 4),
+      match_reasons: match_reasons.slice(0, MATCH.maxReasons),
       matched_skills: matchedSkills.map(s => s.charAt(0).toUpperCase() + s.slice(1)),
       recommended_for: projectTypeLabels[task.project_type] || "General development",
     };
   });
 
-  return results.sort((a, b) => b.match_score - a.match_score).slice(0, 5);
+  return results.sort((a, b) => b.match_score - a.match_score).slice(0, MATCH.maxResults);
 }
 
 export function generateHireMessage(

--- a/src/lib/scoring-config.ts
+++ b/src/lib/scoring-config.ts
@@ -1,0 +1,135 @@
+/**
+ * Scoring tunables — centralized numeric constants for VibeTalent's scoring
+ * logic so weights/thresholds are tuneable in one place rather than scattered
+ * through formulas. Extracted from `streak.ts` and `agent-scoring.ts`.
+ *
+ * ⚠️ Changing any value here changes every user's score. Run
+ *    `npm test -- scoring-baseline` to see if snapshots shift —
+ *    any shift is a real scoring change and should be intentional.
+ *
+ * Two "badge bonus" tables exist on purpose: the vibe-score badge bonuses
+ * (streak.ts, integer-friendly) and the agent-eval badge bonuses
+ * (agent-scoring.ts, 0–100 reputation scale) are tuned independently.
+ */
+import type { BadgeLevel } from "./types/database";
+
+// ---- Vibe score (streak.ts) ----
+export const VIBE_SCORE = {
+  baseline: 10,
+  perStreakDay: 2,
+  verifiedProjectBase: 5,
+  unverifiedProjectPoints: 1,
+  qualityScoreDivisor: 10,
+  qualityScoreCapPerProject: 10,
+  perEndorsement: 5,
+  reviewMultiplier: 2,
+  reviewCap: 50,
+  badgeBonuses: { none: 0, bronze: 10, silver: 20, gold: 30, diamond: 40 } as Record<BadgeLevel, number>,
+} as const;
+
+// ---- Per-project quality score (streak.ts calculateProjectScore) ----
+export const PROJECT_SCORE = {
+  unverifiedFlat: 1,
+  verifiedBase: 5,
+  liveUrlBonus: 3,
+  githubBonus: 2,
+  longDescBonus: 2,
+  imageBonus: 1,
+  techStackBonus: 2,
+  longDescThreshold: 50,
+  techStackThreshold: 3,
+} as const;
+
+// ---- Badge tier thresholds (streak.ts getBadgeLevel) ----
+export const BADGE_THRESHOLDS = {
+  bronze: 30,
+  silver: 90,
+  gold: 180,
+  diamond: 365,
+} as const;
+
+// ---- Agent evaluator (agent-scoring.ts evaluateUser) ----
+export const AGENT_EVAL = {
+  badgeBonuses: { none: 0, bronze: 10, silver: 20, gold: 35, diamond: 50 } as Record<BadgeLevel, number>,
+
+  consistency: {
+    streakWeight: 0.6,
+    longestStreakWeight: 0.4,
+    normalizer: 3.65,
+    scale: 10,
+  },
+
+  // Quality-based project scoring (when quality_metrics is present)
+  projectQuality: {
+    avgWeight: 0.6,
+    quantityBonusPerProject: 5,
+    quantityBonusMax: 20,
+    liveBonusPerProject: 5,
+    liveBonusMax: 15,
+    liveSiteOkPerProject: 5,
+    unverifiedPointsPer: 1,
+    endorsementBonusPer: 3,
+    endorsementBonusMax: 15,
+  },
+
+  // Heuristic fallback (when no quality_metrics)
+  projectQualityFallback: {
+    verifiedPer: 15,
+    unverifiedPer: 2,
+    liveUrlPer: 10,
+    githubPer: 5,
+    longDescBonus: 10,
+    longDescThreshold: 50,
+  },
+
+  techBreadth: {
+    perUniqueTech: 12,
+  },
+
+  activityRecency: {
+    activeBase: 60,
+    perStreakDay: 0.4,
+    activeMaxBonus: 40,
+    inactiveScore: 20,
+  },
+
+  reputation: {
+    vibeScoreDivisor: 9,
+    reviewMultiplier: 1.5,
+    reviewCap: 25,
+  },
+
+  // Weights for combined overall_score (sum to 1.0)
+  overallWeights: {
+    projectQuality: 0.25,
+    clientOutcomes: 0.20,
+    consistency: 0.15,
+    techBreadth: 0.15,
+    activityRecency: 0.10,
+    reputation: 0.15,
+  },
+
+  // Display/UI caps on extracted lists
+  maxStrengths: 6,
+  maxRisks: 5,
+} as const;
+
+// ---- Task-to-user matching (agent-scoring.ts matchUsers) ----
+export const MATCH = {
+  weights: {
+    skill: 0.40,
+    evaluation: 0.30,
+    tag: 0.15,
+    availability: 0.15,
+  },
+  defaultSkillScore: 50, // when task has no requested tech
+  tagMatchScore: 80,
+  tagNoMatchScore: 20,
+  availability: {
+    activeMultiplier: 2,
+    activeCap: 100,
+    inactiveScore: 10,
+  },
+  maxResults: 5,
+  maxReasons: 4,
+} as const;

--- a/src/lib/streak.ts
+++ b/src/lib/streak.ts
@@ -1,4 +1,5 @@
 import type { BadgeLevel } from "@/lib/types/database";
+import { VIBE_SCORE, PROJECT_SCORE, BADGE_THRESHOLDS } from "@/lib/scoring-config";
 
 /** Minimal project shape needed for quality scoring. */
 export interface ProjectScoreInput {
@@ -86,14 +87,18 @@ export function calculateStreak(activityDates: string[]): {
  *   Max per project:  15 pts
  */
 export function calculateProjectScore(project: ProjectScoreInput): number {
-  if (!project.verified) return 1;
+  if (!project.verified) return PROJECT_SCORE.unverifiedFlat;
 
-  let score = 5;
-  if (project.live_url) score += 3;
-  if (project.github_url) score += 2;
-  if (project.description && project.description.length > 50) score += 2;
-  if (project.image_url) score += 1;
-  if (project.tech_stack && project.tech_stack.length >= 3) score += 2;
+  let score = PROJECT_SCORE.verifiedBase;
+  if (project.live_url) score += PROJECT_SCORE.liveUrlBonus;
+  if (project.github_url) score += PROJECT_SCORE.githubBonus;
+  if (project.description && project.description.length > PROJECT_SCORE.longDescThreshold) {
+    score += PROJECT_SCORE.longDescBonus;
+  }
+  if (project.image_url) score += PROJECT_SCORE.imageBonus;
+  if (project.tech_stack && project.tech_stack.length >= PROJECT_SCORE.techStackThreshold) {
+    score += PROJECT_SCORE.techStackBonus;
+  }
   return score;
 }
 
@@ -104,7 +109,7 @@ export function calculateProjectScore(project: ProjectScoreInput): number {
  */
 export function calculateReviewBonus(avgRating: number, reviewCount: number): number {
   if (reviewCount === 0) return 0;
-  return Math.min(50, Math.round(avgRating * reviewCount * 2));
+  return Math.min(VIBE_SCORE.reviewCap, Math.round(avgRating * reviewCount * VIBE_SCORE.reviewMultiplier));
 }
 
 /**
@@ -138,9 +143,8 @@ export function calculateVibeScore(
   reviewBonus: number = 0,
   endorsementCount: number = 0
 ): number {
-  // Baseline: every verified GitHub user starts with 10 points
-  const baseline = 10;
-  const streakPoints = currentStreak * 2;
+  const baseline = VIBE_SCORE.baseline;
+  const streakPoints = currentStreak * VIBE_SCORE.perStreakDay;
 
   let projectPoints: number;
   if (projects && projects.length > 0) {
@@ -149,11 +153,14 @@ export function calculateVibeScore(
       .filter((p) => !p.flagged)
       .reduce((sum, p) => {
         if (p.verified && p.quality_score && p.quality_score > 0) {
-          return sum + Math.min(Math.floor(p.quality_score / 10), 10);
+          return sum + Math.min(
+            Math.floor(p.quality_score / VIBE_SCORE.qualityScoreDivisor),
+            VIBE_SCORE.qualityScoreCapPerProject
+          );
         } else if (p.verified) {
-          return sum + 5;
+          return sum + VIBE_SCORE.verifiedProjectBase;
         }
-        return sum + 1;
+        return sum + VIBE_SCORE.unverifiedProjectPoints;
       }, 0);
   } else if (Array.isArray(projectCountOrProjects)) {
     // Score each project individually using ProjectScoreInput
@@ -165,31 +172,22 @@ export function calculateVibeScore(
     // Legacy path: flat scoring for backward compatibility
     const verified = verifiedCount ?? projectCountOrProjects;
     const unverified = projectCountOrProjects - verified;
-    projectPoints = verified * 5 + unverified * 1;
+    projectPoints = verified * VIBE_SCORE.verifiedProjectBase + unverified * VIBE_SCORE.unverifiedProjectPoints;
   }
 
-  const badgeBonusMap: Record<BadgeLevel, number> = {
-    none: 0,
-    bronze: 10,
-    silver: 20,
-    gold: 30,
-    diamond: 40,
-  };
+  const endorsementPoints = endorsementCount * VIBE_SCORE.perEndorsement;
 
-  // +5 per endorsement received on user's projects
-  const endorsementPoints = endorsementCount * 5;
-
-  return baseline + streakPoints + projectPoints + badgeBonusMap[badgeLevel] + reviewBonus + endorsementPoints;
+  return baseline + streakPoints + projectPoints + VIBE_SCORE.badgeBonuses[badgeLevel] + reviewBonus + endorsementPoints;
 }
 
 /**
  * Determine badge level from longest streak.
  */
 export function getBadgeLevel(longestStreak: number): BadgeLevel {
-  if (longestStreak >= 365) return "diamond";
-  if (longestStreak >= 180) return "gold";
-  if (longestStreak >= 90) return "silver";
-  if (longestStreak >= 30) return "bronze";
+  if (longestStreak >= BADGE_THRESHOLDS.diamond) return "diamond";
+  if (longestStreak >= BADGE_THRESHOLDS.gold) return "gold";
+  if (longestStreak >= BADGE_THRESHOLDS.silver) return "silver";
+  if (longestStreak >= BADGE_THRESHOLDS.bronze) return "bronze";
   return "none";
 }
 


### PR DESCRIPTION
## Summary
Last audit item from the tech-debt cleanup. Centralizes 40+ scoring tunables from [streak.ts](src/lib/streak.ts) + [agent-scoring.ts](src/lib/agent-scoring.ts) into a single [scoring-config.ts](src/lib/scoring-config.ts). **Zero drift in any user's score.**

The audit originally flagged this as Yellow risk because "one wrong placement silently changes every user's vibe score." We addressed that by **writing snapshot tests first** that lock exact numeric outputs — then doing the extraction — then verifying snapshots still match byte-for-byte.

## What changed

### New: `src/lib/scoring-config.ts`
Five read-only config objects:
- **`VIBE_SCORE`** — baseline, per-streak-day, verified/unverified project points, quality divisor/cap, endorsement bonus, review multiplier/cap, badge bonuses
- **`PROJECT_SCORE`** — verified base + bonuses (live URL, github, long desc, image, tech stack), thresholds
- **`BADGE_THRESHOLDS`** — bronze/silver/gold/diamond streak cutoffs
- **`AGENT_EVAL`** — consistency weights, project-quality (both quality-metrics and heuristic-fallback paths), tech-breadth, activity-recency, reputation, overall-weights, display caps
- **`MATCH`** — skill/eval/tag/availability weights, defaults, availability formula, max results/reasons

### New: `src/lib/__tests__/scoring-baseline.test.ts`
30 tests, 12 snapshots — locks **exact numeric outputs** across 5 personas (beginner, bronze shipper, gold high-score, zero-streak inactive, diamond-badge with outcomes) for every scoring function. Snapshot file committed.

### Modified: `streak.ts` + `agent-scoring.ts`
Every magic number now reads from the config. Function logic, signatures, and return shapes are unchanged.

## Worth knowing

**Two badge-bonus tables exist on purpose.** `VIBE_SCORE.badgeBonuses` uses `{bronze:10, silver:20, gold:30, diamond:40}` for integer-friendly vibe-score additions; `AGENT_EVAL.badgeBonuses` uses `{...gold:35, diamond:50}` on the 0–100 reputation scale. This was already the case before the refactor — just made visible. Comment in the config notes it.

## Verification
- [x] **127/127 tests pass** — 30 new baseline/snapshot tests + 97 existing, **zero snapshot drift**
- [x] `npx tsc --noEmit` → 0 errors in src/
- [x] `npm run lint` → 0 errors/warnings in src/

### Concrete numbers the baseline locks (sampled)
| Persona | `evaluateUser.overall_score` |
|---|---|
| beginner | 15 |
| bronze shipper | (in snap) |
| high-score gold | 69 |
| inactive | 19 |
| diamond | 70 |

| Scenario | `calculateVibeScore` |
|---|---|
| beginner | 21 |
| shipper | 125 |
| high-score | 461 |
| diamond w/ reviews+endorsements | 951 |
| legacy path | 97 |
| flagged project excluded | 35 |

If any of these numbers shift in a future PR, the snapshot test fails — force-review any change that alters them.

## Test plan
- [ ] After merge, spot-check live leaderboard — top-ranked users should be unchanged
- [ ] Hit `/api/agent/match` with a real request — match scores should match pre-merge for the same inputs
- [ ] Next nightly cron run (vibe-score recompute) — no mass score movement

## Follow-up
PR-D (Supabase `as any` cleanup) is the one audit item still open — it needs `supabase gen types` CLI access from you. Separate PR when you're ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive baseline tests for user scoring, matching behavior, badge levels, and bonus calculations to ensure scoring consistency.

* **Improvements**
  * Centralized all scoring configuration parameters into a dedicated module for improved consistency and maintainability.
  * Enhanced scoring calculations to use configurable parameters instead of hardcoded values across evaluations and matching logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->