### PR TITLE
fix(cron): authenticate GitHub events API to lift rate limit

### DIFF
--- a/src/app/api/cron/github-sync/route.ts
+++ b/src/app/api/cron/github-sync/route.ts
@@ -117,15 +117,22 @@ export async function GET(req: NextRequest) {
       const batchResults = await Promise.allSettled(
         batch.map(async (userInfo) => {
           try {
-            // Fetch public events from GitHub API
+            // Fetch public events from GitHub API. Authenticated requests get
+            // 5000/hour vs 60/hour unauthenticated — at 2 calls per user, the
+            // unauthenticated budget runs out around user 30 and the rest of
+            // the batch silently rate-limits, leaving lifetime_contributions
+            // at 0 for everyone past the cutoff. Token is optional; if unset
+            // we fall back to anonymous (still works for small userbases).
+            const ghHeaders: Record<string, string> = {
+              Accept: "application/vnd.github.v3+json",
+              "User-Agent": "VibeTalent/1.0",
+            };
+            if (process.env.GITHUB_TOKEN) {
+              ghHeaders.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+            }
             const response = await fetch(
               `https://api.github.com/users/${encodeURIComponent(userInfo.githubUsername)}/events/public?per_page=100`,
-              {
-                headers: {
-                  Accept: "application/vnd.github.v3+json",
-                  "User-Agent": "VibeTalent/1.0",
-                },
-              }
+              { headers: ghHeaders }
             );
 
             if (!response.ok) {


### PR DESCRIPTION
## Why

Right after [#163](https://github.com/unknownking07/vibe-talent/pull/163) merged and the cron ran, **64 of 77 GitHub-linked users came back with \`lifetime_contributions = 0\`**, even though their public commit history was visible (their profile heatmap rendered 16k+ contributions just fine — same parser, called from the browser).

Root cause: \`api.github.com\` rate-limits **unauthenticated requests at 60/hour per IP**. The cron does 2 GitHub calls per user; with ~30 users the budget runs out and the rest of the batch silently 403s. The cron has an early return on non-OK events response, so those users' \`lifetime_contributions\` / \`contributions_30d\` never get written.

Re-triggering didn't recover them — Vercel's IPs are shared with other projects, so we burn through the limit fast.

## Fix

Send \`Authorization: Bearer \${GITHUB_TOKEN}\` on the events fetch when the env var is set. Bumps the limit from 60/hour to **5000/hour authenticated**. Falls back to anonymous if the token isn't configured, so dev environments and small deployments still work.

Token only needs \`public_repo\` and/or \`read:user\` scopes — we're only reading public events.

## Setup steps after merge

1. **Create a Personal Access Token** at https://github.com/settings/tokens
   - Type: classic (or fine-grained, scoped to public read)
   - Scopes: \`public_repo\`, \`read:user\`
   - Expiration: pick a reasonable rotation
2. **Add to Vercel** → Settings → Environment Variables → \`GITHUB_TOKEN\` = (your token), Production + Preview
3. **Re-deploy** main (Vercel auto-redeploys on env var change, or trigger manually)
4. **Re-trigger the cron** (Vercel → Cron Jobs → Run \`/api/cron/daily\`)
5. **Verify** the 64 missed users now have populated \`lifetime_contributions\`:
   ```sql
   select count(*) from users
   where (github_username is not null and github_username != '')
     and lifetime_contributions = 0;
   ```
   Expect this to drop to near zero.

## Test plan

- [x] Typecheck clean
- [ ] After deploy, trigger cron with \`GITHUB_TOKEN\` set → confirm cron logs show \`synced\` for all users (no more \`error: GitHub rate limit exceeded\` entries)
- [ ] SQL count of missing-lifetime users drops from 64 → 0
- [ ] Spot-check Meta Alchemist's \`vibe_score\`: should jump from 25 to ~140 (16k commits → +126 volume + ~5 30d → ~131 + existing 25 - 0 = 156, minus the part that was already counted, so net ~+115)

## Followups

- Consider also auth'ing the github.com HTML scrape in [\`src/lib/github-contributions.ts\`](src/lib/github-contributions.ts) — different host with separate rate limit, less critical, may behave differently with auth (renders the authed user's view, not the public profile). Skipped here for safety.
- Long-term: switch heatmap fetch to GitHub GraphQL \`contributionsCalendar\` API. One authenticated request returns clean per-day counts, no HTML scraping. Bigger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced GitHub API request handling with optional authentication support for improved data synchronization when credentials are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->