### PR TITLE
feat(homepage): live feed grid + end-game ladder

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,6 @@
 import { LiveActivityFeed } from "@/components/ui/live-activity-feed";
+import { LiveFeedSection } from "@/components/homepage/live-feed-section";
+import { EndGameLadder } from "@/components/homepage/end-game-ladder";
 import { FeaturedCarousel } from "@/components/ui/featured-carousel";
 import Link from "next/link";
 import { VibecoderCard } from "@/components/ui/vibecoder-card";
@@ -6,8 +8,20 @@ import { ProjectCard } from "@/components/ui/project-card";
 import { HeroCTA } from "@/components/ui/hero-cta";
 import { TestimonialScroll } from "@/components/ui/testimonial-scroll";
 import { fetchHomepageDataCached } from "@/lib/supabase/server-queries";
+import {
+  fetchHomepageFeedCached,
+  SPARSE_THRESHOLD,
+  type HomepageFeedItem,
+} from "@/lib/homepage-feed";
 import { siteUrl } from "@/lib/seo";
 import { Flame, TrendingUp, Award, Zap, ArrowRight, Code2, Target, Users } from "lucide-react";
+
+// Feature flag: gates the new homepage feed section. When false (or unset),
+// the homepage renders the existing `<LiveActivityFeed />` snippet exactly
+// like before. Strict equality with "true" — same convention as the
+// onboarding tour flag. Kill switch in Vercel takes ~30s to flip back.
+const HOMEPAGE_FEED_V2_ENABLED =
+  process.env.NEXT_PUBLIC_ENABLE_HOMEPAGE_FEED_V2 === "true";
 
 export const revalidate = 60;
 
