### PR TITLE
fix(profile): unbreak Connect GitHub redirect + dashboard self-heal

### DIFF
--- a/src/app/auth/profile-setup/page.tsx
+++ b/src/app/auth/profile-setup/page.tsx
@@ -245,10 +245,14 @@ export default function ProfileSetupPage() {
   const handleConnectGithub = async () => {
     setConnectingGithub(true);
     setError("");
+    // Encode the destination so the inner "?step=2" survives. Without
+    // encoding, the second "?" gets parsed as a separate query param on
+    // /auth/callback and dropped, sending the user back to step 1.
+    const nextPath = encodeURIComponent("/auth/profile-setup?step=2");
     const { error: linkError } = await supabase.auth.linkIdentity({
       provider: "github",
       options: {
-        redirectTo: `${window.location.origin}/auth/callback?next=/auth/profile-setup?step=2`,
+        redirectTo: `${window.location.origin}/auth/callback?next=${nextPath}`,
       },
     });
     if (linkError) {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -136,7 +136,9 @@ export default function DashboardPage() {
 
       const profile = results[0].status === "fulfilled" ? results[0].value?.data : null;
       const projects = results[1].status === "fulfilled" ? results[1].value?.data : [];
-      const socials = results[2].status === "fulfilled" ? results[2].value?.data : null;
+      // `let` because the GitHub self-heal block below may overwrite this in
+      // memory after a fire-and-forget DB upsert.
+      let socials = results[2].status === "fulfilled" ? results[2].value?.data : null;
       const streakData = results[3].status === "fulfilled" ? results[3].value : {};
       const inboxData = results[4].status === "fulfilled" ? results[4].value?.data : [];
       setHireRequests(inboxData || []);
@@ -173,6 +175,37 @@ export default function DashboardPage() {
       if (!profile) {
         window.location.href = "/auth/profile-setup";
         return;
+      }
+
+      // Self-heal: if the GitHub identity is attached in auth.users but the
+      // mirror columns (users.github_username / social_links.github) are out
+      // of sync, repair them in place so the missing-socials redirect below
+      // doesn't bounce the user into an unfixable loop. Same lookup pattern
+      // as settings/page.tsx and profile-setup/page.tsx.
+      if (!profile.github_username || !socials?.github) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const ghIdentity = authUser.identities?.find((i: any) => i.provider === "github");
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const ghData = (ghIdentity?.identity_data ?? {}) as any;
+        const ghUsername =
+          ghData.user_name ||
+          ghData.preferred_username ||
+          authUser.user_metadata?.user_name ||
+          authUser.user_metadata?.preferred_username ||
+          null;
+        if (ghUsername) {
+          if (!profile.github_username) {
+            profile.github_username = ghUsername;
+            sb.from("users").update({ github_username: ghUsername }).eq("id", authUser.id);
+          }
+          if (!socials?.github) {
+            socials = { ...(socials || {}), github: ghUsername, user_id: authUser.id };
+            sb.from("social_links").upsert(
+              { user_id: authUser.id, github: ghUsername },
+              { onConflict: "user_id" }
+            );
+          }
+        }
       }
 
       // Enforce mandatory socials: GitHub + (X or Telegram)


### PR DESCRIPTION
## Summary

Two related fixes for the GitHub-link flow, uncovered while debugging @okgopika's report that her public profile showed no GitHub icon and the **Connect GitHub** button "kept redirecting to the same page."

### Bug A — Connect GitHub loops back to step 1

`linkIdentity`'s `redirectTo` was built as `?next=/auth/profile-setup?step=2`. The second `?` parses as a separate query param on `/auth/callback` and gets dropped, so `sanitizeNext` only sees `/auth/profile-setup` and lands the user on step 1 every time. URL-encoding the path makes `?step=2` round-trip cleanly.

### Bug B — dashboard never repaired stale mirror columns

`users.github_username` and `social_links.github` are written by the OAuth callback, but if either write silently fails (network/RLS/race) the user is stranded: the public profile won't render the GitHub icon, and the dashboard's missing-socials guard bounces them to profile-setup without fixing the underlying state. `settings/page.tsx` and `profile-setup/page.tsx` already have self-heal blocks; the dashboard didn't. Mirroring the existing pattern closes the gap so any future drift heals transparently on next dashboard load — no migration needed.

## Test plan

- [x] 156/156 tests pass
- [x] `eslint` clean on changed files
- [x] Encoded `next` param round-trips correctly (verified in browser console: `next=%2Fauth%2Fprofile-setup%3Fstep%3D2` decodes to `/auth/profile-setup?step=2` and passes `sanitizeNext`)
- [ ] **Real-world**: ask the affected user to click "Connect GitHub" again after deploy. Expected: GitHub OAuth → callback writes `users.github_username` + `social_links.github` → redirect lands on step 2 with verified badge → public profile shows GitHub icon.
- [ ] Confirm no regression for healthy users (self-heal block is fully gated on `!profile.github_username || !socials?.github`, so it's a no-op for everyone with intact data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)