### PR TITLE
fix(cron): bump maxDuration, fix quality-rescore auth + ordering

### DIFF
--- a/src/app/api/cron/daily/route.ts
+++ b/src/app/api/cron/daily/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSiteUrl } from "@/lib/seo";
 
+// Daily orchestrator awaits each child cron sequentially, so its own
+// timeout has to be long enough to cover the slowest child plus all
+// the others. github-sync alone can run up to 5 min at scale.
+export const maxDuration = 300;
+
 /**
  * Daily orchestrator cron — fans out to individual cron job routes.
  * Each job runs in its own serverless invocation for independent timeouts.

--- a/src/app/api/cron/github-sync/route.ts
+++ b/src/app/api/cron/github-sync/route.ts
@@ -2,6 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { fetchGitHubContributions, sumLastNDays } from "@/lib/github-contributions";
 
+// Bump function timeout to 5 minutes — at ~100 users × ~3-5s each (events
+// API + heatmap fetch + per-day upserts) we'd routinely hit the default
+// 60s and leave 60+ users un-synced. Pro plan caps maxDuration at 300s.
+export const maxDuration = 300;
+
 const QUALIFYING_EVENTS = ["PushEvent", "CreateEvent", "PullRequestEvent", "IssuesEvent"];
 const BATCH_SIZE = 5;
 const BATCH_DELAY_MS = 2000;
@@ -57,13 +62,17 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    // Fetch users with github_username set
+    // Fetch users with github_username set. Order by lifetime_contributions
+    // ASC NULLS FIRST so unpopulated users get processed first — if the
+    // function still times out, the next run picks up where this one left
+    // off instead of re-doing the same prefix.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { data: usersWithGithub, error: usersError } = await (supabase as any)
       .from("users")
-      .select("id, username, github_username")
+      .select("id, username, github_username, lifetime_contributions")
       .not("github_username", "is", null)
-      .neq("github_username", "");
+      .neq("github_username", "")
+      .order("lifetime_contributions", { ascending: true, nullsFirst: true });
 
     if (usersError) {
       console.error("Failed to fetch users:", usersError);

--- a/src/app/api/cron/quality-rescore/route.ts
+++ b/src/app/api/cron/quality-rescore/route.ts
@@ -2,6 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { analyzeRepository, checkLiveUrl, parseGithubRepoUrl } from "@/lib/github-quality";
 
+// Each project costs 4 api.github.com calls. At 50 projects per run that's
+// 200 calls — well over the 60/hr anonymous limit. Plus default 60s Vercel
+// timeout can't fit even half of a full run. Pro plan caps maxDuration at
+// 300s; combined with a GITHUB_TOKEN bumping us to 5000/hr, this lets the
+// cron actually finish.
+export const maxDuration = 300;
+
 const BATCH_SIZE = 5;
 const BATCH_DELAY_MS = 2500;
 
@@ -24,6 +31,19 @@ export async function GET(req: NextRequest) {
   }
 
   const supabase = createAdminClient();
+
+  // Pass GITHUB_TOKEN through to analyzeRepository so we get the 5000/hr
+  // authenticated rate limit instead of the 60/hr anonymous one. Token is
+  // optional; without it the cron still runs but will only get through ~15
+  // projects before api.github.com starts returning 403s.
+  const githubToken = process.env.GITHUB_TOKEN;
+  if (!githubToken) {
+    console.warn(
+      "[quality-rescore] GITHUB_TOKEN not set — anonymous api.github.com " +
+      "limit is 60/hr per IP and each project costs 4 calls, so only ~15 " +
+      "projects can be analyzed per run. Add a GitHub PAT to GITHUB_TOKEN."
+    );
+  }
 
   try {
     // Find verified projects with a GitHub URL that were last analyzed 7+ days ago (or never)
@@ -67,7 +87,7 @@ export async function GET(req: NextRequest) {
 
             const { owner: repoOwner, repo: repoName } = parsed;
 
-            const qualityResult = await analyzeRepository(repoOwner, repoName);
+            const qualityResult = await analyzeRepository(repoOwner, repoName, githubToken);
             const qualityScore = qualityResult.success ? (qualityResult.metrics?.quality_score ?? 0) : 0;
             const qualityMetrics = (qualityResult.success && qualityResult.metrics)
               ? {


### PR DESCRIPTION
## Why

Two related production issues, same root cause shape — Vercel function timeouts + anonymous GitHub rate limits combining to leave most users / projects un-synced.

### Issue 1: github-sync only synced 23/90 users
After #166 made the cron resilient, triggering /api/cron/daily on prod gave:
\`\`\`
populated: 23
still_zero: 67
\`\`\`
Default 60s function timeout, ~3-5s per user (events API + heatmap fetch + ~50-100 streak_log upserts), so the cron got killed at ~25 users.

### Issue 2: quality_score stays 0 for newer verified projects
Reported on this PR: Apoorv's verified WalletChan project never got a \`quality_score\`. quality-rescore cron makes 4 api.github.com calls per project — at 50 projects/run that's 200 calls, vs the 60/hr anonymous limit. Older projects get analyzed; newer ones (\`ORDER BY created_at ASC\`) hit 403 before being reached.

## What changed

**[\`/api/cron/github-sync\`](src/app/api/cron/github-sync/route.ts)**
- \`export const maxDuration = 300\` — 5x headroom (Pro plan max).
- Sort users by \`lifetime_contributions ASC NULLS FIRST\` — re-triggering progresses through unpopulated users first instead of redoing the same prefix.

**[\`/api/cron/daily\`](src/app/api/cron/daily/route.ts)**
- \`export const maxDuration = 300\` — orchestrator awaits children sequentially, needs same budget as slowest child.

**[\`/api/cron/quality-rescore\`](src/app/api/cron/quality-rescore/route.ts)**
- \`export const maxDuration = 300\`.
- Pass \`process.env.GITHUB_TOKEN\` through to \`analyzeRepository(...)\` (the lib already accepted a token, the cron just wasn't forwarding one).
- Startup warning when token is missing.

## Optional but recommended: set GITHUB_TOKEN

Without the token, quality-rescore can only analyze ~15 projects per run (60/hr ÷ 4 calls per project). Adding a PAT to Vercel env vars unlocks 5000/hr and lets a full run finish.

- GitHub → Settings → Developer settings → Personal access tokens → Fine-grained or Classic
- **No scopes needed** for public-data access. Don't grant write/repo/anything.
- Vercel → Project Settings → Environment Variables → \`GITHUB_TOKEN\` = your token

## Deploy steps

1. (Optional) Add \`GITHUB_TOKEN\` to Vercel env vars.
2. Merge this PR.
3. Wait for Vercel deploy (~1-2 min).
4. Trigger /api/cron/daily once.
5. Verify both fixes:
   \`\`\`sql
   -- github-sync
   select 
     count(*) filter (where lifetime_contributions > 0) as populated,
     count(*) filter (where lifetime_contributions = 0
                      and (github_username is not null and github_username != '')) as still_zero
   from users;
   
   -- quality-rescore
   select 
     count(*) filter (where quality_score > 0) as analyzed,
     count(*) filter (where quality_score = 0 and verified = true) as still_unanalyzed
   from projects;
   \`\`\`
6. Spot-check Meta and Apoorv:
   \`\`\`sql
   select username, vibe_score, lifetime_contributions, contributions_30d
   from users where username in ('meta_alchemist', 'apoorv');
   
   select title, quality_score, quality_metrics->>'analyzed_at' as analyzed_at
   from projects p join users u on u.id = p.user_id where u.username = 'apoorv';
   \`\`\`

## Why this is safe

- Only timeout headroom + token forwarding. No formula or schema changes.
- \`GITHUB_TOKEN\` is optional — old behavior with warning if missing.
- Rollback: revert the commits. Old timeouts return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)