### PR TITLE
fix(cron): authenticate GitHub API calls + tolerate events-API failures

### DIFF
--- a/src/app/api/cron/github-sync/route.ts
+++ b/src/app/api/cron/github-sync/route.ts
@@ -5,6 +5,7 @@ import { fetchGitHubContributions, sumLastNDays } from "@/lib/github-contributio
 const QUALIFYING_EVENTS = ["PushEvent", "CreateEvent", "PullRequestEvent", "IssuesEvent"];
 const BATCH_SIZE = 5;
 const BATCH_DELAY_MS = 2000;
+const EVENTS_API_TIMEOUT_MS = 8000;
 
 function cleanGithubUsername(raw: string): string {
   return raw
@@ -146,10 +147,15 @@ export async function GET(req: NextRequest) {
             let eventsApiError: string | null = null;
             let userNotFound = false;
 
+            const eventsController = new AbortController();
+            const eventsTimeoutId = setTimeout(
+              () => eventsController.abort(),
+              EVENTS_API_TIMEOUT_MS
+            );
             try {
               const response = await fetch(
                 `https://api.github.com/users/${encodeURIComponent(userInfo.githubUsername)}/events/public?per_page=100`,
-                { headers: ghApiHeaders }
+                { headers: ghApiHeaders, signal: eventsController.signal }
               );
 
               if (response.status === 404) {
@@ -168,7 +174,13 @@ export async function GET(req: NextRequest) {
                 );
               }
             } catch (err) {
-              eventsApiError = err instanceof Error ? err.message : "fetch failed";
+              eventsApiError = err instanceof Error && err.name === "AbortError"
+                ? `timeout after ${EVENTS_API_TIMEOUT_MS}ms`
+                : err instanceof Error
+                  ? err.message
+                  : "fetch failed";
+            } finally {
+              clearTimeout(eventsTimeoutId);
             }
 
             // Hard skip only if GitHub explicitly says the user doesn't exist.

--- a/src/app/api/cron/github-sync/route.ts
+++ b/src/app/api/cron/github-sync/route.ts
@@ -36,6 +36,25 @@ export async function GET(req: NextRequest) {
 
   const supabase = createAdminClient();
 
+  // Build common GitHub API headers. Anonymous calls share Vercel's IP with
+  // every other Vercel project and are capped at 60/hr — easy to exhaust
+  // partway through the run, leaving most users un-synced. With a token the
+  // limit is 5000/hr.
+  const githubToken = process.env.GITHUB_TOKEN;
+  const ghApiHeaders: Record<string, string> = {
+    Accept: "application/vnd.github.v3+json",
+    "User-Agent": "VibeTalent/1.0",
+  };
+  if (githubToken) {
+    ghApiHeaders.Authorization = `Bearer ${githubToken}`;
+  } else {
+    console.warn(
+      "[github-sync] GITHUB_TOKEN not set — anonymous api.github.com limit " +
+      "is 60/hr per IP. Expect partial sync once userbase exceeds ~30 users. " +
+      "Add a GitHub PAT (no scopes / public_repo) as GITHUB_TOKEN in Vercel."
+    );
+  }
+
   try {
     // Fetch users with github_username set
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -108,7 +127,7 @@ export async function GET(req: NextRequest) {
     let synced = 0;
     let skipped = 0;
     let errors = 0;
-    const details: { user: string; github: string; status: string; dates_logged?: number; lifetime?: number; last30d?: number }[] = [];
+    const details: { user: string; github: string; status: string; dates_logged?: number; lifetime?: number; last30d?: number; events_api_error?: string }[] = [];
 
     // Process in batches
     for (let i = 0; i < usersToSync.length; i += BATCH_SIZE) {
@@ -117,40 +136,48 @@ export async function GET(req: NextRequest) {
       const batchResults = await Promise.allSettled(
         batch.map(async (userInfo) => {
           try {
-            // Fetch public events from GitHub API
-            const response = await fetch(
-              `https://api.github.com/users/${encodeURIComponent(userInfo.githubUsername)}/events/public?per_page=100`,
-              {
-                headers: {
-                  Accept: "application/vnd.github.v3+json",
-                  "User-Agent": "VibeTalent/1.0",
-                },
-              }
-            );
+            // Try the events API first (for the activity feed). Failure here
+            // is NON-fatal — we still fetch the heatmap below for lifetime
+            // and 30d totals. Previously a single 403 (rate-limit) on this
+            // call would skip a user entirely, so most users never got their
+            // volume scoring populated.
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            let recentEvents: any[] = [];
+            let eventsApiError: string | null = null;
+            let userNotFound = false;
 
-            if (!response.ok) {
+            try {
+              const response = await fetch(
+                `https://api.github.com/users/${encodeURIComponent(userInfo.githubUsername)}/events/public?per_page=100`,
+                { headers: ghApiHeaders }
+              );
+
               if (response.status === 404) {
-                return { userInfo, status: "skipped", reason: "GitHub user not found" };
+                userNotFound = true;
+              } else if (!response.ok) {
+                eventsApiError = response.status === 403
+                  ? "rate limit exceeded"
+                  : `HTTP ${response.status}`;
+              } else {
+                const events = await response.json();
+                const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+                recentEvents = events.filter(
+                  (event: { type: string; created_at: string }) =>
+                    QUALIFYING_EVENTS.includes(event.type) &&
+                    new Date(event.created_at) > oneDayAgo
+                );
               }
-              if (response.status === 403) {
-                return { userInfo, status: "error", reason: "GitHub rate limit exceeded" };
-              }
-              return { userInfo, status: "error", reason: `GitHub API error: ${response.status}` };
+            } catch (err) {
+              eventsApiError = err instanceof Error ? err.message : "fetch failed";
             }
 
-            const events = await response.json();
-
-            // Filter qualifying events from the last 24 hours
-            const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
-            const recentEvents = events.filter(
-              (event: { type: string; created_at: string }) =>
-                QUALIFYING_EVENTS.includes(event.type) &&
-                new Date(event.created_at) > oneDayAgo
-            );
+            // Hard skip only if GitHub explicitly says the user doesn't exist.
+            if (userNotFound) {
+              return { userInfo, status: "skipped", reason: "GitHub user not found" };
+            }
 
             // Save events to feed_events table for the activity feed (only
-            // when there are recent events; inactive users still get their
-            // lifetime/30d totals refreshed below).
+            // when the events API actually succeeded and returned items).
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const feedRows = recentEvents.slice(0, 10).map((event: any) => {
               const repoName = (event.repo?.name || 'unknown').replace(/^[^/]+\//, '');
@@ -269,7 +296,7 @@ export async function GET(req: NextRequest) {
               };
             }
 
-            return { userInfo, status: "synced", loggedCount, lifetime, last30d };
+            return { userInfo, status: "synced", loggedCount, lifetime, last30d, eventsApiError };
           } catch (err) {
             console.error(`Error syncing GitHub for ${userInfo.githubUsername}:`, err);
             return { userInfo, status: "error", reason: "Unexpected error" };
@@ -289,6 +316,7 @@ export async function GET(req: NextRequest) {
               dates_logged: val.loggedCount,
               lifetime: val.lifetime,
               last30d: val.last30d,
+              ...(val.eventsApiError ? { events_api_error: val.eventsApiError } : {}),
             });
           } else if (val.status === "skipped") {
             skipped++;


### PR DESCRIPTION
## Why

After triggering \`/api/cron/daily\` on prod, only **~13 of 76 users** got their \`lifetime_contributions\` populated. The other 60+ users (including Meta Alchemist, who has 16k+ public commits) showed \`lifetime_contributions = 0\` and a stale vibe_score.

Root cause: the events-API call to \`api.github.com\` is unauthenticated, capped at **60 req/hr per IP**. Vercel's outbound IPs are shared with every other Vercel project, so we may already be partway through that budget when the cron starts. Once the limit hits ~user 30, every subsequent user gets HTTP 403 → early return at [route.ts:131-139](src/app/api/cron/github-sync/route.ts#L131) → never reaches the heatmap fetch that's what actually populates lifetime/30d.

## What changed

**1. Authenticate the events-API call with \`GITHUB_TOKEN\`.** Bumps the limit from 60/hr to **5000/hr**. Token is optional — if absent we log a loud warning at cron start so a missing prod env var can't fail silently:

\`\`\`
[github-sync] GITHUB_TOKEN not set — anonymous api.github.com limit
is 60/hr per IP. Expect partial sync once userbase exceeds ~30 users.
Add a GitHub PAT (no scopes / public_repo) as GITHUB_TOKEN in Vercel.
\`\`\`

(Heatmap scrape stays unauth'd — it hits github.com web pages, which ignore PAT auth and have their own more-lenient web rate limit.)

**2. Stop letting events-API failure abort the user's whole sync.** The events feed is nice-to-have; the heatmap fetch is what powers the volume bonus in vibe_score. Now if events errors (rate-limit, transient, etc.) we record \`eventsApiError\` on the result and still proceed to the heatmap fetch + DB write. Only a 404 ("user does not exist") still short-circuits.

Synced detail entries now carry \`events_api_error\` when relevant, so the cron run log shows when GitHub was throttling vs everything was healthy.

## Deploy steps

1. **Generate a GitHub PAT** at https://github.com/settings/tokens — fine-grained or classic. **No scopes needed** for public-data access (or just \`public_repo\` on classic). Token doesn't need access to any specific repos.
2. **Add it to Vercel** → Project Settings → Environment Variables → \`GITHUB_TOKEN\` = your token, scope: Production (and Preview if you want).
3. **Merge this PR** (Vercel deploys main).
4. **Trigger the cron once**: Vercel → Cron Jobs → \`/api/cron/daily\` → Run.
5. **Verify** in Supabase SQL editor:
   \`\`\`sql
   select count(*) filter (where lifetime_contributions > 0) as populated,
          count(*) filter (where lifetime_contributions = 0
                           and (github_username is not null and github_username != '')) as still_missing
   from users;
   \`\`\`
   Should be ~70+ populated, near-zero still_missing (only users with bad/typo'd handles).

## Test plan

- [x] \`npx tsc --noEmit\` clean for src/
- [x] \`npx vitest run scoring-baseline\` — 36 passed
- [ ] After deploy: trigger cron, confirm logs show GITHUB_TOKEN was set (no warning line)
- [ ] After deploy: re-run the diagnostic SQL above, confirm \`still_missing\` drops to 0 (or near-0)
- [ ] Spot-check Meta Alchemist's profile — vibe_score should jump from 25 to ~135-150 once their 16k+ lifetime lands

## Why this is safe

- Token is optional, missing token just falls back to old behavior (with a loud warning instead of silent failure).
- No schema changes.
- No formula changes.
- Rollback: revert this commit. Old behavior returns. New columns stay where the cron already populated them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sync is more resilient: transient API failures, timeouts, and rate limits no longer stop the process; only "user not found" halts a sync.
  * Sync reports now record when the public-events API failed, and continue with heatmap-based metrics.

* **Chores**
  * Optional bearer-token support added for API requests; absence is warned for visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->