### PR TITLE
fix: sync github_username on profile save + don't fake-verify on quality failure

### DIFF
--- a/src/app/api/cron/verify-backfill/route.ts
+++ b/src/app/api/cron/verify-backfill/route.ts
@@ -56,10 +56,17 @@ export async function GET(req: NextRequest) {
     // projects once the stuck backlog exceeds MAX_PROJECTS_PER_RUN.
     const retryWindow = new Date(Date.now() - RETRY_WINDOW_DAYS * 24 * 60 * 60 * 1000).toISOString();
 
+    // Two classes of candidates:
+    //   1. verified=false — never (successfully) verified yet.
+    //   2. verified=true AND quality_metrics IS NULL — legacy rows from the
+    //      old auto-verify path that marked verified without metrics when
+    //      the GitHub analysis silently failed (e.g. rate limit during
+    //      the after() callback). These need a re-analysis to populate the
+    //      quality_score; otherwise they show "Verified" with score 0 forever.
     const { data: candidates, error: projectsError } = await sb
       .from("projects")
-      .select("id, user_id, github_url, live_url, title")
-      .eq("verified", false)
+      .select("id, user_id, github_url, live_url, title, verified")
+      .or("verified.eq.false,quality_metrics.is.null")
       .eq("flagged", false)
       .not("github_url", "is", null)
       .neq("github_url", "")
@@ -116,6 +123,7 @@ export async function GET(req: NextRequest) {
             github_url: string;
             live_url: string | null;
             title: string;
+            verified: boolean;
           }) => {
             try {
               const parsed = parseGithubRepoUrl(project.github_url);
@@ -189,13 +197,17 @@ export async function GET(req: NextRequest) {
 
               verified++;
 
-              createNotification({
-                user_id: project.user_id,
-                type: "project_verified",
-                title: "Project auto-verified",
-                message: `Your project "${project.title}" was auto-verified. Quality score: ${qualityScore}/100.`,
-                metadata: { project_id: project.id, quality_score: qualityScore },
-              }).catch((err) => console.error("verify-backfill: notification failed:", err));
+              // Only notify on the first verification — projects already
+              // verified are just getting their quality_metrics backfilled.
+              if (!project.verified) {
+                createNotification({
+                  user_id: project.user_id,
+                  type: "project_verified",
+                  title: "Project auto-verified",
+                  message: `Your project "${project.title}" was auto-verified. Quality score: ${qualityScore}/100.`,
+                  metadata: { project_id: project.id, quality_score: qualityScore },
+                }).catch((err) => console.error("verify-backfill: notification failed:", err));
+              }
             } catch (err) {
               console.error(`verify-backfill: failed for project ${project.id}:`, err);
               errors++;

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -124,23 +124,35 @@ export async function POST(request: NextRequest) {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const sb = supabase as any;
             const qualityResult = await analyzeRepository(repoOwner, repoName);
-            const qualityScore = qualityResult.success ? (qualityResult.metrics?.quality_score ?? 0) : 0;
-            const qualityMetrics = (qualityResult.success && qualityResult.metrics)
-              ? {
-                  stars: qualityResult.metrics.stars,
-                  forks: qualityResult.metrics.forks,
-                  contributors: qualityResult.metrics.contributors,
-                  total_commits: qualityResult.metrics.total_commits,
-                  has_tests: qualityResult.metrics.has_tests,
-                  has_ci: qualityResult.metrics.has_ci,
-                  has_readme: qualityResult.metrics.has_readme,
-                  community_score: qualityResult.metrics.community_score,
-                  substance_score: qualityResult.metrics.substance_score,
-                  maintenance_score: qualityResult.metrics.maintenance_score,
-                  quality_score: qualityResult.metrics.quality_score,
-                  analyzed_at: new Date().toISOString(),
-                }
-              : null;
+
+            // If GitHub analysis fails (rate limit, transient API error, etc.)
+            // leave the project unverified so the cron backfill can retry it.
+            // Marking verified=true with quality_score=0 was hiding silent
+            // failures from users.
+            if (!qualityResult.success || !qualityResult.metrics) {
+              console.error(
+                "Auto-verify skipped for project",
+                data.id,
+                "quality analysis failed"
+              );
+              return;
+            }
+
+            const qualityScore = qualityResult.metrics.quality_score;
+            const qualityMetrics = {
+              stars: qualityResult.metrics.stars,
+              forks: qualityResult.metrics.forks,
+              contributors: qualityResult.metrics.contributors,
+              total_commits: qualityResult.metrics.total_commits,
+              has_tests: qualityResult.metrics.has_tests,
+              has_ci: qualityResult.metrics.has_ci,
+              has_readme: qualityResult.metrics.has_readme,
+              community_score: qualityResult.metrics.community_score,
+              substance_score: qualityResult.metrics.substance_score,
+              maintenance_score: qualityResult.metrics.maintenance_score,
+              quality_score: qualityResult.metrics.quality_score,
+              analyzed_at: new Date().toISOString(),
+            };
 
             let live_url_ok: boolean | null = null;
             if (liveUrlTrim) {

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -133,7 +133,8 @@ export async function POST(request: NextRequest) {
               console.error(
                 "Auto-verify skipped for project",
                 data.id,
-                "quality analysis failed"
+                "quality analysis failed:",
+                qualityResult.error ?? "unknown error"
               );
               return;
             }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -37,6 +37,56 @@ import {
   Zap,
 } from "lucide-react";
 
+// Isolated 1Hz timer so it does not re-render the entire DashboardPage tree
+// (heatmap, project cards, milestone, etc.) every second. With this lifted
+// out, the per-second update only re-renders ~3 DOM nodes; left in the
+// parent, an open dashboard tab built up enough reconciliation work over
+// hours to noticeably slow the browser.
+function MidnightCountdown({ onMidnight }: { onMidnight: () => void }) {
+  const [label, setLabel] = useState("");
+  // Read the latest callback via ref so a changing prop identity does not
+  // restart the interval on every parent re-render.
+  const onMidnightRef = useRef(onMidnight);
+  useEffect(() => {
+    onMidnightRef.current = onMidnight;
+  }, [onMidnight]);
+
+  useEffect(() => {
+    const tick = () => {
+      // Skip work while the tab is hidden — user can't see the value, and
+      // browsers throttle setInterval anyway, so this just avoids needless
+      // setState + reconciliation while backgrounded.
+      if (typeof document !== "undefined" && document.hidden) return;
+      const now = new Date();
+      const midnight = new Date(now);
+      midnight.setHours(24, 0, 0, 0);
+      const diff = midnight.getTime() - now.getTime();
+      if (diff <= 0) {
+        onMidnightRef.current();
+        return;
+      }
+      const hours = Math.floor(diff / 3_600_000);
+      const minutes = Math.floor((diff % 3_600_000) / 60_000);
+      const seconds = Math.floor((diff % 60_000) / 1000);
+      setLabel(
+        `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`
+      );
+    };
+    tick();
+    const interval = setInterval(tick, 1000);
+    // Re-sync immediately when the tab becomes visible after being hidden,
+    // otherwise the displayed value would lag by up to a second.
+    const onVisibility = () => { if (!document.hidden) tick(); };
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, []);
+
+  return <>{label}</>;
+}
+
 export default function DashboardPage() {
   const [user, setUser] = useState<UserWithSocials | null>(null);
   const [heatmapData, setHeatmapData] = useState<Record<string, number>>({});
@@ -263,7 +313,6 @@ export default function DashboardPage() {
   const [todayLogged, setTodayLogged] = useState(false);
   const [logging, setLogging] = useState(false);
   const [logError, setLogError] = useState<string | null>(null);
-  const [countdown, setCountdown] = useState("");
   const [addingProject, setAddingProject] = useState(false);
   const [editingProjectId, setEditingProjectId] = useState<string | null>(null);
   const [editingOriginalGithubUrl, setEditingOriginalGithubUrl] = useState<string>("");
@@ -527,9 +576,12 @@ export default function DashboardPage() {
     setSendingReply(false);
   };
 
-  // Check if already logged today on mount
+  // Check if already logged today on mount. Keyed on user.id (not the whole
+  // user object) so the query does not re-run on every setUser call — e.g.
+  // the optimistic streak/longest_streak update after Log Activity used to
+  // re-trigger this effect because setUser swapped the object reference.
   useEffect(() => {
-    if (!user) return;
+    if (!user?.id) return;
     const supabase = createClient();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sb = supabase as any;
@@ -539,34 +591,17 @@ export default function DashboardPage() {
       .then(({ data }: { data: { id: string }[] | null }) => {
         if (data && data.length > 0) setTodayLogged(true);
       });
-  }, [user]);
+  }, [user?.id]);
 
-  // Countdown timer until midnight
-  useEffect(() => {
-    if (!todayLogged) return;
-    const updateCountdown = () => {
-      const now = new Date();
-      const midnight = new Date(now);
-      midnight.setHours(24, 0, 0, 0);
-      const diff = midnight.getTime() - now.getTime();
-      if (diff <= 0) {
-        // Midnight passed — reset so user can log again
-        setTodayLogged(false);
-        setCountdown("");
-        // Tell navbar the dot should reappear for the new day.
-        window.dispatchEvent(new Event("streak-updated"));
-        reloadUser();
-        return;
-      }
-      const hours = Math.floor(diff / (1000 * 60 * 60));
-      const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
-      const seconds = Math.floor((diff % (1000 * 60)) / 1000);
-      setCountdown(`${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`);
-    };
-    updateCountdown();
-    const interval = setInterval(updateCountdown, 1000);
-    return () => clearInterval(interval);
-  }, [todayLogged, reloadUser]);
+  // Midnight rollover handler — fires from <MidnightCountdown /> when the
+  // countdown ticks past 00:00. Resets the local state so the user can log
+  // again, tells the navbar to bring the unlogged-today dot back, and
+  // refreshes the profile so streak/badge values reflect the new day.
+  const handleMidnight = useCallback(() => {
+    setTodayLogged(false);
+    window.dispatchEvent(new Event("streak-updated"));
+    reloadUser();
+  }, [reloadUser]);
 
   const handleLogActivity = async () => {
     if (!user || todayLogged || logging) return;
@@ -1331,7 +1366,9 @@ export default function DashboardPage() {
               </div>
               <div className="flex items-center justify-center gap-1.5">
                 <Clock size={12} className="text-[var(--status-success-text)]" />
-                <span className="text-sm font-extrabold font-mono text-[var(--status-success-text)]">{countdown}</span>
+                <span className="text-sm font-extrabold font-mono text-[var(--status-success-text)]">
+                  <MidnightCountdown onMidnight={handleMidnight} />
+                </span>
               </div>
             </div>
           ) : (

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -52,19 +52,35 @@ function MidnightCountdown({ onMidnight }: { onMidnight: () => void }) {
   }, [onMidnight]);
 
   useEffect(() => {
+    // Detect midnight rollover by comparing the local calendar date
+    // between ticks. We can't use a `diff <= 0` check against the next
+    // midnight: setHours(24, 0, 0, 0) always produces *next* midnight,
+    // so the moment we cross 00:00 the target jumps a full 24h ahead and
+    // diff is never ≤ 0. The previous in-parent implementation had the
+    // same bug — a user who left the dashboard open across midnight
+    // would see the countdown wrap to "21:00:00" instead of resetting.
+    let prevLocalDate: string | null = null;
+
     const tick = () => {
-      // Skip work while the tab is hidden — user can't see the value, and
-      // browsers throttle setInterval anyway, so this just avoids needless
-      // setState + reconciliation while backgrounded.
-      if (typeof document !== "undefined" && document.hidden) return;
+      // Skip while the tab is hidden — the visibilitychange handler
+      // calls tick() the moment the user returns, which both re-syncs
+      // the display and catches a crossed-midnight rollover.
+      if (document.hidden) return;
       const now = new Date();
-      const midnight = new Date(now);
-      midnight.setHours(24, 0, 0, 0);
-      const diff = midnight.getTime() - now.getTime();
-      if (diff <= 0) {
+      const today = now.toDateString();
+      if (prevLocalDate !== null && prevLocalDate !== today) {
+        // Update the ref before firing so a duplicate tick (setInterval
+        // racing with visibilitychange) does not re-trigger onMidnight
+        // before the parent unmounts this component.
+        prevLocalDate = today;
         onMidnightRef.current();
         return;
       }
+      prevLocalDate = today;
+
+      const midnight = new Date(now);
+      midnight.setHours(24, 0, 0, 0);
+      const diff = midnight.getTime() - now.getTime();
       const hours = Math.floor(diff / 3_600_000);
       const minutes = Math.floor((diff % 3_600_000) / 60_000);
       const seconds = Math.floor((diff % 60_000) / 1000);
@@ -75,7 +91,8 @@ function MidnightCountdown({ onMidnight }: { onMidnight: () => void }) {
     tick();
     const interval = setInterval(tick, 1000);
     // Re-sync immediately when the tab becomes visible after being hidden,
-    // otherwise the displayed value would lag by up to a second.
+    // otherwise the displayed value would lag by up to a second and a
+    // crossed-midnight rollover would wait for the next setInterval tick.
     const onVisibility = () => { if (!document.hidden) tick(); };
     document.addEventListener("visibilitychange", onVisibility);
     return () => {

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -243,18 +243,24 @@ export default function SettingsPage() {
     const sb = supabase as any;
 
     const trimmedDisplayName = profileForm.display_name.trim();
+
+    // Preserve the verified GitHub handle — it's only set via OAuth linking,
+    // never from a free-text field on this page.
+    const verifiedGithub = user.github_username || user.social_links?.github || null;
+
+    // Backfill users.github_username for accounts that linked GitHub after
+    // initial signup: the OAuth callback sets it, but earlier flows could
+    // leave it null while social_links.github was populated, which kept the
+    // blue verified badge from rendering.
     await sb
       .from("users")
       .update({
         username: profileForm.username.trim(),
         display_name: trimmedDisplayName || null,
         bio: profileForm.bio.trim(),
+        github_username: verifiedGithub,
       })
       .eq("id", user.id);
-
-    // Preserve the verified GitHub handle — it's only set via OAuth linking,
-    // never from a free-text field on this page.
-    const verifiedGithub = user.github_username || user.social_links?.github || null;
 
     await sb.from("social_links").upsert({
       user_id: user.id,
@@ -270,6 +276,7 @@ export default function SettingsPage() {
       username: profileForm.username,
       display_name: trimmedDisplayName || null,
       bio: profileForm.bio,
+      github_username: verifiedGithub,
       social_links: {
         id: user.social_links?.id || "",
         user_id: user.id,

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -244,14 +244,27 @@ export default function SettingsPage() {
 
     const trimmedDisplayName = profileForm.display_name.trim();
 
-    // Preserve the verified GitHub handle — it's only set via OAuth linking,
-    // never from a free-text field on this page.
-    const verifiedGithub = user.github_username || user.social_links?.github || null;
+    // Source of truth for the verified GitHub handle is the OAuth identity in
+    // the auth session — never social_links.github, which is just a mirror.
+    // This matches loadUserData's lookup so a save always agrees with the
+    // initial sync on page load.
+    const { data: { user: authUser } } = await supabase.auth.getUser();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const ghIdentity = authUser?.identities?.find((i: any) => i.provider === "github");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const ghData = (ghIdentity?.identity_data ?? {}) as any;
+    const oauthGithub =
+      ghData.user_name ||
+      ghData.preferred_username ||
+      authUser?.user_metadata?.user_name ||
+      authUser?.user_metadata?.preferred_username ||
+      null;
+    const verifiedGithub = user.github_username || oauthGithub;
 
     // Backfill users.github_username for accounts that linked GitHub after
     // initial signup: the OAuth callback sets it, but earlier flows could
-    // leave it null while social_links.github was populated, which kept the
-    // blue verified badge from rendering.
+    // leave it null while the GitHub identity was already attached, which
+    // kept the blue verified badge from rendering.
     await sb
       .from("users")
       .update({


### PR DESCRIPTION
## Summary

Three related fixes for the verified-badge + project quality_score gaps:

- **Settings page** now writes `users.github_username` (not just `social_links.github`) so accounts that link GitHub *after* initial signup get the blue badge. The OAuth callback was the only path writing this field, leaving GitHub-linked-later users stuck without a badge despite being legitimately verified. **29 affected users were backfilled via SQL** ahead of this PR.
- **Auto-verify in `/api/projects`** no longer marks `verified=true` with `quality_score=0` when `analyzeRepository()` fails. Silent GitHub API failures (rate limits, transient errors) were hiding behind a "Verified" tag with no score. Failed projects now stay unverified for the cron to retry.
- **`/api/cron/verify-backfill`** query extended to also catch projects with `verified=true` AND `quality_metrics IS NULL` — legacy rows from the old auto-verify behavior that need a re-analysis. Duplicate "auto-verified" notification suppressed for these second-pass updates.

## Test plan

- [ ] Saving the settings page on an account where `users.github_username IS NULL` and `social_links.github` is set populates `github_username` and renders the blue badge without a refresh
- [ ] Creating a project with a GitHub URL that fails `analyzeRepository()` leaves `verified = false` (not `true` with `quality_score = 0`)
- [ ] Triggering `/api/cron/verify-backfill` after deploy picks up Shubham's stuck project (`Proof Of Build`) and writes a real `quality_score` + `quality_metrics`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quality metrics backfilling now applies to legacy verified projects missing metric data.

* **Bug Fixes**
  * Auto-verify no longer marks projects as verified with zero quality scores when analysis fails; projects remain unverified for later retry.
  * Notifications are now conditional, preventing duplicates when backfilling metrics.
  * Midnight countdown logic refactored for improved dashboard reliability.
  * GitHub username handling improved during profile saves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->