### PR TITLE
fix(profile): accept username or profile URL for X/Telegram fields

### DIFF
--- a/src/app/agent/contact/[username]/page.tsx
+++ b/src/app/agent/contact/[username]/page.tsx
@@ -6,6 +6,7 @@ import { generateHireMessage } from "@/lib/agent-scoring";
 import type { UserWithSocials } from "@/lib/types/database";
 import { AgentThinking } from "@/components/agent/agent-thinking";
 import { Bot, Send, ArrowLeft, Github, Globe } from "lucide-react";
+import { extractSocialHandle } from "@/lib/social-handles";
 import Link from "next/link";
 import type { AgentStep } from "@/lib/types/agent";
 
@@ -73,6 +74,7 @@ export default function ContactPage({
   }
 
   const socials = user.social_links;
+  const twitterHandle = extractSocialHandle(socials?.twitter, "twitter");
   const initials = user.username.slice(0, 2).toUpperCase();
 
   if (sent) {
@@ -127,9 +129,9 @@ export default function ContactPage({
                 GitHub
               </a>
             )}
-            {socials?.twitter && (
+            {twitterHandle && (
               <a
-                href={`https://x.com/${socials.twitter}`}
+                href={`https://x.com/${twitterHandle}`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="btn-brutal btn-brutal-secondary text-xs py-2 px-4 flex items-center gap-2"

--- a/src/app/api/v1/builders/[username]/route.ts
+++ b/src/app/api/v1/builders/[username]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { extractSocialHandle } from "@/lib/social-handles";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -101,8 +102,11 @@ export async function GET(
       ),
       social_links: socialLinks
         ? {
-            twitter: socialLinks.twitter,
-            telegram: socialLinks.telegram,
+            // Always return bare handles so API consumers can build their
+            // own URLs without worrying about whether the user pasted a
+            // username or a full profile link at signup.
+            twitter: extractSocialHandle(socialLinks.twitter, "twitter"),
+            telegram: extractSocialHandle(socialLinks.telegram, "telegram"),
             github: socialLinks.github,
             website: socialLinks.website,
             farcaster: socialLinks.farcaster,

--- a/src/app/auth/profile-setup/page.tsx
+++ b/src/app/auth/profile-setup/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { createClient } from "@/lib/supabase/client";
 import { useRouter, useSearchParams } from "next/navigation";
 import { validateDisplayName, containsProfanity } from "@/lib/profanity";
+import { normalizeSocialHandle } from "@/lib/social-handles";
 import {
   Flame,
   Github,
@@ -258,16 +259,29 @@ export default function ProfileSetupPage() {
   };
 
   const handleStep2Next = async () => {
-    const twitter = socials.twitter.trim();
-    const telegram = socials.telegram.trim();
     if (!verifiedGithub) {
       setError("Connect your GitHub account to verify ownership before continuing.");
       return;
     }
+    const twitterResult = normalizeSocialHandle(socials.twitter, "twitter");
+    if (!twitterResult.ok) {
+      setError(twitterResult.error);
+      return;
+    }
+    const telegramResult = normalizeSocialHandle(socials.telegram, "telegram");
+    if (!telegramResult.ok) {
+      setError(telegramResult.error);
+      return;
+    }
+    const twitter = twitterResult.handle;
+    const telegram = telegramResult.handle;
     if (!twitter && !telegram) {
       setError("Please add your X (Twitter) or Telegram so clients can contact you.");
       return;
     }
+    // Reflect cleaned values back so the user sees the bare handle if they
+    // pasted a profile URL.
+    setSocials((s) => ({ ...s, twitter, telegram }));
 
     setError("");
     setLoading(true);
@@ -596,7 +610,7 @@ export default function ProfileSetupPage() {
           type="text"
           value={socials.twitter}
           onChange={(e) => setSocials({ ...socials, twitter: e.target.value })}
-          placeholder="X / Twitter handle"
+          placeholder="X / Twitter handle or profile link"
           className="input-brutal w-full"
         />
       </div>
@@ -618,7 +632,7 @@ export default function ProfileSetupPage() {
           type="text"
           value={socials.telegram}
           onChange={(e) => setSocials({ ...socials, telegram: e.target.value })}
-          placeholder="Telegram username"
+          placeholder="Telegram username or t.me link"
           className="input-brutal w-full"
         />
       </div>

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -101,6 +101,7 @@ export default async function ProfilePage({
     ],
   };
 
+  const twitterHandle = extractSocialHandle(user.social_links?.twitter, "twitter");
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "Person",
@@ -110,14 +111,11 @@ export default async function ProfilePage({
     ...(user.avatar_url ? { image: user.avatar_url } : {}),
     description: user.bio || `Builder on VibeTalent with a ${user.streak}-day streak`,
     jobTitle: "Software Developer",
-    sameAs: (() => {
-      const twitterHandle = extractSocialHandle(user.social_links?.twitter, "twitter");
-      return [
-        user.social_links?.github ? `https://github.com/${user.social_links.github}` : null,
-        twitterHandle ? `https://x.com/${twitterHandle}` : null,
-        user.social_links?.website || null,
-      ].filter(Boolean);
-    })(),
+    sameAs: [
+      user.social_links?.github ? `https://github.com/${user.social_links.github}` : null,
+      twitterHandle ? `https://x.com/${twitterHandle}` : null,
+      user.social_links?.website || null,
+    ].filter((v): v is string => Boolean(v)),
     knowsAbout: (user.projects ?? []).flatMap((p: { tech_stack: string[] }) => p.tech_stack ?? []).filter((v: string, i: number, a: string[]) => a.indexOf(v) === i),
   };
 

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -3,6 +3,7 @@ import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { ProfileSidebar } from "@/components/profile/profile-sidebar";
 import { StatsRibbon } from "@/components/profile/stats-ribbon";
 import { ProfileHeatmap } from "@/components/profile/profile-heatmap";
+import { extractSocialHandle } from "@/lib/social-handles";
 import { ProfileProjectCard } from "@/components/profile/profile-project-card";
 import ReviewsSection from "@/components/profile/reviews-section";
 import { ProfileViewTracker } from "@/components/profile/profile-view-tracker";
@@ -109,11 +110,14 @@ export default async function ProfilePage({
     ...(user.avatar_url ? { image: user.avatar_url } : {}),
     description: user.bio || `Builder on VibeTalent with a ${user.streak}-day streak`,
     jobTitle: "Software Developer",
-    sameAs: [
-      user.social_links?.github ? `https://github.com/${user.social_links.github}` : null,
-      user.social_links?.twitter ? `https://x.com/${user.social_links.twitter}` : null,
-      user.social_links?.website || null,
-    ].filter(Boolean),
+    sameAs: (() => {
+      const twitterHandle = extractSocialHandle(user.social_links?.twitter, "twitter");
+      return [
+        user.social_links?.github ? `https://github.com/${user.social_links.github}` : null,
+        twitterHandle ? `https://x.com/${twitterHandle}` : null,
+        user.social_links?.website || null,
+      ].filter(Boolean);
+    })(),
     knowsAbout: (user.projects ?? []).flatMap((p: { tech_stack: string[] }) => p.tech_stack ?? []).filter((v: string, i: number, a: string[]) => a.indexOf(v) === i),
   };
 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { validateDisplayName, containsProfanity } from "@/lib/profanity";
 import { siteUrl } from "@/lib/seo";
+import { normalizeSocialHandle } from "@/lib/social-handles";
 import type { UserWithSocials } from "@/lib/types/database";
 import { EmailPreferences } from "@/components/dashboard/email-preferences";
 import {
@@ -16,25 +17,13 @@ import {
   CheckCircle2,
 } from "lucide-react";
 
-/**
- * Extract a bare username from a value that might be a full URL or @-prefixed handle.
- */
-function extractUsername(value: string, platform: "twitter" | "telegram"): string {
-  let v = value.trim();
-  if (!v) return "";
-  v = v.replace(/\/+$/, "");
-  const patterns: Record<string, RegExp[]> = {
-    twitter: [/^https?:\/\/(www\.)?(twitter|x)\.com\//i],
-    telegram: [/^https?:\/\/(www\.)?(t\.me|telegram\.me)\//i],
-  };
-  for (const re of patterns[platform]) {
-    v = v.replace(re, "");
-  }
-  v = v.replace(/^@/, "");
-  v = v.split(/[?#]/)[0];
-  v = v.split("/")[0];
-  v = v.trim();
-  return v;
+// Drives the "@" decoration inside the handle inputs: show it for empty
+// fields and bare usernames, hide it once the user pastes a URL so they
+// don't see "@https://x.com/abhinav".
+function looksLikeBareHandle(value: string): boolean {
+  const v = value.trim();
+  if (!v) return true;
+  return /^@?[A-Za-z0-9_]+$/.test(v);
 }
 
 export default function SettingsPage() {
@@ -231,8 +220,18 @@ export default function SettingsPage() {
       alert("Username contains inappropriate language");
       return;
     }
-    const twitter = profileForm.twitter.trim();
-    const telegram = profileForm.telegram.trim();
+    const twitterResult = normalizeSocialHandle(profileForm.twitter, "twitter");
+    if (!twitterResult.ok) {
+      alert(twitterResult.error);
+      return;
+    }
+    const telegramResult = normalizeSocialHandle(profileForm.telegram, "telegram");
+    if (!telegramResult.ok) {
+      alert(telegramResult.error);
+      return;
+    }
+    const twitter = twitterResult.handle;
+    const telegram = telegramResult.handle;
     if (!twitter && !telegram) {
       alert("Please add your X (Twitter) or Telegram so clients can contact you.");
       return;
@@ -293,13 +292,16 @@ export default function SettingsPage() {
       social_links: {
         id: user.social_links?.id || "",
         user_id: user.id,
-        twitter: profileForm.twitter || null,
+        twitter: twitter || null,
         github: verifiedGithub,
-        telegram: profileForm.telegram || null,
+        telegram: telegram || null,
         website: profileForm.website || null,
         farcaster: profileForm.ide || null,
       },
     });
+    // Reflect the normalized values back into the form so a user who
+    // pasted a profile URL sees it cleaned up to a bare handle on save.
+    setProfileForm((p) => ({ ...p, twitter, telegram }));
     // Let other parts of the app (navbar onboarding dot, etc.) react to the
     // profile change without requiring a page reload.
     if (typeof window !== "undefined") {
@@ -448,14 +450,16 @@ export default function SettingsPage() {
             <div>
               <label className="text-xs font-bold uppercase tracking-wide text-[var(--text-muted)] mb-1.5 block">X (Twitter)</label>
               <div className="relative">
-                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-muted-soft)] font-bold text-sm select-none">@</span>
+                {looksLikeBareHandle(profileForm.twitter) && (
+                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-muted-soft)] font-bold text-sm select-none">@</span>
+                )}
                 <input
                   type="text"
                   value={profileForm.twitter}
-                  onChange={(e) => setProfileForm({ ...profileForm, twitter: extractUsername(e.target.value, "twitter") })}
-                  placeholder="username"
+                  onChange={(e) => setProfileForm({ ...profileForm, twitter: e.target.value })}
+                  placeholder="username or x.com link"
                   className="input-brutal"
-                  style={{ paddingLeft: "1.75rem" }}
+                  style={{ paddingLeft: looksLikeBareHandle(profileForm.twitter) ? "1.75rem" : undefined }}
                 />
               </div>
             </div>
@@ -525,14 +529,16 @@ export default function SettingsPage() {
             <div>
               <label className="text-xs font-bold uppercase tracking-wide text-[var(--text-muted)] mb-1.5 block">Telegram</label>
               <div className="relative">
-                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-muted-soft)] font-bold text-sm select-none">@</span>
+                {looksLikeBareHandle(profileForm.telegram) && (
+                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-muted-soft)] font-bold text-sm select-none">@</span>
+                )}
                 <input
                   type="text"
                   value={profileForm.telegram}
-                  onChange={(e) => setProfileForm({ ...profileForm, telegram: extractUsername(e.target.value, "telegram") })}
-                  placeholder="username"
+                  onChange={(e) => setProfileForm({ ...profileForm, telegram: e.target.value })}
+                  placeholder="username or t.me link"
                   className="input-brutal"
-                  style={{ paddingLeft: "1.75rem" }}
+                  style={{ paddingLeft: looksLikeBareHandle(profileForm.telegram) ? "1.75rem" : undefined }}
                 />
               </div>
             </div>

--- a/src/components/profile/profile-sidebar.tsx
+++ b/src/components/profile/profile-sidebar.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import type { UserWithSocials, BadgeLevel } from "@/lib/types/database";
 import { HireModal } from "@/components/ui/hire-modal";
 import { ShareCardModal } from "@/components/profile/share-card-modal";
+import { extractSocialHandle } from "@/lib/social-handles";
 
 interface ProfileSidebarProps {
   user: UserWithSocials;
@@ -93,6 +94,10 @@ export function ProfileSidebar({ user }: ProfileSidebarProps) {
     }
   };
   const socials = user.social_links;
+  // Tolerate legacy values stored as full URLs so the rendered link doesn't
+  // become "https://x.com/https://x.com/<handle>".
+  const twitterHandle = extractSocialHandle(socials?.twitter, "twitter");
+  const telegramHandle = extractSocialHandle(socials?.telegram, "telegram");
   const initials = user.username.slice(0, 2).toUpperCase();
   const badgeLabel = getBadgeLabel(user.badge_level);
 
@@ -190,9 +195,9 @@ export function ProfileSidebar({ user }: ProfileSidebarProps) {
             <Github size={16} />
           </a>
         )}
-        {socials?.twitter && (
+        {twitterHandle && (
           <a
-            href={`https://x.com/${socials.twitter}`}
+            href={`https://x.com/${twitterHandle}`}
             target="_blank"
             rel="noopener noreferrer"
             aria-label={`${user.username} on X (Twitter)`}
@@ -206,9 +211,9 @@ export function ProfileSidebar({ user }: ProfileSidebarProps) {
             <svg aria-hidden="true" width={16} height={16} viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
           </a>
         )}
-        {socials?.telegram && (
+        {telegramHandle && (
           <a
-            href={`https://t.me/${socials.telegram.replace("@", "")}`}
+            href={`https://t.me/${telegramHandle}`}
             target="_blank"
             rel="noopener noreferrer"
             aria-label={`${user.username} on Telegram`}

--- a/src/lib/__tests__/social-handles.test.ts
+++ b/src/lib/__tests__/social-handles.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from "vitest";
+import { normalizeSocialHandle, extractSocialHandle } from "../social-handles";
+
+describe("normalizeSocialHandle (twitter)", () => {
+  it("accepts an empty string", () => {
+    expect(normalizeSocialHandle("", "twitter")).toEqual({ ok: true, handle: "" });
+    expect(normalizeSocialHandle("   ", "twitter")).toEqual({ ok: true, handle: "" });
+  });
+
+  it("accepts a bare username", () => {
+    expect(normalizeSocialHandle("abhinav", "twitter")).toEqual({
+      ok: true,
+      handle: "abhinav",
+    });
+  });
+
+  it("strips a leading @", () => {
+    expect(normalizeSocialHandle("@abhinav", "twitter")).toEqual({
+      ok: true,
+      handle: "abhinav",
+    });
+  });
+
+  it("extracts username from x.com URL", () => {
+    expect(normalizeSocialHandle("https://x.com/abhinav", "twitter")).toEqual({
+      ok: true,
+      handle: "abhinav",
+    });
+  });
+
+  it("extracts username from twitter.com URL", () => {
+    expect(
+      normalizeSocialHandle("https://twitter.com/abhinav", "twitter")
+    ).toEqual({ ok: true, handle: "abhinav" });
+  });
+
+  it("extracts username from URL without protocol", () => {
+    expect(normalizeSocialHandle("x.com/abhinav", "twitter")).toEqual({
+      ok: true,
+      handle: "abhinav",
+    });
+  });
+
+  it("strips www and accepts subdomains like mobile.twitter.com", () => {
+    expect(
+      normalizeSocialHandle("https://www.x.com/abhinav", "twitter")
+    ).toEqual({ ok: true, handle: "abhinav" });
+    expect(
+      normalizeSocialHandle("https://mobile.twitter.com/abhinav", "twitter")
+    ).toEqual({ ok: true, handle: "abhinav" });
+  });
+
+  it("strips trailing slashes, query strings, and fragments", () => {
+    expect(
+      normalizeSocialHandle("https://x.com/abhinav/", "twitter")
+    ).toEqual({ ok: true, handle: "abhinav" });
+    expect(
+      normalizeSocialHandle("https://x.com/abhinav?ref=foo", "twitter")
+    ).toEqual({ ok: true, handle: "abhinav" });
+    expect(
+      normalizeSocialHandle("https://x.com/abhinav#bio", "twitter")
+    ).toEqual({ ok: true, handle: "abhinav" });
+  });
+
+  it("rejects random URLs", () => {
+    const r = normalizeSocialHandle("https://google.com/abhinav", "twitter");
+    expect(r.ok).toBe(false);
+  });
+
+  it("rejects a domain that merely ends with the platform name", () => {
+    const r = normalizeSocialHandle("https://fake-x.com/abhinav", "twitter");
+    expect(r.ok).toBe(false);
+  });
+
+  it("rejects a handle with invalid characters", () => {
+    const r = normalizeSocialHandle("abhinav.eth", "twitter");
+    expect(r.ok).toBe(false);
+  });
+
+  it("rejects a handle longer than the platform limit", () => {
+    const r = normalizeSocialHandle("a".repeat(16), "twitter");
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe("normalizeSocialHandle (telegram)", () => {
+  it("accepts a bare username", () => {
+    expect(normalizeSocialHandle("unknownking7", "telegram")).toEqual({
+      ok: true,
+      handle: "unknownking7",
+    });
+  });
+
+  it("extracts username from t.me URL", () => {
+    expect(
+      normalizeSocialHandle("https://t.me/unknownking7", "telegram")
+    ).toEqual({ ok: true, handle: "unknownking7" });
+  });
+
+  it("extracts username from telegram.me URL", () => {
+    expect(
+      normalizeSocialHandle("https://telegram.me/unknownking7", "telegram")
+    ).toEqual({ ok: true, handle: "unknownking7" });
+  });
+
+  it("extracts username from t.me URL without protocol", () => {
+    expect(normalizeSocialHandle("t.me/unknownking7", "telegram")).toEqual({
+      ok: true,
+      handle: "unknownking7",
+    });
+  });
+
+  it("rejects a Twitter URL on the telegram field", () => {
+    const r = normalizeSocialHandle(
+      "https://x.com/unknownking7",
+      "telegram"
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it("rejects a Telegram invite link with non-handle characters", () => {
+    const r = normalizeSocialHandle(
+      "https://t.me/+abc123def456",
+      "telegram"
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it("allows a 32-char handle and rejects 33", () => {
+    expect(
+      normalizeSocialHandle("a".repeat(32), "telegram").ok
+    ).toBe(true);
+    expect(
+      normalizeSocialHandle("a".repeat(33), "telegram").ok
+    ).toBe(false);
+  });
+});
+
+describe("extractSocialHandle (lenient read path)", () => {
+  it("returns null for empty/null/undefined input", () => {
+    expect(extractSocialHandle("", "twitter")).toBe(null);
+    expect(extractSocialHandle(null, "twitter")).toBe(null);
+    expect(extractSocialHandle(undefined, "twitter")).toBe(null);
+  });
+
+  it("returns the handle for a bare username", () => {
+    expect(extractSocialHandle("abhinav", "twitter")).toBe("abhinav");
+  });
+
+  it("extracts handle from a full URL stored in legacy data", () => {
+    expect(extractSocialHandle("https://x.com/abhinav", "twitter")).toBe("abhinav");
+    expect(extractSocialHandle("https://t.me/abhinav", "telegram")).toBe("abhinav");
+  });
+
+  it("returns null for unparseable values so render sites omit the link", () => {
+    expect(extractSocialHandle("https://google.com/abhinav", "twitter")).toBe(null);
+    expect(extractSocialHandle("not a handle!", "twitter")).toBe(null);
+  });
+});

--- a/src/lib/__tests__/social-handles.test.ts
+++ b/src/lib/__tests__/social-handles.test.ts
@@ -81,6 +81,34 @@ describe("normalizeSocialHandle (twitter)", () => {
     const r = normalizeSocialHandle("a".repeat(16), "twitter");
     expect(r.ok).toBe(false);
   });
+
+  it("rejects multi-segment paths like status permalinks", () => {
+    expect(
+      normalizeSocialHandle("https://x.com/abhinav/status/123", "twitter").ok
+    ).toBe(false);
+  });
+
+  it("rejects Twitter reserved first-segment paths", () => {
+    for (const url of [
+      "https://x.com/home",
+      "https://x.com/explore",
+      "https://x.com/i/communities/123",
+      "https://x.com/intent/tweet",
+      "https://x.com/search?q=foo",
+      "https://x.com/login",
+    ]) {
+      expect(normalizeSocialHandle(url, "twitter").ok).toBe(false);
+    }
+  });
+
+  it("treats a bare domain (no path) as a URL and rejects it", () => {
+    expect(normalizeSocialHandle("x.com", "twitter").ok).toBe(false);
+  });
+
+  it("accepts null and undefined as empty input", () => {
+    expect(normalizeSocialHandle(null, "twitter")).toEqual({ ok: true, handle: "" });
+    expect(normalizeSocialHandle(undefined, "twitter")).toEqual({ ok: true, handle: "" });
+  });
 });
 
 describe("normalizeSocialHandle (telegram)", () => {
@@ -124,6 +152,22 @@ describe("normalizeSocialHandle (telegram)", () => {
       "telegram"
     );
     expect(r.ok).toBe(false);
+  });
+
+  it("rejects legacy joinchat invite links", () => {
+    expect(
+      normalizeSocialHandle("https://t.me/joinchat/AAAAAAAAAAAAAAAAAA", "telegram").ok
+    ).toBe(false);
+  });
+
+  it("rejects Telegram reserved first-segment paths", () => {
+    for (const url of [
+      "https://t.me/share/url?url=foo",
+      "https://t.me/addstickers/somepack",
+      "https://t.me/c/123/456",
+    ]) {
+      expect(normalizeSocialHandle(url, "telegram").ok).toBe(false);
+    }
   });
 
   it("allows a 32-char handle and rejects 33", () => {

--- a/src/lib/social-handles.ts
+++ b/src/lib/social-handles.ts
@@ -1,0 +1,128 @@
+/**
+ * Normalize a Twitter (X) or Telegram social handle to a bare username.
+ *
+ * Accepts:
+ *   - "abhinav" or "@abhinav"
+ *   - "https://x.com/abhinav", "https://twitter.com/abhinav"
+ *   - "https://t.me/abhinav", "https://telegram.me/abhinav"
+ *   - The same URLs without protocol (e.g. "x.com/abhinav", "t.me/abhinav")
+ *   - Subdomains of the platform (e.g. "mobile.twitter.com/abhinav")
+ *
+ * Rejects: any other URL, or a handle with characters outside [A-Za-z0-9_].
+ *
+ * Stored values are concatenated into `https://x.com/${handle}` and
+ * `https://t.me/${handle}` at render time, so we must keep handles bare.
+ */
+
+export type Platform = "twitter" | "telegram";
+
+const URL_HOSTS: Record<Platform, string[]> = {
+  twitter: ["twitter.com", "x.com"],
+  telegram: ["t.me", "telegram.me"],
+};
+
+const HANDLE_PATTERN: Record<Platform, RegExp> = {
+  // Twitter handles: 1–15 chars, letters/digits/underscore.
+  twitter: /^[A-Za-z0-9_]{1,15}$/,
+  // Telegram handles: officially 5–32 chars, but we allow 1–32 to avoid
+  // breaking accounts with legacy short names.
+  telegram: /^[A-Za-z0-9_]{1,32}$/,
+};
+
+const PLATFORM_LABEL: Record<Platform, string> = {
+  twitter: "X (Twitter)",
+  telegram: "Telegram",
+};
+
+const EXAMPLE_DOMAINS: Record<Platform, string> = {
+  twitter: "x.com or twitter.com",
+  telegram: "t.me or telegram.me",
+};
+
+export type NormalizeResult =
+  | { ok: true; handle: string }
+  | { ok: false; error: string };
+
+export function normalizeSocialHandle(
+  input: string,
+  platform: Platform
+): NormalizeResult {
+  const raw = (input ?? "").trim();
+  if (!raw) return { ok: true, handle: "" };
+
+  if (looksLikeUrl(raw)) {
+    const parsed = parseUrlLike(raw);
+    if (!parsed) {
+      return {
+        ok: false,
+        error: `That doesn't look like a valid ${PLATFORM_LABEL[platform]} link.`,
+      };
+    }
+    if (!hostMatches(parsed.host, URL_HOSTS[platform])) {
+      return {
+        ok: false,
+        error: `Use a ${EXAMPLE_DOMAINS[platform]} link or just your username.`,
+      };
+    }
+    const handle = parsed.path
+      .replace(/^\//, "")
+      .split(/[/?#]/)[0]
+      .replace(/^@/, "");
+    if (!handle || !HANDLE_PATTERN[platform].test(handle)) {
+      return {
+        ok: false,
+        error: `Couldn't read a ${PLATFORM_LABEL[platform]} username from that link.`,
+      };
+    }
+    return { ok: true, handle };
+  }
+
+  const handle = raw.replace(/^@/, "");
+  if (!HANDLE_PATTERN[platform].test(handle)) {
+    return {
+      ok: false,
+      error: `${PLATFORM_LABEL[platform]} username can only contain letters, numbers, and underscores.`,
+    };
+  }
+  return { ok: true, handle };
+}
+
+/**
+ * Lenient version for read paths: returns the bare handle if we can extract
+ * one, or `null` otherwise. Use this when rendering profile links so legacy
+ * accounts that stored a full URL still produce a working `https://x.com/<handle>`
+ * (without it, the link becomes `https://x.com/https://x.com/<handle>`).
+ */
+export function extractSocialHandle(
+  input: string | null | undefined,
+  platform: Platform
+): string | null {
+  if (!input) return null;
+  const result = normalizeSocialHandle(input, platform);
+  return result.ok && result.handle ? result.handle : null;
+}
+
+function looksLikeUrl(s: string): boolean {
+  // "https://...", "http://...", "//host/...", or "host.tld/..."
+  return /^(https?:)?\/\//i.test(s) || /^[a-z0-9.-]+\.[a-z]{2,}\//i.test(s);
+}
+
+function parseUrlLike(s: string): { host: string; path: string } | null {
+  let normalized = s;
+  if (!/^https?:\/\//i.test(s)) {
+    normalized = s.startsWith("//") ? `https:${s}` : `https://${s}`;
+  }
+  try {
+    const u = new URL(normalized);
+    return {
+      host: u.hostname.toLowerCase().replace(/^www\./, ""),
+      path: u.pathname,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function hostMatches(host: string, allowed: string[]): boolean {
+  return allowed.some((a) => host === a || host.endsWith(`.${a}`));
+}

--- a/src/lib/social-handles.ts
+++ b/src/lib/social-handles.ts
@@ -29,6 +29,37 @@ const HANDLE_PATTERN: Record<Platform, RegExp> = {
   telegram: /^[A-Za-z0-9_]{1,32}$/,
 };
 
+// First path segments that look username-shaped but aren't user profiles.
+// Without this, "https://x.com/home" or "https://t.me/joinchat/<code>" would
+// be persisted as the handles "home" and "joinchat" and render as broken links.
+const RESERVED_PATHS: Record<Platform, Set<string>> = {
+  twitter: new Set([
+    "i",
+    "home",
+    "explore",
+    "intent",
+    "search",
+    "messages",
+    "notifications",
+    "settings",
+    "compose",
+    "share",
+    "login",
+    "signup",
+    "tos",
+    "privacy",
+  ]),
+  telegram: new Set([
+    "joinchat",
+    "addstickers",
+    "share",
+    "proxy",
+    "c",
+    "s",
+    "iv",
+  ]),
+};
+
 const PLATFORM_LABEL: Record<Platform, string> = {
   twitter: "X (Twitter)",
   telegram: "Telegram",
@@ -44,7 +75,7 @@ export type NormalizeResult =
   | { ok: false; error: string };
 
 export function normalizeSocialHandle(
-  input: string,
+  input: string | null | undefined,
   platform: Platform
 ): NormalizeResult {
   const raw = (input ?? "").trim();
@@ -64,11 +95,22 @@ export function normalizeSocialHandle(
         error: `Use a ${EXAMPLE_DOMAINS[platform]} link or just your username.`,
       };
     }
-    const handle = parsed.path
-      .replace(/^\//, "")
-      .split(/[/?#]/)[0]
-      .replace(/^@/, "");
-    if (!handle || !HANDLE_PATTERN[platform].test(handle)) {
+    // A real profile URL is exactly /<handle>. Anything with multiple path
+    // segments is an invite link (/joinchat/<code>), a status permalink
+    // (/<user>/status/<id>), or a feature page (/i/communities/<id>).
+    const segments = parsed.path.split("/").filter(Boolean);
+    if (segments.length !== 1) {
+      return {
+        ok: false,
+        error: `Couldn't read a ${PLATFORM_LABEL[platform]} username from that link.`,
+      };
+    }
+    const handle = segments[0].replace(/^@/, "");
+    if (
+      !handle ||
+      !HANDLE_PATTERN[platform].test(handle) ||
+      RESERVED_PATHS[platform].has(handle.toLowerCase())
+    ) {
       return {
         ok: false,
         error: `Couldn't read a ${PLATFORM_LABEL[platform]} username from that link.`,
@@ -103,8 +145,8 @@ export function extractSocialHandle(
 }
 
 function looksLikeUrl(s: string): boolean {
-  // "https://...", "http://...", "//host/...", or "host.tld/..."
-  return /^(https?:)?\/\//i.test(s) || /^[a-z0-9.-]+\.[a-z]{2,}\//i.test(s);
+  // "https://...", "http://...", "//host/...", or "host.tld" / "host.tld/..."
+  return /^(https?:)?\/\//i.test(s) || /^[a-z0-9.-]+\.[a-z]{2,}(\/|$)/i.test(s);
 }
 
 function parseUrlLike(s: string): { host: string; path: string } | null {


### PR DESCRIPTION
## Summary
- The X (Twitter) and Telegram fields silently accepted any string. Many users pasted their full profile URL (e.g. `https://x.com/abhinav`), which was stored as-is. Render sites then concatenated it into broken hrefs like `https://x.com/https://x.com/abhinav`.
- Both formats now work: bare handle, `@handle`, or a full Twitter/Telegram URL (with or without protocol). Random URLs (e.g. `https://google.com`) are rejected with a clear error.
- Existing accounts with URL-shaped values render correctly immediately — no re-save required. The `extractSocialHandle` helper is applied at every read site (profile sidebar, agent contact page, JSON-LD `sameAs`, public `/api/v1/builders/[username]`). When the user does eventually save again, the DB row is also cleaned up to a bare handle.

## What changed
- New `src/lib/social-handles.ts` exposes:
  - `normalizeSocialHandle(input, platform)` — strict, used at save time. Returns `{ ok, handle }` or `{ ok, error }`.
  - `extractSocialHandle(input, platform)` — lenient, used at render time. Returns the bare handle or `null` when nothing usable can be parsed.
- Settings + onboarding: replaced the keystroke-time `extractUsername` with save-time normalization. Inputs accept both formats verbatim while typing; the `@` decoration auto-hides when the value contains a URL. Placeholders updated to "username or x.com link" / "username or t.me link".
- Render sites: profile sidebar, agent contact page, JSON-LD `sameAs`, and the public builders API all run input through `extractSocialHandle` so legacy URL data produces working links.

## Test plan
- [x] Unit tests cover bare handles, `@handle`, full URLs, no-protocol URLs (`x.com/foo`), `mobile.twitter.com` subdomains, query strings, fragments, length bounds, random URLs rejected, lookalike domains rejected, Telegram invite links rejected, lenient render-path returning `null` for unparseable values (23 new tests; 150/150 passing across the suite).
- [x] TypeScript clean on touched files; ESLint clean on touched files.
- [x] Live profile render verified: Twitter href = `https://x.com/abhiontwt`, Telegram href = `https://t.me/unknownking7`, JSON-LD `sameAs` produces correct URLs, public API returns bare handles.
- [ ] Manual save flow with a URL pasted into the X/Telegram field — needs auth, please verify in preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Social media inputs now accept both usernames and full profile URLs for Twitter/X and Telegram, with automatic handle extraction.

* **Improvements**
  * Enhanced validation of social media handles with updated input guidance.
  * Refined form behavior for social media fields with improved input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->