@@ -44,17 +58,44 @@ export default async function HomePage() {
   let totalBuilders = 0;
   let totalProjects = 0;
   let avgStreak = 0;
+  let homepageFeed: HomepageFeedItem[] = [];
 
-  try {
-    const data = await fetchHomepageDataCached();
+  // Run the existing homepage data fetch and the new feed fetch in parallel.
+  // Promise.allSettled means a failure in either branch never blocks the
+  // other from rendering — the page degrades gracefully to default values
+  // (empty arrays, zeroed stats) on the failed side. This matters more for
+  // the feed than the stats: a transient feed-query timeout shouldn't make
+  // the homepage stats disappear, and vice versa.
+  const [homepageDataResult, homepageFeedResult] = await Promise.allSettled([
+    fetchHomepageDataCached(),
+    HOMEPAGE_FEED_V2_ENABLED
+      ? fetchHomepageFeedCached()
+      : Promise.resolve([] as HomepageFeedItem[]),
+  ]);
+
+  if (homepageDataResult.status === "fulfilled") {
+    const data = homepageDataResult.value;
     topVibecoders = data.topVibecoders;
     featuredProjects = data.featuredProjects;
     totalBuilders = data.totalBuilders;
     totalProjects = data.totalProjects;
     avgStreak = data.avgStreak;
-  } catch (err) {
-    console.error("[HomePage] Failed to fetch homepage data:", err);
+  } else {
+    console.error("[HomePage] Failed to fetch homepage data:", homepageDataResult.reason);
   }
+
+  if (homepageFeedResult.status === "fulfilled") {
+    homepageFeed = homepageFeedResult.value;
+  } else {
+    // Feed-fetch failure is not fatal — we just fall back to the snippet.
+    console.error("[HomePage] Failed to fetch homepage feed:", homepageFeedResult.reason);
+  }
+
+  // Render the new section only when the flag is on AND we have enough
+  // items for it to look alive. Below SPARSE_THRESHOLD, fall back to the
+  // existing snippet — better a tight curated card than a half-empty grid.
+  const showFeedV2 =
+    HOMEPAGE_FEED_V2_ENABLED && homepageFeed.length >= SPARSE_THRESHOLD;
 
   return (
     <div>
@@ -167,7 +208,12 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <LiveActivityFeed />
+      {showFeedV2 ? <LiveFeedSection items={homepageFeed} /> : <LiveActivityFeed />}
+
+      {/* End-game ladder — answers Meta Alchemist's "what's the goal" gap.
+          Always rendered (no flag): it's purely additive marketing copy
+          that complements every variant of the feed above it. */}
+      <EndGameLadder />
 
       <FeaturedCarousel />
 

--- a/src/components/homepage/end-game-ladder.tsx
+++ b/src/components/homepage/end-game-ladder.tsx
@@ -1,0 +1,164 @@
+/**
+ * End-game ladder — the 4-step path from signup to getting hired.
+ *
+ * Why this exists: Meta Alchemist's feedback called out that the homepage
+ * doesn't communicate the "end game" clearly. The hero says "marketplace
+ * built on consistency and proof of work" but never finishes the sentence.
+ * This component is the missing second half: here's exactly how a builder
+ * goes from signup to a hire request.
+ *
+ * Placement: directly below the live feed reinforcement banner, so the
+ * narrative reads as "look at the activity → here's your path into it."
+ *
+ * Design notes:
+ *   - Server component, no JS bundle.
+ *   - 4 columns on desktop (>= sm), stacked on mobile.
+ *   - The final "Get Hired" step is visually emphasized (accent background)
+ *     because it's the actual end-state — every other step is a means.
+ *   - Arrows render only on desktop. On mobile we drop them to keep the
+ *     vertical stack tight; the order is implicit from top-to-bottom.
+ */
+
+import { Fragment } from "react";
+import Link from "next/link";
+import { ArrowRight, Github, Flame, Trophy, Mail } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+interface Step {
+  number: string;
+  title: string;
+  body: string;
+  icon: LucideIcon;
+  /** True for the terminal "GET HIRED" step — gets accent styling so it
+   *  reads as the destination rather than another waypoint. */
+  isTerminal?: boolean;
+}
+
+const STEPS: readonly Step[] = [
+  {
+    number: "01",
+    title: "Sign up",
+    body: "Connect your GitHub in 60 seconds. No resume, no portfolio.",
+    icon: Github,
+  },
+  {
+    number: "02",
+    title: "Ship daily",
+    body: "Commit every day. Streaks auto-detect from your GitHub activity.",
+    icon: Flame,
+  },
+  {
+    number: "03",
+    title: "Climb the score",
+    body: "Streaks + project quality + endorsements = your vibe score.",
+    icon: Trophy,
+  },
+  {
+    number: "04",
+    title: "Get hired",
+    body: "Founders DM the top builders. Skip the resume gauntlet.",
+    icon: Mail,
+    isTerminal: true,
+  },
+];
+
+export function EndGameLadder() {
+  return (
+    <section className="mx-auto max-w-7xl px-4 sm:px-6 pb-14 sm:pb-20">
+      <div className="text-center mb-10">
+        <div
+          className="inline-flex items-center gap-2 mb-3 px-3 py-1 text-xs font-extrabold uppercase tracking-wider"
+          style={{
+            backgroundColor: "var(--bg-surface)",
+            color: "var(--foreground)",
+            border: "2px solid var(--border-hard)",
+            boxShadow: "var(--shadow-brutal-sm)",
+          }}
+        >
+          How it works
+        </div>
+        <h2 className="text-3xl sm:text-4xl font-extrabold uppercase tracking-tight text-[var(--foreground)]">
+          Four steps to
+          <span className="text-accent-brutal"> getting hired.</span>
+        </h2>
+        <p className="mt-3 text-sm sm:text-base text-[var(--text-secondary)] font-medium max-w-xl mx-auto">
+          No applications. No interviews until you&apos;re ready. Just consistent
+          shipping that founders can verify on their own.
+        </p>
+      </div>
+
+      {/* Steps. Grid on desktop with arrows between, vertical stack on
+          mobile. The arrow column is fixed-width so the steps line up
+          regardless of step-text length. */}
+      <div className="grid grid-cols-1 sm:grid-cols-[1fr_auto_1fr_auto_1fr_auto_1fr] gap-4 sm:gap-3 items-stretch">
+        {STEPS.map((step, idx) => (
+          // Fragment needs the key (not the children) — React's reconciler
+          // tracks the outermost element in a list iteration.
+          <Fragment key={step.number}>
+            <StepCard step={step} />
+            {/* Arrow between cards — only rendered on desktop, only between
+                pairs (not after the final step). */}
+            {idx < STEPS.length - 1 && (
+              <div
+                className="hidden sm:flex items-center justify-center text-[var(--text-muted)]"
+                aria-hidden="true"
+              >
+                <ArrowRight size={20} strokeWidth={2.5} />
+              </div>
+            )}
+          </Fragment>
+        ))}
+      </div>
+
+      {/* Bottom CTA — gives the ladder a clear close-out instead of just
+          dangling. Same destination as the hero's primary CTA so we don't
+          fork the funnel. */}
+      <div className="mt-10 text-center">
+        <Link
+          href="/auth/signup"
+          className="btn-brutal btn-brutal-primary text-sm sm:text-base inline-flex"
+        >
+          Start your streak today
+          <ArrowRight size={16} />
+        </Link>
+      </div>
+    </section>
+  );
+}
+
+function StepCard({ step }: { step: Step }) {
+  const Icon = step.icon;
+  const terminal = step.isTerminal === true;
+
+  return (
+    <article
+      className="p-5 sm:p-6 flex flex-col gap-3"
+      style={{
+        backgroundColor: terminal ? "var(--accent)" : "var(--bg-surface)",
+        color: terminal ? "var(--text-on-inverted)" : "var(--foreground)",
+        border: "2px solid var(--border-hard)",
+        boxShadow: "var(--shadow-brutal-sm)",
+      }}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <span
+          className="text-xs font-extrabold tracking-widest tabular-nums opacity-70"
+        >
+          {step.number}
+        </span>
+        <Icon size={20} className="flex-shrink-0" strokeWidth={2.25} />
+      </div>
+      <div>
+        <div className="text-lg sm:text-xl font-extrabold uppercase tracking-tight">
+          {step.title}
+        </div>
+        <p
+          className="mt-1.5 text-sm font-medium leading-snug"
+          style={{ opacity: terminal ? 0.95 : 0.85 }}
+        >
+          {step.body}
+        </p>
+      </div>
+    </article>
+  );
+}

--- a/src/components/homepage/live-feed-section.tsx
+++ b/src/components/homepage/live-feed-section.tsx
@@ -1,0 +1,356 @@
+/**
+ * Homepage live activity section — server-rendered, richer-than-snippet
+ * version of the live feed for logged-out visitors.
+ *
+ * Why this exists alongside `<LiveActivityFeed>`:
+ *   - The existing snippet is a 480px-wide centered card that says basically
+ *     "@user pushed repo (2m ago)". It works as a tiny social-proof beacon
+ *     but undersells the platform — vibe scores, badges, project quality
+ *     scores, and shipped work never make it into view.
+ *   - This component renders 8–12 richer cards in a 2-column grid (1-col on
+ *     mobile) that surface the actual signals that make VibeTalent VibeTalent:
+ *     badges, streak counts, project descriptions + tech stack, milestones.
+ *
+ * Safety guarantees:
+ *   - Server component, server-fetched, ISR-cached for 60s. No client JS,
+ *     no loading flash, no waterfall.
+ *   - Sparse-feed safeguard: if fewer than `SPARSE_THRESHOLD` items are
+ *     available, this component returns null and the homepage falls back
+ *     to the existing snippet. Ghost-town first-impression is the worst
+ *     possible outcome of putting a feed on the marketing page; we'd rather
+ *     show a tight, full-looking card than a half-empty grid.
+ *   - All copy and CTAs link out — nothing is interactive enough to break.
+ */
+
+import Link from "next/link";
+import Image from "next/image";
+import { ArrowRight, BadgeCheck, Code2, Flame, Rocket, Sparkles, UserPlus } from "lucide-react";
+import {
+  type HomepageFeedItem,
+  MAX_ITEMS,
+  SPARSE_THRESHOLD,
+} from "@/lib/homepage-feed";
+
+interface LiveFeedSectionProps {
+  items: HomepageFeedItem[];
+}
+
+/** Relative-time label. Server-rendered so it's frozen to whatever moment
+ *  the ISR cache was generated — that's intentional and matches every
+ *  other relative-time label we already SSR (e.g. profile pages). */
+function relativeTime(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 2) return "Just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days < 30) return `${days}d ago`;
+  return `${Math.floor(days / 30)}mo ago`;
+}
+
+function actionLabel(item: HomepageFeedItem): string {
+  switch (item.type) {
+    case "project":
+      return "shipped";
+    case "pr":
+      return "merged a PR on";
+    case "create":
+      return "created";
+    case "issue":
+      return "opened an issue on";
+    case "streak":
+      return "logged a coding day";
+    case "joined":
+      return "joined VibeTalent";
+    case "push":
+    default:
+      return "pushed to";
+  }
+}
+
+/** Inline subcomponent rather than `const Icon = pickComponent(item)` —
+ *  the latter trips `react-hooks/static-components` because the lookup
+ *  function is called at render time and the rule treats the return
+ *  value as a "component created during render." This pattern keeps the
+ *  component identities stable across renders. */
+function ActionIcon({ type }: { type: HomepageFeedItem["type"] }) {
+  const props = { size: 12, className: "text-[var(--text-muted)] flex-shrink-0" };
+  switch (type) {
+    case "project":
+      return <Rocket {...props} />;
+    case "joined":
+      return <UserPlus {...props} />;
+    case "streak":
+      return <Flame {...props} />;
+    case "pr":
+    case "create":
+    case "issue":
+    case "push":
+    default:
+      return <Code2 {...props} />;
+  }
+}
+
+const BADGE_LABELS: Record<string, string> = {
+  bronze: "BRONZE",
+  silver: "SILVER",
+  gold: "GOLD",
+  diamond: "DIAMOND",
+};
+
+export function LiveFeedSection({ items }: LiveFeedSectionProps) {
+  // Sparse-feed safeguard. The page-level fallback to the old snippet
+  // happens by the caller checking `items.length < SPARSE_THRESHOLD` and
+  // not rendering us — but we double-guard here so that even if a future
+  // caller forgets, we still bail rather than render a sad 3-card grid.
+  if (items.length < SPARSE_THRESHOLD) return null;
+
+  // Cap defensively. The fetcher already slices to MAX_ITEMS but a buggy
+  // future caller could pass more.
+  const cards = items.slice(0, MAX_ITEMS);
+
+  return (
+    <section className="mx-auto max-w-7xl px-4 sm:px-6 py-14 sm:py-20">
+      {/* Header bar — mirrors the orange-accent "Live Activity" header from
+          the existing snippet so the visual language stays consistent. */}
+      <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4 mb-8">
+        <div>
+          <div className="inline-flex items-center gap-2 mb-3 px-3 py-1 text-xs font-extrabold uppercase tracking-wider"
+            style={{
+              backgroundColor: "var(--accent)",
+              color: "var(--text-on-inverted)",
+              border: "2px solid var(--border-hard)",
+              boxShadow: "var(--shadow-brutal-sm)",
+            }}
+          >
+            <span aria-hidden="true" className="live-dot" />
+            Live Activity
+          </div>
+          <h2 className="text-3xl sm:text-4xl font-extrabold uppercase tracking-tight text-[var(--foreground)]">
+            What builders shipped
+            <br className="hidden sm:block" />
+            <span className="text-accent-brutal"> in the last 24 hours.</span>
+          </h2>
+        </div>
+        <Link
+          href="/feed"
+          className="btn-brutal btn-brutal-secondary text-sm self-start sm:self-end whitespace-nowrap"
+        >
+          See full feed
+          <ArrowRight size={14} />
+        </Link>
+      </div>
+
+      {/* Card grid. 1 column < 640px, 2 columns >= 640px. Items themselves
+          are server-rendered so cards land in their final positions on
+          first paint — no layout shift, no skeleton, no fade-in. */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 stagger-children">
+        {cards.map((item) => (
+          <FeedCard key={item.id} item={item} />
+        ))}
+      </div>
+
+      {/* Reinforcement banner. Meta Alchemist's "tell people what they will
+          gain at the bottom" insight — placed immediately after the proof
+          so the CTA reads as "want to be in this list? sign up." */}
+      <div
+        className="mt-10 flex flex-col sm:flex-row items-center justify-between gap-4 p-5 sm:p-6"
+        style={{
+          backgroundColor: "var(--bg-inverted)",
+          color: "var(--text-on-inverted)",
+          border: "2px solid var(--border-hard)",
+          boxShadow: "var(--shadow-brutal)",
+        }}
+      >
+        <div className="flex items-start sm:items-center gap-3">
+          <Sparkles size={22} className="text-[var(--accent)] flex-shrink-0 mt-0.5 sm:mt-0" />
+          <div>
+            <div className="text-base sm:text-lg font-extrabold uppercase tracking-tight">
+              Your activity goes here next.
+            </div>
+            <div className="text-xs sm:text-sm opacity-80 font-medium mt-0.5">
+              Show up daily. Build a streak. Get discovered. 60-second signup.
+            </div>
+          </div>
+        </div>
+        <Link
+          href="/auth/signup"
+          className="btn-brutal text-sm whitespace-nowrap"
+          style={{
+            backgroundColor: "var(--accent)",
+            color: "var(--text-on-inverted)",
+          }}
+        >
+          Create profile
+          <ArrowRight size={14} />
+        </Link>
+      </div>
+    </section>
+  );
+}
+
+function FeedCard({ item }: { item: HomepageFeedItem }) {
+  const initials = item.username.slice(0, 2).toUpperCase();
+  const badgeLabel = BADGE_LABELS[item.badge_level];
+  const isProject = item.type === "project";
+
+  return (
+    <article
+      className="p-4 sm:p-5 flex flex-col gap-3 transition-transform"
+      style={{
+        backgroundColor: "var(--bg-surface)",
+        border: "2px solid var(--border-hard)",
+        boxShadow: "var(--shadow-brutal-sm)",
+      }}
+    >
+      {/* Top row: avatar + name + action + timestamp. Whole row links to
+          the user profile so a logged-out visitor can immediately drill in
+          to see what kind of builders use this. */}
+      <div className="flex items-start gap-3">
+        <Link
+          href={`/profile/${item.username}`}
+          className="flex-shrink-0"
+          aria-label={`View @${item.username}'s profile`}
+        >
+          <div
+            className="w-10 h-10 sm:w-11 sm:h-11 flex items-center justify-center overflow-hidden"
+            style={{
+              backgroundColor: "var(--bg-inverted)",
+              color: "var(--text-on-inverted)",
+              border: "2px solid var(--border-hard)",
+              borderRadius: "50%",
+              fontWeight: 800,
+              fontSize: "0.85rem",
+            }}
+          >
+            {item.avatar_url ? (
+              <Image
+                src={item.avatar_url}
+                alt={item.username}
+                width={44}
+                height={44}
+                style={{ width: "100%", height: "100%", objectFit: "cover" }}
+              />
+            ) : (
+              initials
+            )}
+          </div>
+        </Link>
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-baseline justify-between gap-2 flex-wrap">
+            <Link
+              href={`/profile/${item.username}`}
+              className="font-extrabold text-sm sm:text-base text-[var(--foreground)] hover:text-[var(--accent)] transition-colors flex items-center gap-1.5 min-w-0"
+            >
+              <span className="truncate">
+                {item.display_name || `@${item.username}`}
+              </span>
+              {item.github_verified && (
+                <BadgeCheck
+                  size={14}
+                  className="text-white fill-[#1D9BF0] flex-shrink-0"
+                  strokeWidth={2.5}
+                  aria-label="GitHub verified"
+                />
+              )}
+            </Link>
+            <span className="text-[11px] font-bold text-[var(--text-muted)] tabular-nums flex-shrink-0">
+              {relativeTime(item.date)}
+            </span>
+          </div>
+
+          <div className="mt-1 text-xs sm:text-sm text-[var(--text-secondary)] font-medium flex items-center gap-1.5 flex-wrap">
+            <ActionIcon type={item.type} />
+            <span>{actionLabel(item)}</span>
+            {item.repo_name && !isProject && (
+              <span className="font-mono text-[var(--foreground)] font-bold truncate max-w-[180px]">
+                {item.repo_name}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Project attachment — when the activity is a shipped project, we
+          surface description + tech stack so the card reads like a mini
+          portfolio entry, not just a notification. */}
+      {isProject && item.project_title && (
+        <div
+          className="px-3 py-2.5"
+          style={{
+            backgroundColor: "var(--bg-surface-light)",
+            border: "1.5px solid var(--border-subtle)",
+          }}
+        >
+          <div className="font-extrabold text-sm text-[var(--foreground)] truncate">
+            {item.project_title}
+          </div>
+          {item.project_description && (
+            <div
+              className="mt-1 text-xs text-[var(--text-secondary)] font-medium"
+              style={{
+                display: "-webkit-box",
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: "vertical",
+                overflow: "hidden",
+              }}
+            >
+              {item.project_description}
+            </div>
+          )}
+          {item.tech_stack && item.tech_stack.length > 0 && (
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {item.tech_stack.slice(0, 4).map((t) => (
+                <span
+                  key={t}
+                  className="text-[10px] font-bold uppercase tracking-wide px-1.5 py-0.5"
+                  style={{
+                    backgroundColor: "var(--bg-pill)",
+                    color: "var(--text-on-inverted)",
+                  }}
+                >
+                  {t}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Signal row: streak count + badge. Always visible (when present)
+          so every card carries at least one VibeTalent-specific signal —
+          this is what differentiates the homepage feed from a generic
+          activity stream. */}
+      <div className="flex items-center gap-2 flex-wrap">
+        {item.streak >= 1 && (
+          <span
+            className="inline-flex items-center gap-1 text-[10px] font-extrabold uppercase tracking-wide px-1.5 py-0.5"
+            style={{
+              backgroundColor: item.streak >= 30 ? "var(--accent)" : "var(--bg-surface-light)",
+              color: item.streak >= 30 ? "var(--text-on-inverted)" : "var(--foreground)",
+              border: "1.5px solid var(--border-hard)",
+            }}
+          >
+            <Flame size={10} />
+            {item.streak}d streak
+          </span>
+        )}
+        {badgeLabel && (
+          <span
+            className="text-[10px] font-extrabold uppercase tracking-wide px-1.5 py-0.5"
+            style={{
+              backgroundColor: `var(--badge-${item.badge_level})`,
+              color: "#FFFFFF",
+              border: "1.5px solid var(--border-hard)",
+            }}
+          >
+            {badgeLabel}
+          </span>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/src/lib/homepage-feed.ts
+++ b/src/lib/homepage-feed.ts
@@ -1,0 +1,216 @@
+/**
+ * Server-side fetcher for the homepage's live activity feed.
+ *
+ * The existing `/api/feed` route already does this work for the client-side
+ * `LiveActivityFeed` component, but we deliberately don't reuse it via fetch
+ * here for two reasons:
+ *  1. Calling our own API route from a server component requires an absolute
+ *     URL and adds an HTTP hop.
+ *  2. The rest of the homepage already queries Supabase directly via
+ *     `fetchHomepageDataCached` (see server-queries.ts), so this matches the
+ *     existing convention — one cached server-side function per page section.
+ *
+ * Cache strategy: `unstable_cache` with a 60s revalidate window, keyed
+ * separately from the existing `homepage-data` cache so a feed-query failure
+ * doesn't poison the rest of the homepage.
+ *
+ * Sparse-feed safeguard lives in the component layer, not here. This module
+ * always returns whatever it found — the caller decides what's "enough."
+ */
+
+import { unstable_cache } from "next/cache";
+import { createClient } from "@supabase/supabase-js";
+
+export type HomepageFeedItem = {
+  id: string;
+  type: "push" | "pr" | "create" | "issue" | "project" | "streak" | "joined";
+  username: string;
+  display_name: string | null;
+  avatar_url: string | null;
+  badge_level: string;
+  streak: number;
+  github_verified: boolean;
+  date: string;
+  repo_name?: string;
+  message?: string;
+  github_url?: string;
+  project_title?: string;
+  project_description?: string;
+  tech_stack?: string[];
+  live_url?: string;
+};
+
+/** Minimum item count to consider the feed "alive enough" to show. Below
+ *  this, the homepage falls back to the small snippet — better to show a
+ *  tight curated card than a sparse 3-item grid that reads as a ghost town. */
+export const SPARSE_THRESHOLD = 8;
+
+/** Hard cap on items rendered. More than this and the feed dominates the
+ *  homepage and pushes everything else below the fold. */
+export const MAX_ITEMS = 12;
+
+function getPublicClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  );
+}
+
+async function _fetchHomepageFeed(): Promise<HomepageFeedItem[]> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const sb = getPublicClient() as any;
+
+  // Mirror the parallel-query pattern in /api/feed/route.ts but with smaller
+  // limits — we only need enough raw rows to fill MAX_ITEMS after dedup.
+  const [usersResult, eventsResult, streakResult, projectsResult, recentUsersResult] = await Promise.all([
+    sb.from("users")
+      .select("id, username, display_name, avatar_url, badge_level, streak, github_username")
+      .order("vibe_score", { ascending: false })
+      .limit(200),
+    sb.from("feed_events")
+      .select("id, event_type, repo_name, message, github_url, created_at, user_id")
+      .order("created_at", { ascending: false })
+      .limit(60)
+      .then(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (r: any) => r,
+        () => ({ data: null, error: "feed_events not available" })
+      ),
+    sb.from("streak_logs")
+      .select("id, activity_date, user_id")
+      .order("activity_date", { ascending: false })
+      .limit(40),
+    sb.from("projects")
+      .select("id, title, description, tech_stack, live_url, github_url, created_at, user_id")
+      .eq("flagged", false)
+      .order("created_at", { ascending: false })
+      .limit(20),
+    sb.from("users")
+      .select("id, username, display_name, avatar_url, badge_level, streak, created_at, github_username")
+      .order("created_at", { ascending: false })
+      .limit(20),
+  ]);
+
+  // Build user lookup map. We only enrich items whose user we can resolve —
+  // anything orphaned gets dropped to avoid showing dangling activity.
+  const userMap = new Map<string, {
+    username: string;
+    display_name: string | null;
+    avatar_url: string | null;
+    badge_level: string;
+    streak: number;
+    github_verified: boolean;
+  }>();
+  for (const u of (usersResult.data || [])) {
+    userMap.set(u.id, {
+      username: u.username,
+      display_name: u.display_name || null,
+      avatar_url: u.avatar_url,
+      badge_level: u.badge_level || "none",
+      streak: u.streak || 0,
+      github_verified: Boolean(u.github_username),
+    });
+  }
+
+  const feed: HomepageFeedItem[] = [];
+
+  // 1. GitHub events. The .then(r=>r, ...) above swallows the error if the
+  // table doesn't exist on this environment — handle that silently.
+  if (eventsResult.data && !eventsResult.error) {
+    for (const event of eventsResult.data) {
+      const user = userMap.get(event.user_id);
+      if (!user) continue;
+      feed.push({
+        id: `event-${event.id}`,
+        type: event.event_type || "push",
+        username: user.username,
+        display_name: user.display_name,
+        avatar_url: user.avatar_url,
+        badge_level: user.badge_level,
+        streak: user.streak,
+        github_verified: user.github_verified,
+        date: event.created_at,
+        repo_name: event.repo_name,
+        message: event.message,
+        github_url: event.github_url,
+      });
+    }
+  }
+
+  // 2. Streak logs — dedup against feed_events on (username, date) so we
+  // don't show "vibed" right next to "pushed 3 commits" for the same day.
+  const coveredDates = new Set(
+    feed.map((f) => `${f.username}|${f.date.slice(0, 10)}`)
+  );
+  for (const log of (streakResult.data || [])) {
+    const user = userMap.get(log.user_id);
+    if (!user) continue;
+    const key = `${user.username}|${log.activity_date}`;
+    if (coveredDates.has(key)) continue;
+    coveredDates.add(key);
+    feed.push({
+      id: `streak-${log.id}`,
+      type: "streak",
+      username: user.username,
+      display_name: user.display_name,
+      avatar_url: user.avatar_url,
+      badge_level: user.badge_level,
+      streak: user.streak,
+      github_verified: user.github_verified,
+      date: log.activity_date,
+    });
+  }
+
+  // 3. Projects (the most marketing-relevant card type — they show actual
+  // shipped work).
+  for (const project of (projectsResult.data || [])) {
+    const user = userMap.get(project.user_id);
+    if (!user) continue;
+    feed.push({
+      id: `project-${project.id}`,
+      type: "project",
+      username: user.username,
+      display_name: user.display_name,
+      avatar_url: user.avatar_url,
+      badge_level: user.badge_level,
+      streak: user.streak,
+      github_verified: user.github_verified,
+      date: project.created_at,
+      project_title: project.title,
+      project_description: project.description,
+      tech_stack: project.tech_stack || [],
+      live_url: project.live_url || undefined,
+      github_url: project.github_url || undefined,
+    });
+  }
+
+  // 4. Recent signups — use sparingly, but a "X just joined" line is a
+  // strong activity signal for an empty-feeling marketplace.
+  for (const user of (recentUsersResult.data || [])) {
+    feed.push({
+      id: `joined-${user.id}`,
+      type: "joined",
+      username: user.username,
+      display_name: user.display_name || null,
+      avatar_url: user.avatar_url,
+      badge_level: user.badge_level || "none",
+      streak: user.streak || 0,
+      github_verified: Boolean(user.github_username),
+      date: user.created_at,
+      message: "joined VibeTalent",
+    });
+  }
+
+  feed.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  return feed.slice(0, MAX_ITEMS);
+}
+
+/** ISR-friendly cached entry point. Mirrors the 60-second window used by the
+ *  rest of `fetchHomepageDataCached` so the whole homepage shares a coherent
+ *  snapshot. The cache key is intentionally separate so a feed query failure
+ *  cannot poison the topVibecoders / stats cache. */
+export const fetchHomepageFeedCached = unstable_cache(
+  _fetchHomepageFeed,
+  ["homepage-feed-v2"],
+  { revalidate: 60 }
+);


### PR DESCRIPTION
## Summary

Two additions to the logged-out homepage that together address Meta Alchemist's feedback ("show the feed faster," "make people realize there's a better feed than the snippet," "tell people what they will gain"). Founders onboarding — the third Meta feedback item — is intentionally deferred to its own focused PR since it needs a DB migration.

## What's in this PR

### 1. Live feed grid (replaces the 480px snippet)
- **Component:** `src/components/homepage/live-feed-section.tsx` (server component)
- **Data:** `src/lib/homepage-feed.ts` (ISR-cached fetcher, 60s window)
- **Layout:** 8–12 cards in a responsive 2-col grid (1-col mobile)
- **Cards surface VibeTalent-specific signals:** badges, streak counts, project descriptions + tech stack, GitHub-verified checkmarks
- **Reinforcement banner** under the grid: "Your activity goes here next" + Create profile CTA
- **Sparse-feed safeguard:** if fewer than 8 items exist, falls back to the original snippet so we never show a half-empty grid that reads as a ghost town
- **Feature-flag gated:** `NEXT_PUBLIC_ENABLE_HOMEPAGE_FEED_V2`

### 2. End-game ladder (always rendered)
- **Component:** `src/components/homepage/end-game-ladder.tsx`
- **4 steps:** `01 SIGN UP` → `02 SHIP DAILY` → `03 CLIMB THE SCORE` → `04 GET HIRED`
- The final "Get hired" step gets accent (orange) styling because it's the destination, not another waypoint
- Subhead: *"No applications. No interviews until you're ready. Just consistent shipping that founders can verify on their own."*
- Bottom CTA: "Start your streak today" → `/auth/signup`
- No state, no fetch, no flag — pure additive marketing copy that's safe alongside any feed variant

## Required env var (for prod)

```
NEXT_PUBLIC_ENABLE_HOMEPAGE_FEED_V2=true
```

Recommend deploying with `false` first, smoke-testing on the Vercel preview, then flipping to `true`. Kill switch flip is ~30s.

## Architecture & safety

- **Server-side fetch + ISR cache (60s)** — no client polling, no "Loading activity..." flash, content visible at first paint, better SEO
- **Promise.allSettled isolation** in `page.tsx` so a feed-query failure can never break the existing stats / topVibecoders / featuredProjects rendering
- **Sparse-feed fallback** to the original `<LiveActivityFeed />` snippet when the feed has fewer than 8 items
- **Idiomatic** to the codebase — uses the same `unstable_cache` pattern as `fetchHomepageDataCached`
- **Visual language** matches the rest of the homepage (brutal shadow, orange accent, warm-grey palette in dark mode)

## Verification

- ✅ ESLint clean on all touched files
- ✅ 175/175 Vitest tests pass
- ✅ Production build compiles (67 pages)
- ✅ DOM-verified both sections render with real data and zero console errors
- ✅ Smoke-tested on dev server locally

## Test plan

- [ ] Set `NEXT_PUBLIC_ENABLE_HOMEPAGE_FEED_V2=true` in `.env.local` and the Vercel preview env
- [ ] Visit homepage in incognito (logged-out state)
- [ ] Confirm 8–12 feed cards render below the hero with badges + streak tags + project tags
- [ ] Click a feed card → goes to that user's profile
- [ ] Click "See full feed" → goes to /feed
- [ ] Click "Create profile" in the reinforcement banner → /auth/signup
- [ ] Scroll to the end-game ladder, click "Start your streak today" → /auth/signup
- [ ] Mobile viewport (375×667): feed cards stack 1-col, ladder steps stack vertically (no arrows), banners full-width
- [ ] Dark mode: warm-grey palette, accent orange stays bright on the GET HIRED card
- [ ] Toggle env var to `false` and restart: confirm fallback to old `<LiveActivityFeed />` snippet, ladder still renders

## Rollback

Vercel → env vars → `NEXT_PUBLIC_ENABLE_HOMEPAGE_FEED_V2=false` → redeploy. ~30s. Falls back to the original snippet. Ladder remains (it's safe additive copy).

## What's NOT in this PR

- **Founders onboarding** — Meta's third feedback item. Needs a DB migration (`user_type` column on users, or separate founders table), separate signup flow, founder profile pages, founders directory. Planned as its own ~3-4 day branch with a feature flag.
- **Daily reason to return** (notifications/digest) — separate effort
- **Hackathon collaboration surface** — separate, larger effort

🤖 Generated with [Claude Code](https://claude.com/claude-code)