### PR TITLE
chore: cut Vercel build minutes + function invocations

### DIFF
--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -10,6 +10,25 @@ export async function updateSession(request: NextRequest) {
     return NextResponse.next({ request });
   }
 
+  // Short-circuit unauthenticated traffic: no auth cookie means getUser() would
+  // round-trip to Supabase just to return null. Skipping that fetch eliminates
+  // the hot-path cost for bots, crawlers, and logged-out visitors — the bulk of
+  // public traffic — without changing behavior (protected routes still redirect
+  // to login, unprotected routes still render anonymously).
+  const hasAuthCookie = request.cookies
+    .getAll()
+    .some((c) => c.name.startsWith("sb-") && c.name.endsWith("-auth-token"));
+
+  if (!hasAuthCookie) {
+    const isProtectedRoute = request.nextUrl.pathname.startsWith("/dashboard");
+    if (isProtectedRoute) {
+      const url = request.nextUrl.clone();
+      url.pathname = "/auth/login";
+      return NextResponse.redirect(url);
+    }
+    return NextResponse.next({ request });
+  }
+
   let supabaseResponse = NextResponse.next({ request });
 
   const supabase = createServerClient(

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,10 @@
 {
+  "git": {
+    "deploymentEnabled": {
+      "main": true
+    }
+  },
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- src public package.json package-lock.json next.config.ts next.config.js next.config.mjs tsconfig.json vercel.json",
   "redirects": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary

Last cycle's Vercel bill was **$28.64**, and **$26.84 of it was Build Minutes** (94%). Preview deploys on every branch push compounded to ~4h of builds. Function invocations were only $0.60, but middleware was doing a Supabase round-trip on every request regardless of whether the visitor was logged in — optimizing that too while we're here.

## Changes

- **`vercel.json`:** restrict deploys to the `main` branch only (`deploymentEnabled: { main: true }`). This disables preview deploys for PRs, which is the root cause of the build-minutes blow-up.
- **`vercel.json`:** add an `ignoreCommand` so commits touching only docs/configs skip the build entirely.
- **`src/lib/supabase/middleware.ts`:** short-circuit `updateSession()` when no Supabase auth cookie is present. Bots, crawlers, and logged-out visitors no longer trigger a Supabase `getUser()` round-trip on every request. Protected-route behavior is preserved (still redirects to `/auth/login`).

## Expected impact

| Metric | Before | After |
|---|---|---|
| Build Minutes / cycle | 4h 5m | ~30-60 min |
| Bill / cycle | $28.64 | ~$20 flat (back inside included credit) |

## Heads-up

**Preview deploy URLs for PRs are gone** after this merges. If you rely on them for review, you'll need to pull the branch locally or re-enable preview deploys for specific branches via `deploymentEnabled`.

## Test plan

- [ ] Open a PR from a non-main branch after merge → confirm no Vercel deploy triggers
- [ ] Push a doc-only commit to main → confirm build skipped (`ignoreCommand`)
- [ ] Visit homepage logged out → loads normally
- [ ] Visit `/dashboard` logged out → redirects to `/auth/login`
- [ ] Visit `/dashboard` logged in → renders dashboard
- [ ] Monitor Vercel Usage tab for ~24h after deploy → build minutes and function invocations should both drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Streamlined authentication middleware to reduce unnecessary API calls during session verification, improving response times for users without active sessions.

* **Chores**
  * Implemented deployment configuration to enable continuous deployments on the main branch and optimize the build pipeline by ignoring commits affecting only configuration and non-source files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->