### PR TITLE
feat: nudge new builders to share referral link

### DIFF
--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -10,6 +10,7 @@ const ALLOWED_NOTIFICATION_TYPES = [
   "endorsement",
   "review",
   "streak_milestone",
+  "referral_prompt",
 ] as const;
 
 export async function GET() {

--- a/src/app/api/notifications/welcome-referral/route.ts
+++ b/src/app/api/notifications/welcome-referral/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { createNotification } from "@/lib/notifications";
+
+export async function POST() {
+  try {
+    const supabase = await createServerSupabaseClient();
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sb = supabase as any;
+    const { data: existing } = await sb
+      .from("notifications")
+      .select("id")
+      .eq("user_id", user.id)
+      .eq("type", "referral_prompt")
+      .limit(1)
+      .maybeSingle();
+
+    if (existing) {
+      return NextResponse.json({ ok: true, skipped: true });
+    }
+
+    await createNotification({
+      user_id: user.id,
+      type: "referral_prompt",
+      title: "Bring your dev frens",
+      message: "Share your referral link from Settings — every signup earns you a streak day.",
+      metadata: { link: "/settings#referral" },
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}

--- a/src/app/auth/profile-setup/page.tsx
+++ b/src/app/auth/profile-setup/page.tsx
@@ -904,6 +904,8 @@ export default function ProfileSetupPage() {
                 }
                 localStorage.removeItem("referral_code");
               }
+              // Drop a one-time in-app nudge so new builders share their referral link.
+              fetch("/api/notifications/welcome-referral", { method: "POST" }).catch(() => {});
               router.push("/dashboard");
             }}
             className="btn-brutal btn-brutal-primary w-full justify-center text-sm"

--- a/src/components/ui/notification-bell.tsx
+++ b/src/components/ui/notification-bell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import { Bell, Flame, Trophy, CheckCircle, AlertTriangle, Mail, Star, Eye, BarChart3, Zap, LinkIcon } from "lucide-react";
+import { Bell, Flame, Trophy, CheckCircle, AlertTriangle, Mail, Star, Eye, BarChart3, Zap, LinkIcon, Users } from "lucide-react";
 import { useRouter } from "next/navigation";
 import type { Notification } from "@/lib/types/database";
 
@@ -17,6 +17,7 @@ const typeIcons: Record<string, typeof Bell> = {
   weekly_digest: BarChart3,
   vibe_score_milestone: Zap,
   project_missing_links: LinkIcon,
+  referral_prompt: Users,
 };
 
 const typeColors: Record<string, string> = {
@@ -31,6 +32,7 @@ const typeColors: Record<string, string> = {
   weekly_digest: "#6366F1",
   vibe_score_milestone: "#FF3A00",
   project_missing_links: "#F59E0B",
+  referral_prompt: "#FF3A00",
 };
 
 function timeAgo(dateStr: string): string {
@@ -118,7 +120,8 @@ export function NotificationBell() {
       setUnreadCount(prev => Math.max(0, prev - 1));
     }
     setOpen(false);
-    router.push("/dashboard");
+    const link = typeof notification.metadata?.link === "string" ? notification.metadata.link : null;
+    router.push(link || "/dashboard");
   };
 
   return (

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -132,7 +132,7 @@ export interface Referral {
   created_at: string;
 }
 
-export type NotificationType = "hire_request" | "streak_milestone" | "streak_warning" | "badge_earned" | "project_verified" | "project_flagged" | "new_review" | "profile_view_summary" | "weekly_digest" | "vibe_score_milestone" | "project_missing_links";
+export type NotificationType = "hire_request" | "streak_milestone" | "streak_warning" | "badge_earned" | "project_verified" | "project_flagged" | "new_review" | "profile_view_summary" | "weekly_digest" | "vibe_score_milestone" | "project_missing_links" | "referral_prompt";
 
 export interface ProfileView {
   id: string;

--- a/supabase/migrations/20260425_add_referral_prompt_notification_type.sql
+++ b/supabase/migrations/20260425_add_referral_prompt_notification_type.sql
@@ -1,0 +1,12 @@
+-- Add `referral_prompt` to notifications.type — fired once after profile-setup
+-- completes to nudge new builders to share their referral link.
+
+ALTER TABLE notifications DROP CONSTRAINT IF EXISTS notifications_type_check;
+ALTER TABLE notifications ADD CONSTRAINT notifications_type_check
+  CHECK (type IN (
+    'hire_request', 'streak_milestone', 'streak_warning',
+    'badge_earned', 'project_verified', 'project_flagged',
+    'new_review', 'profile_view_summary', 'weekly_digest',
+    'vibe_score_milestone', 'project_missing_links',
+    'referral_prompt'
+  ));


### PR DESCRIPTION
## Summary
- Drops a one-time `referral_prompt` in-app notification when a new user finishes profile-setup, deep-linking to `/settings#referral`
- Server-side idempotent — re-entering onboarding won't spam duplicates
- Bell click routing now reads `metadata.link` (falls back to `/dashboard`), so every existing notification type's behavior is unchanged

## Files changed
- `supabase/migrations/20260425_add_referral_prompt_notification_type.sql` — extends `notifications_type_check` with `referral_prompt`
- `src/app/api/notifications/welcome-referral/route.ts` — new POST endpoint, auth-gated, idempotent
- `src/lib/types/database.ts` — adds `"referral_prompt"` to `NotificationType`
- `src/app/api/notifications/route.ts` — adds `"referral_prompt"` to PATCH allowlist
- `src/components/ui/notification-bell.tsx` — `Users` icon + `#FF3A00` accent for the new type, generic `metadata.link` routing
- `src/app/auth/profile-setup/page.tsx` — fire-and-forget POST in the "Complete Setup" handler

## Apply migration before merging
```bash
supabase db push
```
Or paste the SQL into the Supabase dashboard. Pure CHECK-constraint extension — no backfill, same shape as `20260325`/`20260327`/`20260419`.

## Test plan
- [ ] Apply migration to staging DB
- [ ] Sign up with a fresh account
- [ ] Finish all 4 onboarding steps → click "Complete Setup"
- [ ] On `/dashboard`, open the bell → see "Bring your dev frens" with red dot
- [ ] Click it → lands on `/settings#referral` with the referral card scrolled into view
- [ ] Re-enter profile-setup and finish again → no duplicate notification
- [ ] Existing notification types (e.g. trigger a hire request) still route to `/dashboard`

## Audit
Verified the `metadata.link`-based routing change is safe across every existing `createNotification` callsite — none of them set `metadata.link`, so all existing types preserve their `/dashboard` route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)