### PR TITLE
hotfix: revert middleware auth-cookie short-circuit (P0)

### DIFF
--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -10,25 +10,6 @@ export async function updateSession(request: NextRequest) {
     return NextResponse.next({ request });
   }
 
-  // Short-circuit unauthenticated traffic: no auth cookie means getUser() would
-  // round-trip to Supabase just to return null. Skipping that fetch eliminates
-  // the hot-path cost for bots, crawlers, and logged-out visitors — the bulk of
-  // public traffic — without changing behavior (protected routes still redirect
-  // to login, unprotected routes still render anonymously).
-  const hasAuthCookie = request.cookies
-    .getAll()
-    .some((c) => c.name.startsWith("sb-") && c.name.endsWith("-auth-token"));
-
-  if (!hasAuthCookie) {
-    const isProtectedRoute = request.nextUrl.pathname.startsWith("/dashboard");
-    if (isProtectedRoute) {
-      const url = request.nextUrl.clone();
-      url.pathname = "/auth/login";
-      return NextResponse.redirect(url);
-    }
-    return NextResponse.next({ request });
-  }
-
   let supabaseResponse = NextResponse.next({ request });
 
   const supabase = createServerClient(


### PR DESCRIPTION
## P0 — Infinite redirect loop on /dashboard

After [PR #148](https://github.com/unknownking07/vibe-talent/pull/148) merged, logged-in users clicking Dashboard got caught in an infinite redirect loop between \`/dashboard\` → \`/auth/login\` → \`/dashboard\` → ...

## Root cause

The short-circuit introduced in [PR #148](https://github.com/unknownking07/vibe-talent/pull/148) uses:

\`\`\`ts
c.name.startsWith("sb-") && c.name.endsWith("-auth-token")
\`\`\`

Supabase chunks large session cookies (common for GitHub OAuth tokens) into \`sb-<ref>-auth-token.0\`, \`sb-<ref>-auth-token.1\`, etc. These end with \`.0\` / \`.1\` — **not** \`-auth-token\` — so the check fails for a huge class of real sessions. Those users were classified as anonymous and redirected to \`/auth/login\`. The client-side Supabase SDK then saw a valid session and pushed back to \`/dashboard\`, which the middleware rejected again. Loop.

## Fix

Revert the short-circuit. Middleware is back to its pre-#148 behavior: \`getUser()\` on every request.

## Cost impact

Minimal. The short-circuit only saved ~\$0.60/cycle in function invocations. The real win from [PR #148](https://github.com/unknownking07/vibe-talent/pull/148) — disabling non-main preview deploys in \`vercel.json\` — is untouched and continues to cut ~94% of the bill.

## Test plan

- [ ] Log in with GitHub
- [ ] Click Dashboard → renders once, no loop
- [ ] Log out, click Dashboard → redirects to /auth/login once (no loop)
- [ ] Vercel Usage tab → build minutes still trending near-zero (confirms vercel.json fix still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication checking in middleware to consistently verify user authentication for all routes (when configured), ensuring protected dashboard routes are properly secured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->