### PR TITLE
fix: harden trigger functions against Supabase search_path tightening

### DIFF
--- a/supabase/migrations/20260426_harden_trigger_search_paths.sql
+++ b/supabase/migrations/20260426_harden_trigger_search_paths.sql
@@ -1,0 +1,246 @@
+-- Harden every plpgsql trigger function against Supabase's "Function Search
+-- Path Mutable" auto-tightening, which silently sets search_path = "" on
+-- existing functions and breaks any unqualified table reference with
+-- `relation "X" does not exist` (Postgres 42P01).
+--
+-- Incident (2026-04-26): notify_badge_change and notify_streak_milestone
+-- both got search_path="" applied by Supabase, so the AFTER UPDATE triggers
+-- on `users` failed when /api/streak's POST → update_user_streak ran. The
+-- whole streak_logs INSERT transaction aborted → 500 in production.
+--
+-- This migration:
+--   1. Sets `SET search_path = public, pg_temp` on every trigger function
+--      so the next sweep can't break them.
+--   2. Schema-qualifies every table reference (public.notifications,
+--      public.users, etc.) so the function works even if search_path
+--      is later forced empty again.
+--
+-- All CREATE OR REPLACE — safe to re-run.
+
+-- ============================================================
+-- update_user_streak: heavy lifter, recomputes streak + vibe_score.
+-- Body matches 20260411_tiered_review_bonus.sql exactly, only adds
+-- search_path setting and public.* qualifiers.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.update_user_streak(p_user_id UUID)
+RETURNS void
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_current_streak INTEGER := 0;
+  v_longest_streak INTEGER := 0;
+  v_temp_streak INTEGER := 1;
+  v_prev_date DATE;
+  v_curr_date DATE;
+  v_last_date DATE;
+  v_today DATE := CURRENT_DATE;
+  rec RECORD;
+BEGIN
+  FOR rec IN
+    SELECT DISTINCT activity_date
+    FROM public.streak_logs
+    WHERE user_id = p_user_id
+    ORDER BY activity_date ASC
+  LOOP
+    v_curr_date := rec.activity_date;
+
+    IF v_prev_date IS NOT NULL THEN
+      IF v_curr_date - v_prev_date = 1 THEN
+        v_temp_streak := v_temp_streak + 1;
+      ELSE
+        v_temp_streak := 1;
+      END IF;
+    END IF;
+
+    IF v_temp_streak > v_longest_streak THEN
+      v_longest_streak := v_temp_streak;
+    END IF;
+
+    v_last_date := v_curr_date;
+    v_prev_date := v_curr_date;
+  END LOOP;
+
+  IF v_last_date IS NOT NULL AND (v_today - v_last_date) <= 1 THEN
+    v_current_streak := v_temp_streak;
+  ELSE
+    v_current_streak := 0;
+  END IF;
+
+  UPDATE public.users
+  SET
+    streak = v_current_streak,
+    longest_streak = GREATEST(longest_streak, v_longest_streak),
+    badge_level = CASE
+      WHEN GREATEST(longest_streak, v_longest_streak) >= 365 THEN 'diamond'::badge_level
+      WHEN GREATEST(longest_streak, v_longest_streak) >= 180 THEN 'gold'::badge_level
+      WHEN GREATEST(longest_streak, v_longest_streak) >= 90 THEN 'silver'::badge_level
+      WHEN GREATEST(longest_streak, v_longest_streak) >= 30 THEN 'bronze'::badge_level
+      ELSE 'none'::badge_level
+    END,
+    vibe_score =
+      10
+      + (v_current_streak * 2)
+      + COALESCE((
+        SELECT SUM(
+          2
+          + CASE WHEN live_url IS NOT NULL AND live_url != '' THEN 2 ELSE 0 END
+          + CASE WHEN github_url IS NOT NULL AND github_url != '' THEN 2 ELSE 0 END
+          + CASE WHEN quality_score > 0 THEN LEAST(quality_score, 100) ELSE 0 END
+        ) FROM public.projects WHERE projects.user_id = p_user_id AND NOT COALESCE(flagged, false)
+      ), 0)
+      + COALESCE((
+        SELECT COUNT(*) * 5
+        FROM public.project_endorsements pe
+        JOIN public.projects p ON p.id = pe.project_id
+        WHERE p.user_id = p_user_id AND NOT COALESCE(p.flagged, false)
+      ), 0)
+      + CASE
+        WHEN GREATEST(longest_streak, v_longest_streak) >= 365 THEN 40
+        WHEN GREATEST(longest_streak, v_longest_streak) >= 180 THEN 30
+        WHEN GREATEST(longest_streak, v_longest_streak) >= 90 THEN 20
+        WHEN GREATEST(longest_streak, v_longest_streak) >= 30 THEN 10
+        ELSE 0
+      END
+      + COALESCE((
+        SELECT SUM(
+          CASE rating
+            WHEN 5 THEN 20
+            WHEN 4 THEN 15
+            WHEN 3 THEN 10
+            WHEN 2 THEN 5
+            ELSE 0
+          END
+        )
+        FROM public.reviews
+        WHERE builder_id = p_user_id
+          AND COALESCE(trust_score, 100) >= 30
+      ), 0)
+  WHERE id = p_user_id;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================
+-- trigger_update_streak: AFTER INSERT on streak_logs
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.trigger_update_streak()
+RETURNS TRIGGER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  PERFORM public.update_user_streak(NEW.user_id);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================
+-- trigger_update_vibe_score_on_project: AFTER INSERT/UPDATE/DELETE on projects
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.trigger_update_vibe_score_on_project()
+RETURNS TRIGGER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    PERFORM public.update_user_streak(OLD.user_id);
+    RETURN OLD;
+  ELSE
+    PERFORM public.update_user_streak(NEW.user_id);
+    RETURN NEW;
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================
+-- trigger_update_vibe_score_on_endorsement: AFTER INSERT/DELETE on project_endorsements
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.trigger_update_vibe_score_on_endorsement()
+RETURNS TRIGGER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_project_owner UUID;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    SELECT user_id INTO v_project_owner FROM public.projects WHERE id = OLD.project_id;
+  ELSE
+    SELECT user_id INTO v_project_owner FROM public.projects WHERE id = NEW.project_id;
+  END IF;
+
+  IF v_project_owner IS NOT NULL THEN
+    PERFORM public.update_user_streak(v_project_owner);
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================
+-- trigger_update_vibe_score_on_review: AFTER INSERT on reviews
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.trigger_update_vibe_score_on_review()
+RETURNS TRIGGER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  PERFORM public.update_user_streak(NEW.builder_id);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================
+-- trigger_init_vibe_score: AFTER INSERT on users
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.trigger_init_vibe_score()
+RETURNS TRIGGER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  PERFORM public.update_user_streak(NEW.id);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================
+-- notify_badge_change: AFTER UPDATE OF badge_level on users
+-- (Already fixed in production via direct SQL on 2026-04-26;
+--  re-affirmed here so fresh environments get the fix too.)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.notify_badge_change()
+RETURNS TRIGGER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  IF OLD.badge_level IS DISTINCT FROM NEW.badge_level AND NEW.badge_level != 'none' THEN
+    INSERT INTO public.notifications (user_id, type, title, message, metadata)
+    VALUES (
+      NEW.id, 'badge_earned', 'Badge earned!',
+      'You earned the ' || NEW.badge_level || ' badge!',
+      jsonb_build_object('badge_level', NEW.badge_level)
+    );
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================
+-- notify_streak_milestone: AFTER UPDATE OF streak on users
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.notify_streak_milestone()
+RETURNS TRIGGER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  IF NEW.streak IN (7, 30, 90, 180, 365) AND (OLD.streak IS NULL OR OLD.streak < NEW.streak) THEN
+    INSERT INTO public.notifications (user_id, type, title, message, metadata)
+    VALUES (
+      NEW.id, 'streak_milestone', NEW.streak || '-day streak!',
+      'You hit a ' || NEW.streak || '-day coding streak!',
+      jsonb_build_object('streak_days', NEW.streak)
+    );
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -107,9 +107,14 @@ CREATE POLICY "Social links are viewable by everyone"
 CREATE POLICY "Users can manage own social links"
   ON social_links FOR ALL USING (auth.uid() = user_id);
 
