### PR TITLE
fix(supabase): enable RLS on public.feedback

### DIFF
--- a/supabase/migrations/20260429_enable_feedback_rls.sql
+++ b/supabase/migrations/20260429_enable_feedback_rls.sql
@@ -1,0 +1,31 @@
+-- Enable RLS on public.feedback to fix Supabase advisor critical warning.
+--
+-- The feedback table exists in production but its CREATE TABLE was never
+-- committed (created out-of-band when re-engagement-email feedback shipped).
+-- This migration:
+--   1. Backfills CREATE TABLE IF NOT EXISTS so fresh DBs get a working table.
+--   2. Enables RLS and adds a service-role-only INSERT policy.
+--
+-- The /feedback form is anonymous; submissions go through /api/feedback,
+-- which uses the service role client. Service role bypasses RLS, so the
+-- policy primarily blocks direct anon-key inserts via PostgREST.
+
+CREATE TABLE IF NOT EXISTS public.feedback (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  username TEXT,
+  reason TEXT NOT NULL,
+  details TEXT,
+  would_return TEXT,
+  source TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_feedback_created_at
+  ON public.feedback (created_at DESC);
+
+ALTER TABLE public.feedback ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Service role can insert feedback" ON public.feedback;
+CREATE POLICY "Service role can insert feedback"
+  ON public.feedback FOR INSERT
+  WITH CHECK (auth.role() = 'service_role');


### PR DESCRIPTION
## Summary
- Enables Row Level Security on `public.feedback` to clear a **critical** Supabase advisor warning (table was exposed via PostgREST without RLS).
- Backfills the missing `CREATE TABLE IF NOT EXISTS` — the table was created out-of-band in production when the re-engagement-email feedback shipped (#103) but never committed to the repo.
- Adds a service-role-only `INSERT` policy that matches how [`/api/feedback`](src/app/api/feedback/route.ts) writes (uses `createAdminClient()` with `SUPABASE_SERVICE_ROLE_KEY`).

## Status
- **Already applied to production** via the Supabase SQL editor — advisor warning has cleared. This PR brings the repo in sync.
- Idempotent (`IF NOT EXISTS`, `DROP POLICY IF EXISTS`) so re-runs against any environment are safe.

## Out of scope (follow-ups)
- `email_log` has the same RLS gap — separate PR.
- `email_preferences.re_engagement` column is referenced by code but missing from schema — separate PR, unrelated.

## Test plan
- [x] Migration applied successfully against production
- [x] Supabase Advisor → `rls_disabled_in_public` warning for `public.feedback` cleared
- [ ] Smoke test `/feedback` form submission still lands rows (service role bypasses RLS)
- [ ] Verify dashboard shows the new policy under Authentication → Policies → `feedback`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened security infrastructure for feedback submissions with improved access controls and data management.
  * Optimized feedback data retrieval with performance enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->