### PR TITLE
feat: dashboard dot reflects unlogged-today + add Codex IDE option

### DIFF
--- a/src/app/api/streak/today-logged/route.ts
+++ b/src/app/api/streak/today-logged/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+
+// GET /api/streak/today-logged?date=YYYY-MM-DD — returns { loggedToday }
+//
+// Used by the navbar to decide whether to show the "unlogged activity" dot on
+// the Dashboard link. The client passes its local calendar date so the check
+// matches what POST /api/streak writes (also client-local).
+export async function GET(request: NextRequest) {
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ loggedToday: false });
+  }
+
+  const clientDate = request.nextUrl.searchParams.get("date");
+  const activityDate =
+    clientDate && /^\d{4}-\d{2}-\d{2}$/.test(clientDate)
+      ? clientDate
+      : new Date().toISOString().split("T")[0];
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const sb = supabase as any;
+  const { data, error } = await sb
+    .from("streak_logs")
+    .select("id")
+    .eq("user_id", user.id)
+    .eq("activity_date", activityDate)
+    .limit(1);
+
+  if (error) {
+    console.error("today-logged query failed:", error);
+    return NextResponse.json({ loggedToday: false });
+  }
+
+  return NextResponse.json({ loggedToday: !!(data && data.length > 0) });
+}

--- a/src/app/api/streak/today-logged/route.ts
+++ b/src/app/api/streak/today-logged/route.ts
@@ -1,26 +1,38 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { messagesLimiter, getIP, checkRateLimit } from "@/lib/rate-limit";
 
-// GET /api/streak/today-logged?date=YYYY-MM-DD — returns { loggedToday }
+// GET /api/streak/today-logged?date=YYYY-MM-DD
+// Returns { loggedToday: boolean } for the authenticated user.
 //