--- Function to calculate and update user streak
-CREATE OR REPLACE FUNCTION update_user_streak(p_user_id UUID)
-RETURNS void AS $$
+-- Function to calculate and update user streak.
+-- search_path is pinned and table references are schema-qualified to survive
+-- Supabase's "Function Search Path Mutable" auto-tightening (which sets
+-- search_path = "" on existing functions and breaks unqualified refs).
+CREATE OR REPLACE FUNCTION public.update_user_streak(p_user_id UUID)
+RETURNS void
+SET search_path = public, pg_temp
+AS $$
 DECLARE
   v_current_streak INTEGER := 0;
   v_longest_streak INTEGER := 0;
@@ -123,7 +128,7 @@ BEGIN
   -- Get all activity dates for user, ordered ascending
   FOR rec IN
     SELECT DISTINCT activity_date
-    FROM streak_logs
+    FROM public.streak_logs
     WHERE user_id = p_user_id
     ORDER BY activity_date ASC
   LOOP
@@ -153,7 +158,7 @@ BEGIN
   END IF;
 
   -- Update user record
-  UPDATE users
+  UPDATE public.users
   SET
     streak = v_current_streak,
     longest_streak = GREATEST(longest_streak, v_longest_streak),
@@ -182,14 +187,14 @@ BEGIN
               + CASE WHEN array_length(tech_stack, 1) >= 3 THEN 2 ELSE 0 END
             ELSE 1
           END
