### PR TITLE
fix(heatmap): show real per-day commit counts in contribution graph

### DIFF
--- a/src/app/api/github/contributions/route.ts
+++ b/src/app/api/github/contributions/route.ts
@@ -4,32 +4,59 @@ import { createAdminClient } from "@/lib/supabase/admin";
 
 function parseContributions(html: string): { contributions: Record<string, number>; total: number } {
   const contributions: Record<string, number> = {};
-  let total = 0;
 
-  // GitHub contribution calendar uses <td> with data-date and data-level
-  // Try multiple patterns to be resilient to GitHub HTML changes
+  // GitHub renders one <td> per day with a stable id, plus a sibling <tool-tip>
+  // whose text contains the real count ("8 contributions on May 4th."). The
+  // td's data-level is only a 0-4 color bucket — using it as the count is the
+  // bug we're fixing here.
+  const idToDate = new Map<string, string>();
+  let m: RegExpExecArray | null;
 
-  // Pattern 1: data-date="YYYY-MM-DD" ... data-level="N"
-  const p1 = /data-date="(\d{4}-\d{2}-\d{2})"[^>]*data-level="(\d)"/g;
-  let match;
-  while ((match = p1.exec(html)) !== null) {
-    contributions[match[1]] = parseInt(match[2], 10);
+  const td1 = /<td\b[^>]*data-date="(\d{4}-\d{2}-\d{2})"[^>]*id="(contribution-day-component-\d+-\d+)"/g;
+  while ((m = td1.exec(html)) !== null) {
+    idToDate.set(m[2], m[1]);
   }
-
-  // Pattern 2: reversed attribute order
-  if (Object.keys(contributions).length === 0) {
-    const p2 = /data-level="(\d)"[^>]*data-date="(\d{4}-\d{2}-\d{2})"/g;
-    while ((match = p2.exec(html)) !== null) {
-      contributions[match[2]] = parseInt(match[1], 10);
+  if (idToDate.size === 0) {
+    const td2 = /<td\b[^>]*id="(contribution-day-component-\d+-\d+)"[^>]*data-date="(\d{4}-\d{2}-\d{2})"/g;
+    while ((m = td2.exec(html)) !== null) {
+      idToDate.set(m[1], m[2]);
     }
   }
 
-  // Extract total from header text: "589 contributions in the last year"
+  // <tool-tip for="ID" ...>N contributions on Month Dth.</tool-tip>
+  const tipRe = /<tool-tip\b[^>]*\sfor="(contribution-day-component-\d+-\d+)"[^>]*>([^<]+)</g;
+  while ((m = tipRe.exec(html)) !== null) {
+    const date = idToDate.get(m[1]);
+    if (!date) continue;
+    const numMatch = m[2].trim().match(/^(\d[\d,]*|No)\s+contribution/i);
+    if (!numMatch) continue;
+    contributions[date] = numMatch[1].toLowerCase() === "no"
+      ? 0
+      : parseInt(numMatch[1].replace(/,/g, ""), 10);
+  }
+
+  // Fallback: if no tool-tip parse hit (GitHub HTML changed), degrade to the
+  // old data-level scrape so the heatmap still renders colors — counts will
+  // be wrong but the calendar won't go blank.
+  if (Object.keys(contributions).length === 0) {
+    const p1 = /data-date="(\d{4}-\d{2}-\d{2})"[^>]*data-level="(\d)"/g;
+    while ((m = p1.exec(html)) !== null) {
+      contributions[m[1]] = parseInt(m[2], 10);
+    }
+    if (Object.keys(contributions).length === 0) {
+      const p2 = /data-level="(\d)"[^>]*data-date="(\d{4}-\d{2}-\d{2})"/g;
+      while ((m = p2.exec(html)) !== null) {
+        contributions[m[2]] = parseInt(m[1], 10);
+      }
+    }
+  }
+
+  let total = 0;
   const totalMatch = html.match(/(\d[\d,]*)\s+contributions?\s+in\s+the\s+last\s+year/i);
   if (totalMatch) {
     total = parseInt(totalMatch[1].replace(/,/g, ""), 10);
   } else {
-    total = Object.values(contributions).filter(v => v > 0).length;
+    total = Object.values(contributions).reduce((sum, v) => sum + (v > 0 ? v : 0), 0);
   }
 
   return { contributions, total };

--- a/src/app/api/github/contributions/route.ts
+++ b/src/app/api/github/contributions/route.ts
@@ -2,42 +2,58 @@ import { NextRequest, NextResponse } from "next/server";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 
+const FETCH_TIMEOUT_MS = 8000;
+
 function parseContributions(html: string): { contributions: Record<string, number>; total: number } {
   const contributions: Record<string, number> = {};
 
-  // GitHub renders one <td> per day with a stable id, plus a sibling <tool-tip>
-  // whose text contains the real count ("8 contributions on May 4th."). The
-  // td's data-level is only a 0-4 color bucket — using it as the count is the
-  // bug we're fixing here.
-  const idToDate = new Map<string, string>();
+  // Step 1: collect every day cell, capturing both date and data-level (the
+  // 0-4 color bucket). Iterating opening <td> tags first then extracting
+  // attributes from each tag handles any attribute ordering GitHub uses.
+  const cellInfo = new Map<string, { date: string; level: number }>();
+  const tdRe = /<td\b[^>]*\bdata-date="\d{4}-\d{2}-\d{2}"[^>]*>/g;
   let m: RegExpExecArray | null;
-
-  const td1 = /<td\b[^>]*data-date="(\d{4}-\d{2}-\d{2})"[^>]*id="(contribution-day-component-\d+-\d+)"/g;
-  while ((m = td1.exec(html)) !== null) {
-    idToDate.set(m[2], m[1]);
-  }
-  if (idToDate.size === 0) {
-    const td2 = /<td\b[^>]*id="(contribution-day-component-\d+-\d+)"[^>]*data-date="(\d{4}-\d{2}-\d{2})"/g;
-    while ((m = td2.exec(html)) !== null) {
-      idToDate.set(m[1], m[2]);
+  while ((m = tdRe.exec(html)) !== null) {
+    const tag = m[0];
+    const dateMatch = tag.match(/\bdata-date="(\d{4}-\d{2}-\d{2})"/);
+    const idMatch = tag.match(/\bid="(contribution-day-component-\d+-\d+)"/);
+    const levelMatch = tag.match(/\bdata-level="(\d)"/);
+    if (dateMatch && idMatch) {
+      cellInfo.set(idMatch[1], {
+        date: dateMatch[1],
+        level: levelMatch ? parseInt(levelMatch[1], 10) : 0,
+      });
     }
   }
 
-  // <tool-tip for="ID" ...>N contributions on Month Dth.</tool-tip>
+  // Step 2: pull real per-day counts from the sibling <tool-tip> blocks.
+  // GitHub renders one per cell: "8 contributions on May 4th." or
+  // "No contributions on April 30th." The td's data-level is only a color
+  // bucket and is wrong as a count — so prefer tool-tip when available.
+  const tooltipCounts = new Map<string, number>();
   const tipRe = /<tool-tip\b[^>]*\sfor="(contribution-day-component-\d+-\d+)"[^>]*>([^<]+)</g;
   while ((m = tipRe.exec(html)) !== null) {
-    const date = idToDate.get(m[1]);
-    if (!date) continue;
     const numMatch = m[2].trim().match(/^(\d[\d,]*|No)\s+contribution/i);
     if (!numMatch) continue;
-    contributions[date] = numMatch[1].toLowerCase() === "no"
-      ? 0
-      : parseInt(numMatch[1].replace(/,/g, ""), 10);
+    tooltipCounts.set(
+      m[1],
+      numMatch[1].toLowerCase() === "no"
+        ? 0
+        : parseInt(numMatch[1].replace(/,/g, ""), 10)
+    );
   }
 
-  // Fallback: if no tool-tip parse hit (GitHub HTML changed), degrade to the
-  // old data-level scrape so the heatmap still renders colors — counts will
-  // be wrong but the calendar won't go blank.
+  // Step 3: per-cell merge. If a cell has a tool-tip count, use it (real
+  // number). Otherwise fall back to that specific cell's data-level — wrong
+  // scale but at least preserves heatmap shading. This makes partial parse
+  // failures degrade per-cell instead of either-or-nothing.
+  for (const [id, { date, level }] of cellInfo.entries()) {
+    const tipCount = tooltipCounts.get(id);
+    contributions[date] = tipCount !== undefined ? tipCount : level;
+  }
+
+  // Step 4: last-resort fallback if no <td data-date> matched at all
+  // (GitHub HTML structure changed). Old date-level regex.
   if (Object.keys(contributions).length === 0) {
     const p1 = /data-date="(\d{4}-\d{2}-\d{2})"[^>]*data-level="(\d)"/g;
     while ((m = p1.exec(html)) !== null) {
@@ -63,22 +79,37 @@ function parseContributions(html: string): { contributions: Record<string, numbe
 }
 
 async function fetchGitHubContributions(githubUsername: string) {
-  const res = await fetch(
-    `https://github.com/users/${encodeURIComponent(githubUsername)}/contributions`,
-    {
-      headers: {
-        Accept: "text/html",
-        "User-Agent": "VibeTalent/1.0",
-      },
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(
+      `https://github.com/users/${encodeURIComponent(githubUsername)}/contributions`,
+      {
+        headers: {
+          Accept: "text/html",
+          "User-Agent": "VibeTalent/1.0",
+        },
+        signal: controller.signal,
+      }
+    );
+
+    if (!res.ok) {
+      console.error(`GitHub contributions fetch failed for ${githubUsername}: ${res.status}`);
+      return { contributions: {}, total: 0 };
     }
-  );
 
-  if (!res.ok) {
-    console.error(`GitHub contributions fetch failed for ${githubUsername}: ${res.status}`);
+    return parseContributions(await res.text());
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      console.error(`GitHub contributions fetch timed out for ${githubUsername} after ${FETCH_TIMEOUT_MS}ms`);
+    } else {
+      console.error(`GitHub contributions fetch errored for ${githubUsername}:`, err);
+    }
     return { contributions: {}, total: 0 };
+  } finally {
+    clearTimeout(timeoutId);
   }
-
-  return parseContributions(await res.text());
 }
 
 /**

--- a/src/components/profile/profile-heatmap.tsx
+++ b/src/components/profile/profile-heatmap.tsx
@@ -20,6 +20,17 @@ const getLevelColor = (level: number) => {
   }
 };
 
+// Bucket a real per-day commit count into a 0-4 color intensity. Mirrors the
+// shape of GitHub's own contribution calendar buckets so the visual feel is
+// familiar (low/med/high days look low/med/high).
+const countToLevel = (count: number) => {
+  if (count <= 0) return 0;
+  if (count < 3) return 1;
+  if (count < 8) return 2;
+  if (count < 20) return 3;
+  return 4;
+};
+
 export function ProfileHeatmap({ data, githubUsername }: ProfileHeatmapProps) {
   const [ghData, setGhData] = useState<Record<string, number>>({});
   const [ghTotal, setGhTotal] = useState<number>(0);
@@ -59,17 +70,17 @@ export function ProfileHeatmap({ data, githubUsername }: ProfileHeatmapProps) {
   }, [data, ghData]);
 
   const { weeks, monthLabels } = useMemo(() => {
-    const result: { date: string; level: number }[][] = [];
+    const result: { date: string; count: number }[][] = [];
     const today = new Date();
     const start = new Date(today);
     start.setDate(start.getDate() - 363);
     while (start.getDay() !== 0) start.setDate(start.getDate() - 1);
 
-    let currentWeek: { date: string; level: number }[] = [];
+    let currentWeek: { date: string; count: number }[] = [];
     const current = new Date(start);
     while (current <= today) {
       const key = current.toISOString().split("T")[0];
-      currentWeek.push({ date: key, level: mergedData[key] || 0 });
+      currentWeek.push({ date: key, count: mergedData[key] || 0 });
       if (currentWeek.length === 7) {
         result.push(currentWeek);
         currentWeek = [];
@@ -150,8 +161,10 @@ export function ProfileHeatmap({ data, githubUsername }: ProfileHeatmapProps) {
                   <div
                     key={day.date}
                     className="w-3 h-3"
-                    style={{ backgroundColor: getLevelColor(day.level), border: "1px solid var(--border-subtle)" }}
-                    title={`${day.date}: ${day.level > 0 ? day.level : "No"} contributions`}
+                    style={{ backgroundColor: getLevelColor(countToLevel(day.count)), border: "1px solid var(--border-subtle)" }}
+                    title={day.count > 0
+                      ? `${day.count} ${day.count === 1 ? "contribution" : "contributions"} on ${day.date}`
+                      : `No contributions on ${day.date}`}
                   />
                 ))}
               </div>

--- a/src/components/profile/profile-heatmap.tsx
+++ b/src/components/profile/profile-heatmap.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState, useEffect, useLayoutEffect, useRef } from "react";
+import { countToLevel } from "@/lib/heatmap-utils";
 
 interface ProfileHeatmapProps {
   data: Record<string, number>;
@@ -20,16 +21,10 @@ const getLevelColor = (level: number) => {
   }
 };
 
-// Bucket a real per-day commit count into a 0-4 color intensity. Mirrors the
-// shape of GitHub's own contribution calendar buckets so the visual feel is
-// familiar (low/med/high days look low/med/high).
-const countToLevel = (count: number) => {
-  if (count <= 0) return 0;
-  if (count < 3) return 1;
-  if (count < 8) return 2;
-  if (count < 20) return 3;
-  return 4;
-};
+function dayLabel(count: number, date: string): string {
+  if (count <= 0) return `No contributions on ${date}`;
+  return `${count} ${count === 1 ? "contribution" : "contributions"} on ${date}`;
+}
 
 export function ProfileHeatmap({ data, githubUsername }: ProfileHeatmapProps) {
   const [ghData, setGhData] = useState<Record<string, number>>({});
@@ -157,16 +152,19 @@ export function ProfileHeatmap({ data, githubUsername }: ProfileHeatmapProps) {
           <div className="flex gap-[3px]">
             {weeks.map((week, wi) => (
               <div key={wi} className="flex flex-col gap-[3px]">
-                {week.map((day) => (
-                  <div
-                    key={day.date}
-                    className="w-3 h-3"
-                    style={{ backgroundColor: getLevelColor(countToLevel(day.count)), border: "1px solid var(--border-subtle)" }}
-                    title={day.count > 0
-                      ? `${day.count} ${day.count === 1 ? "contribution" : "contributions"} on ${day.date}`
-                      : `No contributions on ${day.date}`}
-                  />
-                ))}
+                {week.map((day) => {
+                  const label = dayLabel(day.count, day.date);
+                  return (
+                    <div
+                      key={day.date}
+                      className="w-3 h-3"
+                      style={{ backgroundColor: getLevelColor(countToLevel(day.count)), border: "1px solid var(--border-subtle)" }}
+                      title={label}
+                      aria-label={label}
+                      role="img"
+                    />
+                  );
+                })}
               </div>
             ))}
           </div>

--- a/src/components/ui/activity-heatmap.tsx
+++ b/src/components/ui/activity-heatmap.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useLayoutEffect, useRef } from "react";
+import { countToLevel } from "@/lib/heatmap-utils";
 
 interface ActivityHeatmapProps {
   data: Record<string, number>;
@@ -10,15 +11,10 @@ interface ActivityHeatmapProps {
 const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 const DAY_LABELS = ["", "Mon", "", "Wed", "", "Fri", ""];
 
-// Bucket a real per-day commit count into a 0-4 color intensity. Same scale
-// used by ProfileHeatmap so the two views feel consistent.
-const countToLevel = (count: number) => {
-  if (count <= 0) return 0;
-  if (count < 3) return 1;
-  if (count < 8) return 2;
-  if (count < 20) return 3;
-  return 4;
-};
+function dayLabel(count: number, date: string): string {
+  if (count <= 0) return `No contributions on ${date}`;
+  return `${count} ${count === 1 ? "contribution" : "contributions"} on ${date}`;
+}
 
 export function ActivityHeatmap({ data, totalOverride }: ActivityHeatmapProps) {
   const { weeks, monthLabels } = useMemo(() => {
@@ -146,19 +142,22 @@ export function ActivityHeatmap({ data, totalOverride }: ActivityHeatmapProps) {
           <div className="flex gap-[3px]">
             {weeks.map((week, wi) => (
               <div key={wi} className="flex flex-col gap-[3px]">
-                {week.map((day) => (
-                  <div
-                    key={day.date}
-                    className="w-3 h-3"
-                    style={{
-                      backgroundColor: getLevelColor(countToLevel(day.count)),
-                      border: "1px solid var(--border-subtle)",
-                    }}
-                    title={day.count > 0
-                      ? `${day.count} ${day.count === 1 ? "contribution" : "contributions"} on ${day.date}`
-                      : `No contributions on ${day.date}`}
-                  />
-                ))}
+                {week.map((day) => {
+                  const label = dayLabel(day.count, day.date);
+                  return (
+                    <div
+                      key={day.date}
+                      className="w-3 h-3"
+                      style={{
+                        backgroundColor: getLevelColor(countToLevel(day.count)),
+                        border: "1px solid var(--border-subtle)",
+                      }}
+                      title={label}
+                      aria-label={label}
+                      role="img"
+                    />
+                  );
+                })}
               </div>
             ))}
           </div>

--- a/src/components/ui/activity-heatmap.tsx
+++ b/src/components/ui/activity-heatmap.tsx
@@ -10,9 +10,19 @@ interface ActivityHeatmapProps {
 const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 const DAY_LABELS = ["", "Mon", "", "Wed", "", "Fri", ""];
 
+// Bucket a real per-day commit count into a 0-4 color intensity. Same scale
+// used by ProfileHeatmap so the two views feel consistent.
+const countToLevel = (count: number) => {
+  if (count <= 0) return 0;
+  if (count < 3) return 1;
+  if (count < 8) return 2;
+  if (count < 20) return 3;
+  return 4;
+};
+
 export function ActivityHeatmap({ data, totalOverride }: ActivityHeatmapProps) {
   const { weeks, monthLabels } = useMemo(() => {
-    const result: { date: string; level: number; dayOfWeek: number }[][] = [];
+    const result: { date: string; count: number; dayOfWeek: number }[][] = [];
     const today = new Date();
 
     // Go back to the start: 52 weeks ago, aligned to Sunday
@@ -23,13 +33,13 @@ export function ActivityHeatmap({ data, totalOverride }: ActivityHeatmapProps) {
       start.setDate(start.getDate() - 1);
     }
 
-    let currentWeek: { date: string; level: number; dayOfWeek: number }[] = [];
+    let currentWeek: { date: string; count: number; dayOfWeek: number }[] = [];
     const current = new Date(start);
 
     while (current <= today) {
       const key = current.toISOString().split("T")[0];
-      const level = data[key] || 0;
-      currentWeek.push({ date: key, level, dayOfWeek: current.getDay() });
+      const count = data[key] || 0;
+      currentWeek.push({ date: key, count, dayOfWeek: current.getDay() });
 
       if (currentWeek.length === 7) {
         result.push(currentWeek);
@@ -141,10 +151,12 @@ export function ActivityHeatmap({ data, totalOverride }: ActivityHeatmapProps) {
                     key={day.date}
                     className="w-3 h-3"
                     style={{
-                      backgroundColor: getLevelColor(day.level),
+                      backgroundColor: getLevelColor(countToLevel(day.count)),
                       border: "1px solid var(--border-subtle)",
                     }}
-                    title={`${day.date}: ${day.level > 0 ? day.level : "No"} contributions`}
+                    title={day.count > 0
+                      ? `${day.count} ${day.count === 1 ? "contribution" : "contributions"} on ${day.date}`
+                      : `No contributions on ${day.date}`}
                   />
                 ))}
               </div>

--- a/src/lib/heatmap-utils.ts
+++ b/src/lib/heatmap-utils.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared utilities for the contribution heatmap components.
+ *
+ * Used by ProfileHeatmap and ActivityHeatmap so both views agree on how
+ * a raw per-day commit count maps to a color intensity bucket.
+ */
+
+/**
+ * Bucket a real per-day commit count into a 0-4 color intensity.
+ * Mirrors GitHub's own contribution calendar feel (low/mid/high days
+ * look low/mid/high).
+ */
+export function countToLevel(count: number): number {
+  if (count <= 0) return 0;
+  if (count < 3) return 1;
+  if (count < 8) return 2;
+  if (count < 20) return 3;
+  return 4;
+}


### PR DESCRIPTION
## Summary

GitHub's `data-level` attribute is a 0-4 color bucket, not the actual commit count, but [`parseContributions`](src/app/api/github/contributions/route.ts) was storing it as the per-day count. Result: every active heatmap cell hovered as "1", "2", "3", or "4" regardless of the real volume.

For a heavy committer like Linus, that meant a 27-commit day showed "2 contributions" because data-level=2 was the bucket. Beta user [Meta Alchemist](https://t.me/meta_alchemist) flagged it: _"check github commits too they all show as 2 in the github like thing when you hover over stuff"_.

## What changed

- Build an `id → date` map from the contribution `<td>` elements.
- Parse the sibling `<tool-tip for="ID">N contributions on Month Dth.</tool-tip>` blocks (where the real number lives) and resolve `id → date → count`.
- Fall back to the old `data-level` scrape only if no `<tool-tip>` matches — so the calendar still renders if GitHub changes their HTML again.
- Components: split "real count" from "color level". Hover shows `${count} contributions on ${date}`; color is bucketed locally via `countToLevel(count)` (0 / 1-2 / 3-7 / 8-19 / 20+).

## Test plan

- [x] `npx tsc --noEmit` clean for `src/`
- [x] `curl /api/github/contributions?github=torvalds` returns total=3067, per-day values 0-35 (was 0-4)
- [x] Profile heatmap hover shows e.g. `"11 contributions on 2025-05-10"`, `"27 contributions on 2026-04-17"`, `"No contributions on 2025-04-30"`
- [x] Color buckets still feel right — heavy days dark, sparse days light
- [ ] One reviewer confirms the regex doesn't accidentally cross cell boundaries on edge cases (private profiles, brand-new accounts, accounts with 1k+ commits/day if any)

## Why this is safe

Pure parsing fix. No schema, no scoring, no auth, no migrations. If the new parser fails on some HTML variant, falls back to the old behavior — calendar still renders, counts go back to 0-4 buckets. No user data changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Heatmaps now show exact per-day contribution counts and use those counts to determine intensity.
  * Tooltips and accessible labels updated with clear, grammatically correct phrasing (e.g., "No contributions on …", "1 contribution on …").

* **Bug Fixes**
  * More reliable contribution fetching with timeouts and clearer timeout handling.
  * Robust parsing fallbacks to improve data accuracy when page structure varies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->