-// Used by the navbar to decide whether to show the "unlogged activity" dot on
-// the Dashboard link. The client passes its local calendar date so the check
-// matches what POST /api/streak writes (also client-local).
+// Why the date is required: streak_logs.activity_date is written using the
+// client's local YYYY-MM-DD (see POST /api/streak). If we silently fell back
+// to the server's UTC date here, evening-timezone users would get the wrong
+// answer and the navbar dot would flicker. Force the client to be explicit.
 export async function GET(request: NextRequest) {
+  // Same limiter the streak POST uses — 60/min per IP. Enough headroom for
+  // navbar refetches on focus changes; cheap insurance against scripted abuse.
+  const { success } = await checkRateLimit(messagesLimiter, getIP(request));
+  if (!success) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
   const supabase = await createServerSupabaseClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();
 
   if (!user) {
-    return NextResponse.json({ loggedToday: false });
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const clientDate = request.nextUrl.searchParams.get("date");
-  const activityDate =
-    clientDate && /^\d{4}-\d{2}-\d{2}$/.test(clientDate)
-      ? clientDate
-      : new Date().toISOString().split("T")[0];
+  if (!clientDate || !/^\d{4}-\d{2}-\d{2}$/.test(clientDate)) {
+    return NextResponse.json(
+      { error: "Missing or invalid date parameter (expected YYYY-MM-DD)" },
+      { status: 400 }
+    );
+  }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const sb = supabase as any;
@@ -28,12 +40,12 @@ export async function GET(request: NextRequest) {
     .from("streak_logs")
     .select("id")
     .eq("user_id", user.id)
-    .eq("activity_date", activityDate)
+    .eq("activity_date", clientDate)
     .limit(1);
 
   if (error) {
     console.error("today-logged query failed:", error);
-    return NextResponse.json({ loggedToday: false });
+    return NextResponse.json({ error: "Lookup failed" }, { status: 500 });
   }
 
   return NextResponse.json({ loggedToday: !!(data && data.length > 0) });

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -152,6 +152,9 @@ export default function DashboardPage() {
                   const todayStr = `${nowLocal.getFullYear()}-${String(nowLocal.getMonth() + 1).padStart(2, "0")}-${String(nowLocal.getDate()).padStart(2, "0")}`;
                   if (newStreakData[todayStr]) {
                     setTodayLogged(true);
+                    // Tell navbar the dot can drop — GitHub activity filled
+                    // today's slot without a manual log.
+                    window.dispatchEvent(new Event("streak-updated"));
                   }
                   // Recalculate streak from new data
                   const newDates = Object.keys(newStreakData).sort().reverse();
@@ -382,6 +385,13 @@ export default function DashboardPage() {
         // Update heatmap
         const streakData = await fetchStreakLogs(user.id);
         setHeatmapData(streakData);
+        // If today is now in streak_logs, clear the dot without a reload.
+        const nowLocal = new Date();
+        const todayStr = `${nowLocal.getFullYear()}-${String(nowLocal.getMonth() + 1).padStart(2, "0")}-${String(nowLocal.getDate()).padStart(2, "0")}`;
+        if (streakData[todayStr]) {
+          setTodayLogged(true);
+        }
+        window.dispatchEvent(new Event("streak-updated"));
       } else if (data.error) {
         setGithubSyncResult(`\u26A0 ${data.error}`);
       } else {
@@ -543,6 +553,8 @@ export default function DashboardPage() {
         // Midnight passed — reset so user can log again
         setTodayLogged(false);
         setCountdown("");
+        // Tell navbar the dot should reappear for the new day.
+        window.dispatchEvent(new Event("streak-updated"));
         reloadUser();
         return;
       }
@@ -600,6 +612,9 @@ export default function DashboardPage() {
     setHeatmapData({ ...heatmapData, [today]: (heatmapData[today] || 0) + 1 });
     setTodayLogged(true);
     setLogging(false);
+
+    // Drop the navbar "unlogged activity" dot without a reload.
+    window.dispatchEvent(new Event("streak-updated"));
 
     // Mark streak warning notifications as read and refresh the bell
     fetch("/api/notifications", {

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -538,6 +538,7 @@ export default function SettingsPage() {
               <option value="Claude Code (Pro)">Claude Code (Pro)</option>
               <option value="Claude Code (Max 5x)">Claude Code (Max 5x)</option>
               <option value="Claude Code (Max 20x)">Claude Code (Max 20x)</option>
+              <option value="Codex">Codex</option>
               <option value="Cursor">Cursor</option>
               <option value="Windsurf">Windsurf</option>
               <option value="Antigravity">Antigravity</option>

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -58,17 +58,31 @@ export function Navbar() {
   const [userProfile, setUserProfile] = useState<{ username: string; avatar_url: string | null; github_username: string | null; display_name: string | null } | null>(null);
   const [hasUnloggedActivity, setHasUnloggedActivity] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  // Mirror isLoggedIn into a ref so checkTodayLogged (a stable useCallback)
+  // can read the latest auth state without going stale across re-renders.
+  // Critical for the visibilitychange / streak-updated listeners — without
+  // the guard, anonymous visitors would hit the API and the 401 response
+  // would still leave hasUnloggedActivity true from a prior session.
+  const isLoggedInRef = useRef(false);
 
   const checkTodayLogged = useCallback(async () => {
+    if (!isLoggedInRef.current) {
+      setHasUnloggedActivity(false);
+      return;
+    }
     try {
       const now = new Date();
       const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
       const res = await fetch(`/api/streak/today-logged?date=${today}`);
-      if (!res.ok) return;
+      if (!res.ok) {
+        // 401 / 429 / 5xx — clear the dot rather than leaving a stale value.
+        setHasUnloggedActivity(false);
+        return;
+      }
       const data = await res.json();
       setHasUnloggedActivity(data.loggedToday === false);
     } catch {
-      // Silently fail — dot simply won't show
+      setHasUnloggedActivity(false);
     }
   }, []);
 
@@ -106,6 +120,10 @@ export function Navbar() {
 
     // Check auth once on mount, then listen for changes
     supabase.auth.getUser().then(({ data: { user } }) => {
+      // Update the ref synchronously alongside the state so the very next
+      // checkTodayLogged() call (below, or via event listeners that fire
+      // before React commits) reads the right value.
+      isLoggedInRef.current = !!user;
       setIsLoggedIn(!!user);
       if (user) {
         fetchProfile(user.id, user.email);
@@ -116,6 +134,7 @@ export function Navbar() {
     });
 
     const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      isLoggedInRef.current = !!session?.user;
       setIsLoggedIn(!!session?.user);
       if (session?.user) {
         fetchProfile(session.user.id, session.user.email);
@@ -260,6 +279,9 @@ export function Navbar() {
                 <span
                   className="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full"
                   style={{ backgroundColor: "var(--accent)" }}
+                  role="status"
+                  aria-label="No activity logged today"
+                  title="No activity logged today"
                 />
               )}
             </Link>
@@ -518,6 +540,9 @@ export function Navbar() {
                 <span
                   className="inline-block w-2 h-2 rounded-full ml-1.5 align-middle"
                   style={{ backgroundColor: "var(--accent)" }}
+                  role="status"
+                  aria-label="No activity logged today"
+                  title="No activity logged today"
                 />
               )}
             </Link>

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -56,17 +56,19 @@ export function Navbar() {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [profileDropdownOpen, setProfileDropdownOpen] = useState(false);
   const [userProfile, setUserProfile] = useState<{ username: string; avatar_url: string | null; github_username: string | null; display_name: string | null } | null>(null);
-  const [hasUnreadNotifications, setHasUnreadNotifications] = useState(false);
+  const [hasUnloggedActivity, setHasUnloggedActivity] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  const checkUnread = useCallback(async () => {
+  const checkTodayLogged = useCallback(async () => {
     try {
-      const res = await fetch("/api/notifications");
+      const now = new Date();
+      const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+      const res = await fetch(`/api/streak/today-logged?date=${today}`);
       if (!res.ok) return;
       const data = await res.json();
-      setHasUnreadNotifications((data.unread_count || 0) > 0);
+      setHasUnloggedActivity(data.loggedToday === false);
     } catch {
-      // Silently fail
+      // Silently fail — dot simply won't show
     }
   }, []);
 
@@ -107,7 +109,9 @@ export function Navbar() {
       setIsLoggedIn(!!user);
       if (user) {
         fetchProfile(user.id, user.email);
-        checkUnread();
+        checkTodayLogged();
+      } else {
+        setHasUnloggedActivity(false);
       }
     });
 
@@ -115,8 +119,10 @@ export function Navbar() {
       setIsLoggedIn(!!session?.user);
       if (session?.user) {
         fetchProfile(session.user.id, session.user.email);
+        checkTodayLogged();
       } else {
         setUserProfile(null);
+        setHasUnloggedActivity(false);
       }
     });
 
@@ -129,17 +135,27 @@ export function Navbar() {
     };
     window.addEventListener("profile-updated", handleProfileUpdated);
 
-    // Refresh the Dashboard-link dot when notifications change (e.g. after
-    // the user logs activity, which marks streak_warning notifications read).
-    // Without this, the dot only clears on a hard refresh.
-    window.addEventListener("notifications-updated", checkUnread);
+    // The dashboard dispatches this after manual Log Activity, successful
+    // GitHub sync, and midnight rollover. Refetch so the dot updates without
+    // a full page reload.
+    window.addEventListener("streak-updated", checkTodayLogged);
+
+    // Catch the "pushed to GitHub in another tab/terminal, came back" case:
+    // when the tab regains focus, re-check. GitHub auto-sync is scheduled
+    // server-side, so by the time the user comes back, streak_logs may have
+    // been updated and the dot should clear.
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") checkTodayLogged();
+    };
+    document.addEventListener("visibilitychange", handleVisibility);
 
     return () => {
       subscription.unsubscribe();
       window.removeEventListener("profile-updated", handleProfileUpdated);
-      window.removeEventListener("notifications-updated", checkUnread);
+      window.removeEventListener("streak-updated", checkTodayLogged);
+      document.removeEventListener("visibilitychange", handleVisibility);
     };
-  }, [checkUnread]);
+  }, [checkTodayLogged]);
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -240,7 +256,7 @@ export function Navbar() {
               }}
             >
               {link.label}
-              {link.href === "/dashboard" && hasUnreadNotifications && (
+              {link.href === "/dashboard" && hasUnloggedActivity && (
                 <span
                   className="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full"
                   style={{ backgroundColor: "var(--accent)" }}
@@ -498,7 +514,7 @@ export function Navbar() {
               }}
             >
               {link.label}
-              {link.href === "/dashboard" && hasUnreadNotifications && (
+              {link.href === "/dashboard" && hasUnloggedActivity && (
                 <span
                   className="inline-block w-2 h-2 rounded-full ml-1.5 align-middle"
                   style={{ backgroundColor: "var(--accent)" }}


### PR DESCRIPTION
## What this does

Two small fixes bundled together.

### 1. Dashboard notification dot — new rule

**Before:** Dot was driven by unread \`streak_warning\` notifications created by a cron job. It appeared late (whenever the cron fired) and didn't clear when the user's activity came from a GitHub commit instead of the manual "Log Activity" button.

**After:** Dot simply mirrors "has the user logged activity for the current local day?" — no notification plumbing.

Dot appears:
- As soon as the calendar rolls over to a new local day (via the dashboard's existing midnight countdown)
- On login / tab-regain if today's slot is empty

Dot clears (without a page refresh) via any of:
- ✅ Clicking **Log Activity**
- ✅ Clicking **Sync Now** (if it pulls in today's commits)
- ✅ Auto-sync finishing and finding today's GitHub activity
- ✅ Returning focus to the tab after a GitHub push (visibilitychange re-checks)

### 2. Codex as vibecoding IDE option

One-line addition to the IDE dropdown in Settings, placed between the Claude Code variants and Cursor (both AI-agent CLIs).

## Files changed

- **\`src/app/api/streak/today-logged/route.ts\`** (new) — \`GET\` endpoint returning \`{ loggedToday: boolean }\`. Cheap single-row \`streak_logs\` lookup, accepts client's local \`YYYY-MM-DD\`.
- **\`src/components/layout/navbar.tsx\`** — replaces notifications-count check with today-logged fetch; listens for new \`streak-updated\` window event; re-checks on \`visibilitychange\`.
- **\`src/app/dashboard/page.tsx\`** — dispatches \`streak-updated\` on manual log, successful sync, auto-sync-fills-today, and midnight rollover. Existing \`streak_warning\` mark-as-read is untouched (the bell badge still clears correctly).
- **\`src/app/settings/page.tsx\`** — one \`<option value=\"Codex\">Codex</option>\`.

## Cost impact

One new lightweight DB query on navbar mount (single-row lookup by indexed \`user_id + activity_date\`). Offset by removing the notifications-count query that used to fire on every mount. Net near-zero.

## Test plan

Dot behavior:
- [ ] Load dashboard without logging → dot visible
- [ ] Click Log Activity → dot disappears instantly
- [ ] In a new tab: \`POST /api/streak\` to log today → switch back to the first tab → dot clears on focus
- [ ] Click Sync Now after a GitHub commit → dot clears if sync logged today
- [ ] At local midnight, dot reappears without refresh
- [ ] Log out → dot never shows

Codex option:
- [ ] Settings page shows Codex in the Vibe Coding IDE dropdown, positioned between Claude Code (Max 20x) and Cursor
- [ ] Selecting Codex and saving persists the value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "logged today" visual indicator in the navbar.
  * Added Codex as an IDE option in Settings.
* **Improvements**
  * Real-time synchronization so streak status updates propagate across the app.
  * Navbar now avoids unnecessary checks for anonymous visitors and refreshes status when the app becomes visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->