-        ) FROM projects WHERE projects.user_id = p_user_id AND NOT COALESCE(flagged, false)
+        ) FROM public.projects WHERE projects.user_id = p_user_id AND NOT COALESCE(flagged, false)
       ), 0)
     ) + (
       -- Endorsement points: +5 per endorsement received on user's projects
       COALESCE((
         SELECT COUNT(*) * 5
-        FROM project_endorsements pe
-        JOIN projects p ON p.id = pe.project_id
+        FROM public.project_endorsements pe
+        JOIN public.projects p ON p.id = pe.project_id
         WHERE p.user_id = p_user_id AND NOT COALESCE(p.flagged, false)
       ), 0)
     ) + CASE
@@ -204,10 +209,12 @@ END;
 $$ LANGUAGE plpgsql;
 
 -- Trigger: auto-update streak when activity is logged
-CREATE OR REPLACE FUNCTION trigger_update_streak()
-RETURNS TRIGGER AS $$
+CREATE OR REPLACE FUNCTION public.trigger_update_streak()
+RETURNS TRIGGER
+SET search_path = public, pg_temp
+AS $$
 BEGIN
-  PERFORM update_user_streak(NEW.user_id);
+  PERFORM public.update_user_streak(NEW.user_id);
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
@@ -218,14 +225,16 @@ CREATE TRIGGER on_streak_log_insert
   EXECUTE FUNCTION trigger_update_streak();
 
 -- Trigger: update vibe score when project is added/removed
-CREATE OR REPLACE FUNCTION trigger_update_vibe_score_on_project()
-RETURNS TRIGGER AS $$
+CREATE OR REPLACE FUNCTION public.trigger_update_vibe_score_on_project()
+RETURNS TRIGGER
+SET search_path = public, pg_temp
+AS $$
 BEGIN
   IF TG_OP = 'DELETE' THEN
-    PERFORM update_user_streak(OLD.user_id);
+    PERFORM public.update_user_streak(OLD.user_id);
     RETURN OLD;
   ELSE
-    PERFORM update_user_streak(NEW.user_id);
+    PERFORM public.update_user_streak(NEW.user_id);
     RETURN NEW;
   END IF;
 END;
@@ -394,11 +403,13 @@ CREATE POLICY "Service can insert notifications"
   ON notifications FOR INSERT WITH CHECK (true);
 
 -- Auto-create notification when badge level changes
-CREATE OR REPLACE FUNCTION notify_badge_change()
-RETURNS TRIGGER AS $$
+CREATE OR REPLACE FUNCTION public.notify_badge_change()
+RETURNS TRIGGER
+SET search_path = public, pg_temp
+AS $$
 BEGIN
   IF OLD.badge_level IS DISTINCT FROM NEW.badge_level AND NEW.badge_level != 'none' THEN
