### PR TITLE
docs: full refresh for the vibe score volume credit shipping

### DIFF
--- a/docs/builders/github-sync.md
+++ b/docs/builders/github-sync.md
@@ -1,18 +1,18 @@
 # GitHub Integration
 
-VibeTalent can automatically sync your GitHub activity to log streaks — so you don't have to remember to click "Log Activity" every day.
+Connecting GitHub does three things for your VibeTalent profile:
 
-## What It Does
+1. **Auto-logs your daily streak** — every day you push code, your streak stays alive without you clicking anything.
+2. **Powers the contribution heatmap** on your profile — the year-long grid that shows when you're active.
+3. **Unlocks the Lifetime + Recent-30d Vibe Score bonuses** (up to **+300 combined**). For builders with years of public commit history, this is often the biggest single component of their score.
 
-When you sync your GitHub activity, VibeTalent:
-1. Fetches your recent public events from the GitHub API
-2. Filters for qualifying coding activity
-3. Logs each unique day as a streak entry
-4. Triggers a recalculation of your streak, badge, and Vibe Score
+## What gets synced
 
-## Which Events Count
+A daily cron at **6 AM UTC** pulls two things from GitHub for every connected user:
 
-Not everything on GitHub counts. VibeTalent tracks events that represent real coding work:
+### Recent events (last 24 hours)
+
+Used for streak logging and the public activity feed:
 
 | Event | What It Means |
 |---|---|
@@ -21,34 +21,47 @@ Not everything on GitHub counts. VibeTalent tracks events that represent real co
 | **PullRequestEvent** | You opened or merged a pull request |
 | **IssuesEvent** | You created or worked on an issue |
 
-Other activity (starring repos, watching, commenting) doesn't count — we only track actions that involve writing or shipping code.
+Stars, watches, and comments don't count — only events that represent real coding.
 
-## How to Enable It
+### Full-year contribution heatmap
 
-1. **Sign up with GitHub** — Your GitHub username is automatically linked to your VibeTalent account
-2. **Go to your Dashboard**
-3. **Click "Sync GitHub Activity"**
-4. VibeTalent fetches your recent events and logs any qualifying days
+Pulled from your public GitHub profile page. We extract:
 
-You can trigger a sync manually from your Dashboard whenever you want. The sync looks at your last 24 hours of public GitHub activity.
+- **Real per-day commit counts** (e.g. "8 commits on May 4th"), not just whether you were active. This drives the contribution heatmap on your profile and the per-day numbers that show on hover.
+- **Lifetime contribution count** (last 365 days) → stored as `lifetime_contributions`, feeds the Vibe Score lifetime bonus on a square-root curve (16k commits → +126 points, capped at +250).
+- **Last-30-day contribution count** → stored as `contributions_30d`, feeds the recent activity bonus (up to +50 points).
 
-## Benefits
+## How to connect
 
-- **Never miss a day** — If you pushed code on GitHub, your streak is safe
-- **No double work** — You're already coding on GitHub; no need to also log manually
-- **Automatic** — Just code and push like you normally do
+1. **Sign up with GitHub** — Your username is automatically linked.
+2. Or, if you signed up with email: go to your **Dashboard → Settings → Connect GitHub**.
+3. The next daily cron run picks you up and populates everything within ~6 hours.
 
-## Things to Know
+You don't need to push a button to sync — it's automatic once your GitHub username is on file.
 