-    INSERT INTO notifications (user_id, type, title, message, metadata)
+    INSERT INTO public.notifications (user_id, type, title, message, metadata)
     VALUES (
       NEW.id, 'badge_earned', 'Badge earned!',
       'You earned the ' || NEW.badge_level || ' badge!',
@@ -414,11 +425,13 @@ CREATE TRIGGER on_badge_change
   FOR EACH ROW EXECUTE FUNCTION notify_badge_change();
 
 -- Auto-create notification on streak milestones
-CREATE OR REPLACE FUNCTION notify_streak_milestone()
-RETURNS TRIGGER AS $$
+CREATE OR REPLACE FUNCTION public.notify_streak_milestone()
+RETURNS TRIGGER
+SET search_path = public, pg_temp
+AS $$
 BEGIN
   IF NEW.streak IN (7, 30, 90, 180, 365) AND (OLD.streak IS NULL OR OLD.streak < NEW.streak) THEN
-    INSERT INTO notifications (user_id, type, title, message, metadata)
+    INSERT INTO public.notifications (user_id, type, title, message, metadata)
     VALUES (
       NEW.id, 'streak_milestone', NEW.streak || '-day streak!',
       'You hit a ' || NEW.streak || '-day coding streak!',
@@ -467,19 +480,21 @@ CREATE POLICY "Users can remove own endorsements"
   ON project_endorsements FOR DELETE USING (auth.uid() = user_id);
 
 -- Trigger: update vibe score when endorsement is added/removed
-CREATE OR REPLACE FUNCTION trigger_update_vibe_score_on_endorsement()
-RETURNS TRIGGER AS $$
+CREATE OR REPLACE FUNCTION public.trigger_update_vibe_score_on_endorsement()
+RETURNS TRIGGER
+SET search_path = public, pg_temp
+AS $$
 DECLARE
   v_project_owner UUID;
 BEGIN
   IF TG_OP = 'DELETE' THEN
-    SELECT user_id INTO v_project_owner FROM projects WHERE id = OLD.project_id;
+    SELECT user_id INTO v_project_owner FROM public.projects WHERE id = OLD.project_id;
   ELSE
-    SELECT user_id INTO v_project_owner FROM projects WHERE id = NEW.project_id;
+    SELECT user_id INTO v_project_owner FROM public.projects WHERE id = NEW.project_id;
   END IF;
 
   IF v_project_owner IS NOT NULL THEN
-    PERFORM update_user_streak(v_project_owner);
+    PERFORM public.update_user_streak(v_project_owner);
   END IF;
 
   IF TG_OP = 'DELETE' THEN


### PR DESCRIPTION
## Summary

- Production `POST /api/streak` was returning 500 because Supabase's "Function Search Path Mutable" linter silently applied `search_path = ""` to `notify_badge_change` and `notify_streak_milestone`. The unqualified `INSERT INTO notifications` inside those triggers then failed with `relation "notifications" does not exist`, aborting the whole streak insert transaction.
- Hot-fix was already applied to production via SQL editor (the two `notify_*` functions). This PR locks the fix into the repo and proactively hardens **all 8 trigger functions** before Supabase's linter takes another one out.
- Every function now uses `SET search_path = public, pg_temp` AND schema-qualified table references (`public.notifications`, `public.users`, etc.), so they survive even if search_path is forced empty again.

## Root cause

Trigger chain: `streak_logs INSERT` → `trigger_update_streak` → `update_user_streak` → `UPDATE users` → `notify_badge_change` / `notify_streak_milestone` fire → `INSERT INTO notifications` → table not found in empty search_path → transaction aborts → 500.

Diagnosed via:
\`\`\`sql
SELECT proname, proconfig FROM pg_proc
WHERE proname IN ('notify_badge_change', 'notify_streak_milestone');
-- proconfig: ["search_path=\"\""]
\`\`\`

## Files changed

- `supabase/migrations/20260426_harden_trigger_search_paths.sql` — new defensive migration, all `CREATE OR REPLACE`, idempotent.
- `supabase/schema.sql` — updates the 6 trigger functions defined here so fresh environments bootstrap with safe definitions.

## Test plan

- [x] Diagnosed live production with `pg_proc.proconfig` query (confirmed empty search_path)
- [x] Applied the two `notify_*` `CREATE OR REPLACE` blocks via Supabase SQL editor → Log Activity click now succeeds in production
- [ ] After merge: run `supabase/migrations/20260426_harden_trigger_search_paths.sql` in production SQL editor to harden the remaining 6 functions before Supabase's linter sweeps them
- [ ] Spot-check `pg_proc.proconfig` for all 8 functions returns `["search_path=public, pg_temp"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved stability and reliability of streak tracking, vibe score calculations, and badge notifications by enhancing database infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->