-- Only **public** events are synced (GitHub's API only exposes public activity for users)
-- The sync checks the **last 24 hours** of activity per trigger
-- If you code in a private repo, you'll need to log manually via the Dashboard
-- Your GitHub username is stored securely and only used for API calls
+## What counts as "activity"
 
-## Combining Manual + GitHub
+Public commits to public repos. The heatmap only sees what github.com itself shows publicly, so:
 
-You can use both methods:
-- **GitHub sync** catches your public coding activity
-- **Manual logging** covers private repo work, design, planning, or any other coding you do outside GitHub
+- **Commits to private repos** don't count toward `lifetime_contributions` or the heatmap.
+- **Commits to forks** don't count unless they're merged upstream (GitHub's rule, not ours).
+- **Squashed merge commits** count as one commit on the merge date.
+- **Co-authored commits** count for every co-author.
 
-Both contribute to the same streak. As long as at least one log exists for each day, your streak stays alive.
+If you do a lot of private work, your VibeTalent score will under-represent your output. The fix today: open-source what you can. The fix tomorrow: we may add a way to log private activity manually for streak purposes (already supported via the Dashboard's "Log Activity" button — but that only credits the streak, not the volume bonus).
+
+## Combining manual + GitHub
+
+You can still log activity manually from the Dashboard for days you worked entirely in private repos. Both contribute to your **streak**. Volume credit (lifetime + 30d) is GitHub-only, since it depends on public, verifiable counts.
+
+## Privacy
+
+- We only read **public** data via the public GitHub API and the public profile page.
+- Your GitHub username is stored on your `users` row; we don't store an OAuth token unless you explicitly authenticate via GitHub.
+- We never write to your GitHub account.
+
+## Things to know
+
+- The cron has a **5000 req/hour** rate limit on GitHub API calls. If we approach it, the system gracefully degrades — heatmap fetch keeps working (it uses a different rate limit) so volume scoring stays accurate even when the events feed temporarily stops updating.
+- If your GitHub username is wrong on your VibeTalent profile, fix it in **Dashboard → Settings** — the next cron run will pick up the corrected handle.
+- The volume bonus is **purely additive** — your score can go up when this kicks in, never down.

--- a/docs/builders/vibe-score.md
+++ b/docs/builders/vibe-score.md
@@ -6,10 +6,17 @@ You can't buy it. You can only earn it — through consistent work and quality o
 
 ## How It's Calculated
 
-Your Vibe Score is made up of six components:
+Your Vibe Score is made up of eight components:
 
 ```text
-Vibe Score = 10 (baseline) + Streak Points + Project Score + Endorsements + Badge Bonus + Review Bonus
+Vibe Score = 10 (baseline)
+           + Streak Points
+           + Project Score
+           + Endorsements
+           + Badge Bonus
+           + Review Bonus
+           + Lifetime GitHub Bonus       ← rewards veteran builders
+           + Recent Activity Bonus       ← rewards builders shipping right now
 ```
 
 ### 1. Streak Points
@@ -59,20 +66,60 @@ Each client review awards points based on the star rating:
 
 Three 5-star reviews = `3 × 20 = 60` bonus points. There's no cap — every trusted review counts. Only reviews with a trust score of 30+ contribute to your Vibe Score (spam and bot reviews are filtered out).
 
-## Quality vs Consistency
+### 5. Lifetime GitHub Bonus
 
-**Consistency gets you noticed. Quality makes you hireable.**
+Your full-year GitHub contribution count earns points on a square-root curve, capped at 250:
 
-VibeTalent rewards both — but quality signals carry serious weight. Here's a real comparison:
+```text
+min(floor(sqrt(lifetime_contributions)), 250)
+```
 
-| Builder | Streak | Projects | Details | Reviews | Vibe Score |
+| Lifetime commits | Bonus |
+|---|---|
+| 100 | +10 |
+| 1,000 | +31 |
+| 10,000 | +100 |
+| 16,000 | +126 |
+| 50,000 | +223 |
+| 62,500+ | +250 (cap) |
+
+This rewards builders who've been shipping for years — your reputation isn't reset because you took a break. The square-root curve gives veterans visible separation from casuals while still capping bot-scale outliers (so a 1M-commit account doesn't dwarf actual platform activity).
+
+Connect your GitHub in your profile settings to enable this — the daily cron pulls from your public contribution heatmap.
+
+### 6. Recent Activity Bonus
+
+Commits in the last 30 days earn extra points, capped at +50:
+
+```text
+min(floor(contributions_30d × 0.5), 50)
+```
+
+| Last 30d commits | Bonus |
+|---|---|
+| 10 | +5 |
+| 50 | +25 |
+| 100+ | +50 (cap) |
+
+This rewards builders who are *actively shipping right now*. Combined with the lifetime bonus, the score reflects both "are you a veteran" and "are you currently active" — neither alone, both together.
+
+## Quality vs Consistency vs Volume
+
+**Consistency gets you noticed. Quality makes you hireable. Volume proves you're a real builder.**
+
+VibeTalent rewards all three. Here's how three real-shaped builders compare under the new scoring:
+
+| Builder | Streak | Projects | Lifetime commits | Last 30d | Vibe Score |
 |---|---|---|---|---|---|
-| **Streak-focused** | 100 days | 2 projects, no URLs | Minimal | None | 10 + (100×2) + (2×2) + 0 + 0 + 0 = **214** |
-| **Quality-focused** | 30 days | 5 projects, full URLs + quality 60 avg | Live demos, GitHub repos | 3 five-star reviews | 10 + (30×2) + (5×66) + 0 + 10 + 60 = **470** |
+| **Streak-focused** | 100 days | 2 projects, no URLs | 0 (no GitHub linked) | 0 | 10 + (100×2) + (2×2) + 0 + 0 + 0 + 0 + 0 = **214** |
+| **Quality-focused** | 30 days | 5 projects, full URLs + quality 60 avg | 1,000 | 50 | 10 + (30×2) + (5×66) + 0 + 10 + 60 + 31 + 25 = **526** |
+| **Veteran** | 0 days (just joined) | 1 verified project | 16,000 | 0 | 10 + 0 + 6 + 0 + 0 + 0 + 126 + 0 = **142** |
 
-The quality builder is ahead — and their score is **resilient**: projects and reviews don't go away when a streak breaks.
+The quality builder leads — and their score is **resilient**: even if their streak resets, they still have ~400 points from projects, lifetime, reviews, and badges. The veteran, despite no streak and just one project, lands above the streak-only builder because their lifetime work is visible.
 
-And when a client is choosing who to hire? They're looking at live demos, verified projects, and reviews — not just a streak number.
+That's the design: no single dimension dominates. Volume credits lifetime contribution. Streak credits daily consistency. Project score and reviews credit shipped quality. Multiple paths to a strong score.
+
+And when a client is choosing who to hire? They're looking at live demos, verified projects, reviews, and a real GitHub history — not just a streak number.
 
 ## How to Increase Your Vibe Score
 
@@ -89,7 +136,7 @@ And when a client is choosing who to hire? They're looking at live demos, verifi
 3. **Earn badges** — permanent bonus that never goes away
 4. **Get client reviews** — a 5-star review is worth 20 points
 5. **Get endorsements** — each endorsement on your projects adds 5 points
-6. **Connect GitHub** — auto-log activity so you never miss a day
+6. **Connect GitHub** — unlocks the lifetime + recent-30d bonuses (up to +300 combined). If you have years of public commits, this alone can be worth more than every other component.
 
 ## Where Your Score Appears
 

--- a/docs/developers/database-schema.md
+++ b/docs/developers/database-schema.md
@@ -76,9 +76,11 @@ The core profile table. Scores and badges are **auto-calculated** by database tr
 | `avatar_url` | TEXT | Profile photo URL |
 | `streak` | INTEGER | Current consecutive active days |
 | `longest_streak` | INTEGER | All-time best streak |
-| `vibe_score` | INTEGER | Composite reputation score |
+| `vibe_score` | INTEGER | Composite reputation score (see `update_user_streak` below) |
 | `badge_level` | TEXT | `none`, `bronze`, `silver`, `gold`, `diamond` |
 | `github_username` | TEXT | Extracted from GitHub OAuth metadata |
+| `lifetime_contributions` | INTEGER | Sum of last-365-day public GitHub commits, populated daily by the github-sync cron from the public contribution heatmap. Default 0. Feeds the volume bonus in `update_user_streak`. |
+| `contributions_30d` | INTEGER | Sum of last-30-day public GitHub commits. Same source as above. Default 0. Feeds the recent activity bonus. |
 | `created_at` | TIMESTAMPTZ | Account creation date |
 
 ### projects
@@ -114,6 +116,7 @@ One row per user per day. The `UNIQUE(user_id, activity_date)` constraint preven
 | `id` | UUID (PK) | Auto-generated |
 | `user_id` | UUID (FK → users) | Who logged the activity |
 | `activity_date` | DATE | The day of activity |
+| `commit_count` | INTEGER | Real number of commits on this date, from the GitHub heatmap. Default 1 for manually-logged days. Feeds the contribution heatmap on profile pages. |
 
 **Trigger:** On INSERT, fires `update_user_streak()` to recalculate the user's streak, longest_streak, badge_level, and vibe_score.
 
@@ -211,7 +214,7 @@ This is the most critical function in the system. It runs automatically when a s
 **What it calculates:**
 
 ```sql
--- 1. Current streak: count consecutive days backwards from today
+-- 1. Current streak: count consecutive days backwards from today (from streak_logs)
 -- 2. Longest streak: MAX of current and all historical streaks
 -- 3. Badge level based on longest_streak:
 --    - none:    < 30 days
@@ -219,11 +222,19 @@ This is the most critical function in the system. It runs automatically when a s
 --    - silver:  >= 90 days
 --    - gold:    >= 180 days
 --    - diamond: >= 365 days
--- 4. Vibe score formula:
---    (current_streak * 2) + Σ project_quality_scores + badge_bonus + review_bonus
---    Project quality: up to 15 pts per verified project (completeness bonuses)
---    Badge bonuses: bronze=10, silver=20, gold=30, diamond=40
---    Review bonus: avg_rating × review_count × 2, capped at 50
+-- 4. Vibe score formula (eight components):
+--    10 (baseline)
+--    + (current_streak * 2)                                          ← streak
+--    + Σ per_project (2 + live_url? +2 + github_url? +2 + LEAST(quality_score, 100))
+--    + (endorsement_count * 5)
+--    + badge_bonus                                                    ← bronze=10, silver=20, gold=30, diamond=40
+--    + Σ review_bonus per rating (5★=+20, 4★=+15, 3★=+10, 2★=+5, only if trust_score>=30)
+--    + LEAST(FLOOR(SQRT(GREATEST(0, lifetime_contributions))), 250)  ← lifetime volume
+--    + LEAST(FLOOR(contributions_30d * 0.5), 50)                     ← recent activity
+--
+-- Lifetime + recent volume terms were added in migration
+-- 20260430_add_volume_credit_to_vibe_score.sql to credit GitHub history
+-- and recent activity (e.g. 16,000 lifetime commits → +126 points).
 ```
 
 **Triggers:**

--- a/docs/vibecoders/github-sync.md
+++ b/docs/vibecoders/github-sync.md
@@ -1,18 +1,18 @@
 # GitHub Integration
 
-VibeTalent can automatically sync your GitHub activity to log streaks — so you don't have to remember to click "Log Activity" every day.
+Connecting GitHub does three things for your VibeTalent profile:
 
-## What It Does
+1. **Auto-logs your daily streak** — every day you push code, your streak stays alive without you clicking anything.
+2. **Powers the contribution heatmap** on your profile — the year-long grid that shows when you're active.
+3. **Unlocks the Lifetime + Recent-30d Vibe Score bonuses** (up to **+300 combined**). For builders with years of public commit history, this is often the biggest single component of their score.
 
-When you sync your GitHub activity, VibeTalent:
-1. Fetches your recent public events from the GitHub API
-2. Filters for qualifying coding activity
-3. Logs each unique day as a streak entry
-4. Triggers a recalculation of your streak, badge, and Vibe Score
+## What gets synced
 
-## Which Events Count
+A daily cron at **6 AM UTC** pulls two things from GitHub for every connected user:
 
-Not everything on GitHub counts. VibeTalent tracks events that represent real coding work:
+### Recent events (last 24 hours)
+
+Used for streak logging and the public activity feed:
 
 | Event | What It Means |
 |---|---|
@@ -21,34 +21,47 @@ Not everything on GitHub counts. VibeTalent tracks events that represent real co
 | **PullRequestEvent** | You opened or merged a pull request |
 | **IssuesEvent** | You created or worked on an issue |
 
-Other activity (starring repos, watching, commenting) doesn't count — we only track actions that involve writing or shipping code.
+Stars, watches, and comments don't count — only events that represent real coding.
 
-## How to Enable It
+### Full-year contribution heatmap
 
-1. **Sign up with GitHub** — Your GitHub username is automatically linked to your VibeTalent account
-2. **Go to your Dashboard**
-3. **Click "Sync GitHub Activity"**
-4. VibeTalent fetches your recent events and logs any qualifying days
+Pulled from your public GitHub profile page. We extract:
 
-You can trigger a sync manually from your Dashboard whenever you want. The sync looks at your last 24 hours of public GitHub activity.
+- **Real per-day commit counts** (e.g. "8 commits on May 4th"), not just whether you were active. This drives the contribution heatmap on your profile and the per-day numbers that show on hover.
+- **Lifetime contribution count** (last 365 days) → stored as `lifetime_contributions`, feeds the Vibe Score lifetime bonus on a square-root curve (16k commits → +126 points, capped at +250).
+- **Last-30-day contribution count** → stored as `contributions_30d`, feeds the recent activity bonus (up to +50 points).
 
-## Benefits
+## How to connect
 
-- **Never miss a day** — If you pushed code on GitHub, your streak is safe
-- **No double work** — You're already coding on GitHub; no need to also log manually
-- **Automatic** — Just code and push like you normally do
+1. **Sign up with GitHub** — Your username is automatically linked.
+2. Or, if you signed up with email: go to your **Dashboard → Settings → Connect GitHub**.
+3. The next daily cron run picks you up and populates everything within ~6 hours.
 
-## Things to Know
+You don't need to push a button to sync — it's automatic once your GitHub username is on file.
 
-- Only **public** events are synced (GitHub's API only exposes public activity for users)
-- The sync checks the **last 24 hours** of activity per trigger
-- If you code in a private repo, you'll need to log manually via the Dashboard
-- Your GitHub username is stored securely and only used for API calls
+## What counts as "activity"
 
-## Combining Manual + GitHub
+Public commits to public repos. The heatmap only sees what github.com itself shows publicly, so:
 
-You can use both methods:
-- **GitHub sync** catches your public coding activity
-- **Manual logging** covers private repo work, design, planning, or any other coding you do outside GitHub
+- **Commits to private repos** don't count toward `lifetime_contributions` or the heatmap.
+- **Commits to forks** don't count unless they're merged upstream (GitHub's rule, not ours).
+- **Squashed merge commits** count as one commit on the merge date.
+- **Co-authored commits** count for every co-author.
 
-Both contribute to the same streak. As long as at least one log exists for each day, your streak stays alive.
+If you do a lot of private work, your VibeTalent score will under-represent your output. The fix today: open-source what you can. The fix tomorrow: we may add a way to log private activity manually for streak purposes (already supported via the Dashboard's "Log Activity" button — but that only credits the streak, not the volume bonus).
+
+## Combining manual + GitHub
+
+You can still log activity manually from the Dashboard for days you worked entirely in private repos. Both contribute to your **streak**. Volume credit (lifetime + 30d) is GitHub-only, since it depends on public, verifiable counts.
+
+## Privacy
+
+- We only read **public** data via the public GitHub API and the public profile page.
+- Your GitHub username is stored on your `users` row; we don't store an OAuth token unless you explicitly authenticate via GitHub.
+- We never write to your GitHub account.
+
+## Things to know
+
+- The cron has a **5000 req/hour** rate limit on GitHub API calls. If we approach it, the system gracefully degrades — heatmap fetch keeps working (it uses a different rate limit) so volume scoring stays accurate even when the events feed temporarily stops updating.
+- If your GitHub username is wrong on your VibeTalent profile, fix it in **Dashboard → Settings** — the next cron run will pick up the corrected handle.
+- The volume bonus is **purely additive** — your score can go up when this kicks in, never down.

--- a/docs/vibecoders/vibe-score.md
+++ b/docs/vibecoders/vibe-score.md
@@ -8,7 +8,7 @@ You can't buy it. You can only earn it — through quality output and consistent
 
 Your Vibe Score is made up of eight components:
 
-```
+```text
 Vibe Score = 10 (baseline)
            + Project Score
            + Streak Points
@@ -34,7 +34,7 @@ Every project you add earns points:
 
 ### 2. Streak Points
 
-```
+```text
 Current Streak × 2
 ```
 
@@ -74,7 +74,7 @@ Reviews are also scored for **trust** (0-100) to detect fake/bot reviews. Review
 
 Your full-year GitHub contribution count earns points on a square-root curve, capped at 250:
 
-```
+```text
 min(floor(sqrt(lifetime_contributions)), 250)
 ```
 
@@ -95,7 +95,7 @@ Connect your GitHub in your profile settings to enable this — the daily cron p
 
 Commits in the last 30 days earn extra points, capped at +50:
 
-```
+```text
 min(floor(contributions_30d × 0.5), 50)
 ```
 

--- a/docs/vibecoders/vibe-score.md
+++ b/docs/vibecoders/vibe-score.md
@@ -6,10 +6,17 @@ You can't buy it. You can only earn it — through quality output and consistent
 
 ## How It's Calculated
 
-Your Vibe Score is made up of six components:
+Your Vibe Score is made up of eight components:
 
 ```
-Vibe Score = 10 (baseline) + Project Score + Streak Points + Endorsements + Badge Bonus + Review Bonus
+Vibe Score = 10 (baseline)
+           + Project Score
+           + Streak Points
+           + Endorsements
+           + Badge Bonus
+           + Review Bonus
+           + Lifetime GitHub Bonus       ← rewards veteran builders
+           + Recent Activity Bonus       ← rewards builders shipping right now
 ```
 
 ### 1. Project Score
@@ -63,18 +70,58 @@ Three 5-star reviews = `3 × 20 = 60` bonus points. There's no cap — every tru
 
 Reviews are also scored for **trust** (0-100) to detect fake/bot reviews. Reviews from disposable emails, burst submissions, or accounts with no hire history get lower trust scores. Only reviews with trust_score >= 30 contribute to your Vibe Score.
 
-## Quality vs Consistency
+### 5. Lifetime GitHub Bonus
 
-**Quality makes you hireable. Consistency keeps you visible.**
+Your full-year GitHub contribution count earns points on a square-root curve, capped at 250:
 
-VibeTalent rewards both — but project quality is the primary driver of a strong, resilient score. Here's a real comparison:
+```
+min(floor(sqrt(lifetime_contributions)), 250)
+```
 
-| VibeCoder | Streak | Projects | Details | Reviews | Vibe Score |
+| Lifetime commits | Bonus |
+|---|---|
+| 100 | +10 |
+| 1,000 | +31 |
+| 10,000 | +100 |
+| 16,000 | +126 |
+| 50,000 | +223 |
+| 62,500+ | +250 (cap) |
+
+This rewards builders who've been shipping for years — your reputation isn't reset because you took a break. The square-root curve gives veterans visible separation from casuals while still capping bot-scale outliers (so a 1M-commit account doesn't dwarf actual platform activity).
+
+Connect your GitHub in your profile settings to enable this — the daily cron pulls from your public contribution heatmap.
+
+### 6. Recent Activity Bonus
+
+Commits in the last 30 days earn extra points, capped at +50:
+
+```
+min(floor(contributions_30d × 0.5), 50)
+```
+
+| Last 30d commits | Bonus |
+|---|---|
+| 10 | +5 |
+| 50 | +25 |
+| 100+ | +50 (cap) |
+
+This rewards builders who are *actively shipping right now*. Combined with the lifetime bonus, the score reflects both "are you a veteran" and "are you currently active" — neither alone, both together.
+
+## Quality vs Consistency vs Volume
+
+**Quality makes you hireable. Consistency keeps you visible. Volume proves you're a real builder.**
+
+VibeTalent rewards all three. Here's how three real-shaped builders compare under the new scoring:
+
+| Builder | Streak | Projects | Lifetime commits | Last 30d | Vibe Score |
 |---|---|---|---|---|---|
-| **Streak-only** | 100 days | 2 projects, no URLs | Minimal | None | 10 + (2×2) + (100×2) + 0 + 0 + 0 = **214** |
-| **Quality-focused** | 30 days | 5 projects, full URLs + quality 60 avg | Live demos, GitHub repos | 3 five-star reviews | 10 + (5×66) + (30×2) + 0 + 10 + 60 = **470** |
+| **Streak-focused** | 100 days | 2 projects, no URLs | 0 (no GitHub linked) | 0 | 10 + (2×2) + (100×2) + 0 + 0 + 0 + 0 + 0 = **214** |
+| **Quality-focused** | 30 days | 5 projects, full URLs + quality 60 avg | 1,000 | 50 | 10 + (5×66) + (30×2) + 0 + 10 + 60 + 31 + 25 = **526** |
+| **Veteran** | 0 days (just joined) | 1 verified project | 16,000 | 0 | 10 + 6 + 0 + 0 + 0 + 0 + 126 + 0 = **142** |
 
-The quality builder is ahead — and their score is **resilient**: even if their streak resets, they still have **400 points** from projects, badges, and reviews. That's the power of shipping quality code.
+The quality builder leads — and their score is **resilient**: even if their streak resets, they still have ~400 points from projects, lifetime, reviews, and badges. The veteran builder, despite no streak and just one project, lands above the streak-only builder because their lifetime work is visible.
+
+That's the design: no single dimension dominates. Volume credits lifetime contribution. Streak credits daily consistency. Project score and reviews credit shipped quality. Multiple paths to a strong score.
 
 ## How to Increase Your Vibe Score
 
@@ -90,7 +137,7 @@ The quality builder is ahead — and their score is **resilient**: even if their
 3. **Earn badges** — permanent bonus that never goes away
 4. **Get client reviews** — a 5-star review is worth 20 points
 5. **Get endorsements** — each endorsement on your projects adds 5 points
-6. **Connect GitHub** — auto-log activity so you never miss a day
+6. **Connect GitHub** — unlocks the lifetime + recent-30d bonuses (up to +300 combined). If you have years of public commits, this alone can be worth more than every other component.
 
 ## Peer Endorsements
 


### PR DESCRIPTION
## Why

Recent shipping (#162, #163, #166, #167) materially changed how the score works and how GitHub data flows through the system, but the docs (which GitBook syncs from this repo) were still describing the old six-component formula and the old "click a button to sync" flow. Builders looking at the live leaderboard see scores that don't match what the docs explain.

This PR refreshes every doc page touched by those shipping PRs so the GitBook site stays accurate.

## What changed

### [\`docs/vibecoders/vibe-score.md\`](docs/vibecoders/vibe-score.md) + [\`docs/builders/vibe-score.md\`](docs/builders/vibe-score.md)
- Formula now lists **eight** components (was six).
- New section **"5. Lifetime GitHub Bonus"** — sqrt curve, 100 commits → +10, 16k → +126, capped at +250.
- New section **"6. Recent Activity Bonus"** — last-30d × 0.5, capped at +50.
- Comparison table expanded to **Quality vs Consistency vs Volume** with a third "Veteran" persona showing how a 16k-lifetime-commit user with no streak still ranks above someone gaming a daily-touch streak (the original Meta Alchemist feedback case).

### [\`docs/vibecoders/github-sync.md\`](docs/vibecoders/github-sync.md) + [\`docs/builders/github-sync.md\`](docs/builders/github-sync.md)
- Reframed around the three things connecting GitHub now does: streak, heatmap with **real per-day commit counts** (PR #162), and unlocking the +300 max volume bonus (PR #163).
- Documents the daily 6 AM UTC cron + the two data sources (events API for feed, public profile page for heatmap counts + lifetime/30d totals).
- Notes the rate-limit graceful degradation from PRs #166 / #167.
- Updated privacy section.

### [\`docs/developers/database-schema.md\`](docs/developers/database-schema.md)
- `users` table: documents new `lifetime_contributions` and `contributions_30d` columns.
- `streak_logs` table: documents new `commit_count` column.
- `update_user_streak()` function: full eight-component formula matching [`20260430_add_volume_credit_to_vibe_score.sql`](supabase/migrations/20260430_add_volume_credit_to_vibe_score.sql).

## Test plan

- [x] Numbers in tables match `scoring-config.ts` and the SQL migration.
- [x] Both `vibecoders/` (live in SUMMARY.md) and parallel `builders/` paths stay in sync.
- [ ] Reviewer skims the GitBook preview after merge to spot-check rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Vibe Score calculation with two new GitHub-driven bonus components: Lifetime GitHub Bonus and Recent Activity (30-day) Bonus, expanding the scoring model from six to eight components.
  * Enhanced GitHub sync documentation with details on daily streak auto-logging, contribution heatmap tracking, and how GitHub activity unlocks new score bonuses.
  * Clarified scoring formulas, privacy policies, and integration mechanics for GitHub connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->