### PR TITLE
fix(urls): normalize bare-domain repo and external URLs end-to-end

### DIFF
--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -3,6 +3,7 @@ import { after } from "next/server";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { projectsLimiter, checkRateLimit, getIP } from "@/lib/rate-limit";
 import { analyzeRepository, checkLiveUrl, parseGithubRepoUrl } from "@/lib/github-quality";
+import { normalizeExternalUrl, normalizeRepoUrl } from "@/lib/url-normalize";
 import { createNotification } from "@/lib/notifications";
 
 // GET /api/projects — List projects (public)
@@ -68,13 +69,29 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
-    if (liveUrlTrim && !liveUrlTrim.match(/^https:\/\/.+/)) {
-      return NextResponse.json({ error: "live_url must be a valid HTTPS URL" }, { status: 400 });
+    // Validate + canonicalize URLs through the shared helpers so this API
+    // path agrees with the dashboard / profile-setup write paths. Persist
+    // the canonical form (never the raw input) — the bug class that caused
+    // the SPARK link to render as a relative path was exactly this: stale
+    // raw values stored in `live_url` / `github_url`.
+    let normalizedLiveUrl: string | null = null;
+    if (liveUrlTrim) {
+      normalizedLiveUrl = normalizeExternalUrl(liveUrlTrim);
+      if (!normalizedLiveUrl || !normalizedLiveUrl.startsWith("https://")) {
+        return NextResponse.json({ error: "live_url must be a valid HTTPS URL" }, { status: 400 });
+      }
     }
-    // Delegate to parseGithubRepoUrl so validation tolerates the same shapes
-    // the parser does (www., .git, subpaths) and rejects non-repo URLs like
-    // /login/oauth consistently across the app.
-    if (githubUrlTrim && !parseGithubRepoUrl(githubUrlTrim)) {
+    let normalizedGithubUrl: string | null = null;
+    if (githubUrlTrim) {
+      normalizedGithubUrl = normalizeRepoUrl(githubUrlTrim);
+      if (!normalizedGithubUrl) {
+        return NextResponse.json({ error: "github_url must be a valid GitHub repo URL" }, { status: 400 });
+      }
+    }
+    // Sanity-check the GitHub URL through `parseGithubRepoUrl` directly too,
+    // since the auto-verify path below pulls owner/repo from the same parser
+    // and we want a clear 400 here rather than a silently-skipped verify.
+    if (normalizedGithubUrl && !parseGithubRepoUrl(normalizedGithubUrl)) {
       return NextResponse.json({ error: "github_url must be a valid GitHub repo URL" }, { status: 400 });
     }
 
@@ -85,8 +102,8 @@ export async function POST(request: NextRequest) {
       title: title.trim().slice(0, 100),
       description: description.trim().slice(0, 500),
       tech_stack: Array.isArray(tech_stack) ? tech_stack.slice(0, 20).map((t: string) => String(t).trim().slice(0, 50)) : [],
-      live_url: liveUrlTrim || null,
-      github_url: githubUrlTrim || null,
+      live_url: normalizedLiveUrl,
+      github_url: normalizedGithubUrl,
       build_time: build_time ? String(build_time).trim().slice(0, 50) : null,
       tags: Array.isArray(tags) ? tags.slice(0, 10).map((t: string) => String(t).trim().slice(0, 30)) : [],
     }).select().single();
@@ -100,7 +117,7 @@ export async function POST(request: NextRequest) {
     // GitHub identity on every OAuth callback, covering linked-later accounts
     // whose user_metadata doesn't hold the GitHub handle). OAuth metadata is a
     // fallback for the first-login edge case before the callback has written.
-    if (data && githubUrlTrim) {
+    if (data && normalizedGithubUrl) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const { data: userRow } = await (supabase as any)
         .from("users")
@@ -114,7 +131,7 @@ export async function POST(request: NextRequest) {
         user.user_metadata?.preferred_username ||
         null;
 
-      const parsed = parseGithubRepoUrl(githubUrlTrim);
+      const parsed = parseGithubRepoUrl(normalizedGithubUrl);
       if (githubUsername && parsed && parsed.owner.toLowerCase() === githubUsername.toLowerCase()) {
         const { owner: repoOwner, repo: repoName } = parsed;
 
@@ -156,8 +173,8 @@ export async function POST(request: NextRequest) {
             };
 
             let live_url_ok: boolean | null = null;
-            if (liveUrlTrim) {
-              live_url_ok = await checkLiveUrl(liveUrlTrim);
+            if (normalizedLiveUrl) {
+              live_url_ok = await checkLiveUrl(normalizedLiveUrl);
             }
 
             const { error: updateError } = await sb.from("projects").update({

--- a/src/app/auth/profile-setup/page.tsx
+++ b/src/app/auth/profile-setup/page.tsx
@@ -5,6 +5,7 @@ import { createClient } from "@/lib/supabase/client";
 import { useRouter, useSearchParams } from "next/navigation";
 import { validateDisplayName, containsProfanity } from "@/lib/profanity";
 import { normalizeSocialHandle } from "@/lib/social-handles";
+import { normalizeExternalUrl, normalizeRepoUrl } from "@/lib/url-normalize";
 import { armTourTrigger, TOUR_FLAG_ENABLED } from "@/lib/onboarding";
 import {
   Flame,
@@ -298,13 +299,24 @@ export default function ProfileSetupPage() {
       const hasLinks = github || twitter || website || telegram;
 
       if (hasLinks) {
+        // Normalize the website URL so the DB stores a canonical https:// form.
+        let normalizedWebsite: string | null = null;
+        if (website) {
+          normalizedWebsite = normalizeExternalUrl(website);
+          if (!normalizedWebsite) {
+            setError("Website must be a valid URL (e.g. https://example.com)");
+            setLoading(false);
+            return;
+          }
+        }
+
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const { error: dbError } = await (supabase.from("social_links") as any).upsert(
           {
             user_id: userId,
             github: github || null,
             twitter: twitter || null,
-            website: website || null,
+            website: normalizedWebsite,
             telegram: telegram || null,
           },
           { onConflict: "user_id" }
@@ -343,13 +355,25 @@ export default function ProfileSetupPage() {
         .map((t) => t.trim())
         .filter(Boolean);
 
+      // Validate + canonicalize GitHub URL — same shared validator the
+      // dashboard form and POST /api/projects use, so all write paths agree.
+      let normalizedGithubUrl: string | null = null;
+      if (project.github_url && project.github_url.trim()) {
+        normalizedGithubUrl = normalizeRepoUrl(project.github_url);
+        if (!normalizedGithubUrl) {
+          setError("GitHub URL must be a valid GitHub repo (e.g. https://github.com/username/repo)");
+          setLoading(false);
+          return;
+        }
+      }
+
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const { error: dbError } = await (supabase.from("projects") as any).insert({
         user_id: userId,
         title: project.title,
         description: project.description,
         tech_stack: techArray.length > 0 ? techArray : null,
-        github_url: project.github_url || null,
+        github_url: normalizedGithubUrl,
       });
 
       if (dbError) throw dbError;

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { createClient } from "@/lib/supabase/client";
 import { fetchStreakLogs } from "@/lib/supabase/queries";
 import { siteUrl } from "@/lib/seo";
+import { normalizeExternalUrl, normalizeRepoUrl } from "@/lib/url-normalize";
 import { BadgeDisplay } from "@/components/ui/badge-display";
 import type { UserWithSocials } from "@/lib/types/database";
 import { StreakCounter } from "@/components/ui/streak-counter";
@@ -817,19 +818,21 @@ export default function DashboardPage() {
       setProjectError("Add a live URL or a GitHub repo — at least one is required so clients can verify your work.");
       return;
     }
+    // Validate + canonicalize URLs. Persist normalized forms so the DB
+    // never carries bare-domain values that would render as relative paths.
+    let normalizedLiveUrl: string | null = null;
     if (liveUrlTrim) {
-      try {
-        const url = new URL(liveUrlTrim);
-        if (url.protocol !== "https:") throw new Error();
-      } catch {
-        setProjectError("Live URL must be a valid URL starting with https://");
+      normalizedLiveUrl = normalizeExternalUrl(liveUrlTrim);
+      if (!normalizedLiveUrl || !normalizedLiveUrl.startsWith("https://")) {
+        setProjectError("Live URL must be a valid URL (e.g. https://example.com)");
         return;
       }
     }
+    let normalizedGithubUrl: string | null = null;
     if (githubUrlTrim) {
-      const ghPattern = /^https:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+\/?$/;
-      if (!ghPattern.test(githubUrlTrim)) {
-        setProjectError("GitHub URL must be in the format: https://github.com/username/repo");
+      normalizedGithubUrl = normalizeRepoUrl(githubUrlTrim);
+      if (!normalizedGithubUrl) {
+        setProjectError("GitHub URL must be a valid GitHub repo (e.g. https://github.com/username/repo)");
         return;
       }
     }
@@ -844,8 +847,8 @@ export default function DashboardPage() {
       title: projectForm.title,
       description: projectForm.description,
       tech_stack: projectForm.tech_stack ? projectForm.tech_stack.split(",").map((t: string) => t.trim()).filter(Boolean) : [],
-      live_url: projectForm.live_url || null,
-      github_url: projectForm.github_url || null,
+      live_url: normalizedLiveUrl,
+      github_url: normalizedGithubUrl,
       build_time: projectForm.build_time || null,
       tags: projectForm.tags ? projectForm.tags.split(",").map((t: string) => t.trim()).filter(Boolean) : [],
     }).select("id").single();
@@ -937,19 +940,19 @@ export default function DashboardPage() {
       setProjectError("Add a live URL or a GitHub repo — at least one is required so clients can verify your work.");
       return;
     }
+    let normalizedLiveUrl: string | null = null;
     if (liveUrlTrim) {
-      try {
-        const url = new URL(liveUrlTrim);
-        if (url.protocol !== "https:") throw new Error();
-      } catch {
-        setProjectError("Live URL must be a valid URL starting with https://");
+      normalizedLiveUrl = normalizeExternalUrl(liveUrlTrim);
+      if (!normalizedLiveUrl || !normalizedLiveUrl.startsWith("https://")) {
+        setProjectError("Live URL must be a valid URL (e.g. https://example.com)");
         return;
       }
     }
+    let normalizedGithubUrl: string | null = null;
     if (githubUrlTrim) {
-      const ghPattern = /^https:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+\/?$/;
-      if (!ghPattern.test(githubUrlTrim)) {
-        setProjectError("GitHub URL must be in the format: https://github.com/username/repo");
+      normalizedGithubUrl = normalizeRepoUrl(githubUrlTrim);
+      if (!normalizedGithubUrl) {
+        setProjectError("GitHub URL must be a valid GitHub repo (e.g. https://github.com/username/repo)");
         return;
       }
     }
@@ -963,8 +966,8 @@ export default function DashboardPage() {
       title: projectForm.title,
       description: projectForm.description,
       tech_stack: projectForm.tech_stack ? projectForm.tech_stack.split(",").map((t: string) => t.trim()).filter(Boolean) : [],
-      live_url: projectForm.live_url || null,
-      github_url: projectForm.github_url || null,
+      live_url: normalizedLiveUrl,
+      github_url: normalizedGithubUrl,
       build_time: projectForm.build_time || null,
       tags: projectForm.tags ? projectForm.tags.split(",").map((t: string) => t.trim()).filter(Boolean) : [],
     }).eq("id", editingProjectId);

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { BadgeCheck } from "lucide-react";
+import { normalizeExternalUrl } from "@/lib/url-normalize";
 
 type FeedItem = {
   id: string;
@@ -272,11 +273,14 @@ export default function FeedPage() {
                             </div>
                           )}
                         </div>
-                        {item.live_url && (
-                          <a href={item.live_url} target="_blank" rel="noopener noreferrer" style={{ flexShrink: 0, color: "var(--text-muted, #8A8B94)" }}>
-                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M5 12h14M12 5l7 7-7 7"></path></svg>
-                          </a>
-                        )}
+                        {(() => {
+                          const liveHref = normalizeExternalUrl(item.live_url);
+                          return liveHref ? (
+                            <a href={liveHref} target="_blank" rel="noopener noreferrer" style={{ flexShrink: 0, color: "var(--text-muted, #8A8B94)" }}>
+                              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M5 12h14M12 5l7 7-7 7"></path></svg>
+                            </a>
+                          ) : null;
+                        })()}
                       </div>
                     )}
 

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -276,7 +276,14 @@ export default function FeedPage() {
                         {(() => {
                           const liveHref = normalizeExternalUrl(item.live_url);
                           return liveHref ? (
-                            <a href={liveHref} target="_blank" rel="noopener noreferrer" style={{ flexShrink: 0, color: "var(--text-muted, #8A8B94)" }}>
+                            <a
+                              href={liveHref}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              aria-label="Open live project"
+                              title="Open live project"
+                              style={{ flexShrink: 0, color: "var(--text-muted, #8A8B94)" }}
+                            >
                               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M5 12h14M12 5l7 7-7 7"></path></svg>
                             </a>
                           ) : null;

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -7,6 +7,7 @@ import { createClient } from "@/lib/supabase/client";
 import { validateDisplayName, containsProfanity } from "@/lib/profanity";
 import { siteUrl } from "@/lib/seo";
 import { normalizeSocialHandle } from "@/lib/social-handles";
+import { normalizeExternalUrl } from "@/lib/url-normalize";
 import type { UserWithSocials } from "@/lib/types/database";
 import { EmailPreferences } from "@/components/dashboard/email-preferences";
 import {
@@ -236,6 +237,18 @@ export default function SettingsPage() {
       alert("Please add your X (Twitter) or Telegram so clients can contact you.");
       return;
     }
+    // Canonicalize the website URL so the DB stores `https://...` form. The
+    // onboarding write path already does this; the settings save bypassed it
+    // and could re-introduce bare-domain values that render as relative paths.
+    const websiteTrim = profileForm.website.trim();
+    let normalizedWebsite: string | null = null;
+    if (websiteTrim) {
+      normalizedWebsite = normalizeExternalUrl(websiteTrim);
+      if (!normalizedWebsite) {
+        alert("Website must be a valid URL (e.g. https://example.com)");
+        return;
+      }
+    }
     setSaving(true);
     const supabase = createClient();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -279,7 +292,7 @@ export default function SettingsPage() {
       twitter: twitter || null,
       github: verifiedGithub,
       telegram: telegram || null,
-      website: profileForm.website.trim() || null,
+      website: normalizedWebsite,
       farcaster: profileForm.ide || null,
     }, { onConflict: "user_id" });
 
@@ -295,13 +308,14 @@ export default function SettingsPage() {
         twitter: twitter || null,
         github: verifiedGithub,
         telegram: telegram || null,
-        website: profileForm.website || null,
+        website: normalizedWebsite,
         farcaster: profileForm.ide || null,
       },
     });
     // Reflect the normalized values back into the form so a user who
-    // pasted a profile URL sees it cleaned up to a bare handle on save.
-    setProfileForm((p) => ({ ...p, twitter, telegram }));
+    // pasted a profile URL sees it cleaned up to a bare handle on save,
+    // and a bare-domain website becomes the canonical https:// form.
+    setProfileForm((p) => ({ ...p, twitter, telegram, website: normalizedWebsite ?? "" }));
     // Let other parts of the app (navbar onboarding dot, etc.) react to the
     // profile change without requiring a page reload.
     if (typeof window !== "undefined") {

--- a/src/components/profile/profile-project-card.tsx
+++ b/src/components/profile/profile-project-card.tsx
@@ -8,6 +8,7 @@ import { QualityScoreBadge } from "@/components/ui/quality-score-badge";
 import { EndorseButton } from "@/components/ui/endorse-button";
 import { createClient } from "@/lib/supabase/client";
 import { parseImageCrop } from "@/lib/image-crop";
+import { normalizeExternalUrl, normalizeRepoUrl } from "@/lib/url-normalize";
 
 interface ProfileProjectCardProps {
   project: Project;
@@ -130,32 +131,38 @@ export function ProfileProjectCard({ project, verified = false, isOwner = false 
       <div className="flex justify-between items-start gap-3">
         <span className="text-[1.1rem] font-extrabold uppercase text-[var(--foreground)] min-w-0 break-words">{project.title}</span>
         <div className="flex items-center gap-2 shrink-0">
-          {project.live_url && (
-            <a
-              href={project.live_url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors"
-              onClick={(e) => e.stopPropagation()}
-              title="Open live site"
-              aria-label="Open live site"
-            >
-              <ExternalLink size={16} />
-            </a>
-          )}
-          {project.github_url && (
-            <a
-              href={project.github_url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors"
-              onClick={(e) => e.stopPropagation()}
-              title="Open GitHub repo"
-              aria-label="Open GitHub repo"
-            >
-              <Github size={16} />
-            </a>
-          )}
+          {(() => {
+            const liveHref = normalizeExternalUrl(project.live_url);
+            return liveHref ? (
+              <a
+                href={liveHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors"
+                onClick={(e) => e.stopPropagation()}
+                title="Open live site"
+                aria-label="Open live site"
+              >
+                <ExternalLink size={16} />
+              </a>
+            ) : null;
+          })()}
+          {(() => {
+            const repoHref = normalizeRepoUrl(project.github_url);
+            return repoHref ? (
+              <a
+                href={repoHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors"
+                onClick={(e) => e.stopPropagation()}
+                title="Open GitHub repo"
+                aria-label="Open GitHub repo"
+              >
+                <Github size={16} />
+              </a>
+            ) : null;
+          })()}
           <div className="relative" ref={reportRef}>
             {reported ? (
               <button

--- a/src/components/profile/profile-sidebar.tsx
+++ b/src/components/profile/profile-sidebar.tsx
@@ -8,6 +8,7 @@ import type { UserWithSocials, BadgeLevel } from "@/lib/types/database";
 import { HireModal } from "@/components/ui/hire-modal";
 import { ShareCardModal } from "@/components/profile/share-card-modal";
 import { extractSocialHandle } from "@/lib/social-handles";
+import { normalizeExternalUrl } from "@/lib/url-normalize";
 
 interface ProfileSidebarProps {
   user: UserWithSocials;
@@ -227,22 +228,25 @@ export function ProfileSidebar({ user }: ProfileSidebarProps) {
             <Send size={16} />
           </a>
         )}
-        {socials?.website && (
-          <a
-            href={socials.website}
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label={`${user.username}'s website`}
-            className="w-10 h-10 flex items-center justify-center text-[var(--foreground)] transition-all hover:translate-x-[1px] hover:translate-y-[1px] hover:shadow-[1px_1px_0_var(--border-hard)]"
-            style={{
-              backgroundColor: "var(--bg-surface)",
-              border: "2px solid var(--border-hard)",
-              boxShadow: "var(--shadow-brutal-sm)",
-            }}
-          >
-            <Globe size={16} />
-          </a>
-        )}
+        {(() => {
+          const websiteHref = normalizeExternalUrl(socials?.website);
+          return websiteHref ? (
+            <a
+              href={websiteHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={`${user.username}'s website`}
+              className="w-10 h-10 flex items-center justify-center text-[var(--foreground)] transition-all hover:translate-x-[1px] hover:translate-y-[1px] hover:shadow-[1px_1px_0_var(--border-hard)]"
+              style={{
+                backgroundColor: "var(--bg-surface)",
+                border: "2px solid var(--border-hard)",
+                boxShadow: "var(--shadow-brutal-sm)",
+              }}
+            >
+              <Globe size={16} />
+            </a>
+          ) : null;
+        })()}
       </div>
 
       {/* IDE Badge */}

--- a/src/components/ui/featured-carousel.tsx
+++ b/src/components/ui/featured-carousel.tsx
@@ -13,6 +13,7 @@ import { BadgeDisplay } from "@/components/ui/badge-display";
 import { CHAIN_CONFIGS, SUPPORTED_CHAINS, DEFAULT_CHAIN, getChainConfig, isEVMChain, isSolanaChain } from "@/lib/chains-config";
 import { buildSolanaUSDCTransfer, confirmSolanaTransaction, signatureToString } from "@/lib/solana-payment";
 import { fetchPromotions, enrichPromotions, msUntilNextExpiry, type EnrichedPromotion } from "@/lib/featured-promotions";
+import { normalizeRepoUrl } from "@/lib/url-normalize";
 
 // Base chain defaults (for fetching promotions — always read from Base contract)
 const BASE_CONFIG = CHAIN_CONFIGS.base;
@@ -349,21 +350,24 @@ export function FeaturedCarousel() {
                               View Project <ExternalLink size={12} />
                             </a>
                           )}
-                          {promo.project?.github_url && (
-                            <a
-                              href={promo.project.github_url}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="p-2 text-[var(--text-secondary)] hover:text-[var(--foreground)] transition-colors"
-                              style={{
-                                border: "2px solid var(--border-hard)",
-                                backgroundColor: "var(--bg-surface)",
-                              }}
-                              aria-label="View on GitHub"
-                            >
-                              <Github size={14} />
-                            </a>
-                          )}
+                          {(() => {
+                            const repoHref = normalizeRepoUrl(promo.project?.github_url);
+                            return repoHref ? (
+                              <a
+                                href={repoHref}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="p-2 text-[var(--text-secondary)] hover:text-[var(--foreground)] transition-colors"
+                                style={{
+                                  border: "2px solid var(--border-hard)",
+                                  backgroundColor: "var(--bg-surface)",
+                                }}
+                                aria-label="View on GitHub"
+                              >
+                                <Github size={14} />
+                              </a>
+                            ) : null;
+                          })()}
                           {promo.project?.endorsement_count ? (
                             <span className="text-[10px] font-bold uppercase text-[var(--text-muted)] flex items-center gap-1">
                               <Sparkles size={10} style={{ color: "var(--accent)" }} />

--- a/src/components/ui/project-card.tsx
+++ b/src/components/ui/project-card.tsx
@@ -207,6 +207,8 @@ export function ProjectCard({ project, authorUsername, onEdit, showReport = true
                 href={liveHref}
                 target="_blank"
                 rel="noopener noreferrer"
+                aria-label="Open live site"
+                title="Open live site"
                 className="text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors"
                 onClick={(e) => e.stopPropagation()}
               >
@@ -221,6 +223,8 @@ export function ProjectCard({ project, authorUsername, onEdit, showReport = true
                 href={repoHref}
                 target="_blank"
                 rel="noopener noreferrer"
+                aria-label="Open GitHub repository"
+                title="Open GitHub repository"
                 className="text-[var(--text-secondary)] hover:text-[var(--foreground)] transition-colors"
                 onClick={(e) => e.stopPropagation()}
               >

--- a/src/components/ui/project-card.tsx
+++ b/src/components/ui/project-card.tsx
@@ -9,6 +9,7 @@ import { QualityScoreBadge } from "@/components/ui/quality-score-badge";
 import { EndorseButton } from "@/components/ui/endorse-button";
 import { createClient } from "@/lib/supabase/client";
 import { parseImageCrop } from "@/lib/image-crop";
+import { normalizeExternalUrl, normalizeRepoUrl } from "@/lib/url-normalize";
 
 function ProjectImageBanner({ url, alt }: { url: string; alt: string }) {
   const crop = parseImageCrop(url);
@@ -199,28 +200,34 @@ export function ProjectCard({ project, authorUsername, onEdit, showReport = true
               )}
             </div>
           )}
-          {project.live_url && (
-            <a
-              href={project.live_url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <ExternalLink size={16} />
-            </a>
-          )}
-          {project.github_url && (
-            <a
-              href={project.github_url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-[var(--text-secondary)] hover:text-[var(--foreground)] transition-colors"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <Github size={16} />
-            </a>
-          )}
+          {(() => {
+            const liveHref = normalizeExternalUrl(project.live_url);
+            return liveHref ? (
+              <a
+                href={liveHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <ExternalLink size={16} />
+              </a>
+            ) : null;
+          })()}
+          {(() => {
+            const repoHref = normalizeRepoUrl(project.github_url);
+            return repoHref ? (
+              <a
+                href={repoHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[var(--text-secondary)] hover:text-[var(--foreground)] transition-colors"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Github size={16} />
+              </a>
+            ) : null;
+          })()}
         </div>
       </div>
 

--- a/src/lib/__tests__/url-normalize.test.ts
+++ b/src/lib/__tests__/url-normalize.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { normalizeExternalUrl, normalizeRepoUrl } from "../url-normalize";
+
+describe("normalizeExternalUrl", () => {
+  it("returns null for empty / nullish inputs", () => {
+    expect(normalizeExternalUrl("")).toBeNull();
+    expect(normalizeExternalUrl("   ")).toBeNull();
+    expect(normalizeExternalUrl(null)).toBeNull();
+    expect(normalizeExternalUrl(undefined)).toBeNull();
+  });
+
+  it("returns the canonical URL when already https", () => {
+    expect(normalizeExternalUrl("https://example.com")).toBe("https://example.com/");
+    expect(normalizeExternalUrl("https://example.com/path")).toBe(
+      "https://example.com/path",
+    );
+  });
+
+  it("preserves http:// when explicitly given", () => {
+    expect(normalizeExternalUrl("http://example.com")).toBe("http://example.com/");
+  });
+
+  it("prepends https:// to bare-domain inputs (the SPARK bug)", () => {
+    expect(normalizeExternalUrl("github.com/vibeforge1111/spark-cli")).toBe(
+      "https://github.com/vibeforge1111/spark-cli",
+    );
+    expect(normalizeExternalUrl("example.com/path?q=1")).toBe(
+      "https://example.com/path?q=1",
+    );
+  });
+
+  it("handles protocol-relative inputs", () => {
+    expect(normalizeExternalUrl("//example.com/x")).toBe("https://example.com/x");
+  });
+
+  it("rejects unsafe schemes", () => {
+    expect(normalizeExternalUrl("javascript:alert(1)")).toBeNull();
+    expect(normalizeExternalUrl("data:text/html,<script>alert(1)</script>")).toBeNull();
+    expect(normalizeExternalUrl("file:///etc/passwd")).toBeNull();
+  });
+
+  it("rejects inputs that don't resolve to a real host", () => {
+    expect(normalizeExternalUrl("not a url")).toBeNull();
+    expect(normalizeExternalUrl("http://")).toBeNull();
+    // No TLD — could be a relative path mistaken for a host.
+    expect(normalizeExternalUrl("localhost")).toBeNull();
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(normalizeExternalUrl("  github.com/x/y  ")).toBe("https://github.com/x/y");
+  });
+});
+
+describe("normalizeRepoUrl", () => {
+  it("returns null for empty inputs", () => {
+    expect(normalizeRepoUrl("")).toBeNull();
+    expect(normalizeRepoUrl(null)).toBeNull();
+    expect(normalizeRepoUrl(undefined)).toBeNull();
+  });
+
+  it("normalizes bare-domain GitHub URLs (the original bug)", () => {
+    expect(normalizeRepoUrl("github.com/vibeforge1111/spark-cli")).toBe(
+      "https://github.com/vibeforge1111/spark-cli",
+    );
+  });
+
+  it("normalizes www.github.com to github.com", () => {
+    expect(normalizeRepoUrl("https://www.github.com/owner/repo")).toBe(
+      "https://github.com/owner/repo",
+    );
+  });
+
+  it("strips .git suffix", () => {
+    expect(normalizeRepoUrl("https://github.com/owner/repo.git")).toBe(
+      "https://github.com/owner/repo",
+    );
+  });
+
+  it("strips trailing path segments and queries", () => {
+    expect(
+      normalizeRepoUrl("https://github.com/owner/repo/tree/main"),
+    ).toBe("https://github.com/owner/repo");
+  });
+
+  it("rejects non-GitHub URLs", () => {
+    expect(normalizeRepoUrl("https://gitlab.com/owner/repo")).toBeNull();
+    expect(normalizeRepoUrl("https://example.com/owner/repo")).toBeNull();
+  });
+
+  it("rejects malformed input that prepending https:// can't rescue", () => {
+    expect(normalizeRepoUrl("not a url")).toBeNull();
+    expect(normalizeRepoUrl("github.com")).toBeNull();
+    expect(normalizeRepoUrl("github.com/owner")).toBeNull();
+  });
+});

--- a/src/lib/__tests__/url-normalize.test.ts
+++ b/src/lib/__tests__/url-normalize.test.ts
@@ -39,6 +39,19 @@ describe("normalizeExternalUrl", () => {
     expect(normalizeExternalUrl("file:///etc/passwd")).toBeNull();
   });
 
+  it("rejects explicit non-http(s) schemes that would otherwise survive the prepend step", () => {
+    // Without the explicit-scheme guard, prepending https:// to any of these
+    // produces a string that `new URL()` parses as protocol="https:" with a
+    // dotted hostname — slipping past the protocol check below.
+    expect(normalizeExternalUrl("mailto:user@example.com")).toBeNull();
+    expect(normalizeExternalUrl("ftp://example.com")).toBeNull();
+    expect(normalizeExternalUrl("ftp://files.example.com/path")).toBeNull();
+    expect(normalizeExternalUrl("tel:+1234567890")).toBeNull();
+    expect(normalizeExternalUrl("ssh://user@host.example.com")).toBeNull();
+    // Case-insensitivity: an upper-case scheme is rejected the same way.
+    expect(normalizeExternalUrl("MAILTO:user@example.com")).toBeNull();
+  });
+
   it("rejects inputs that don't resolve to a real host", () => {
     expect(normalizeExternalUrl("not a url")).toBeNull();
     expect(normalizeExternalUrl("http://")).toBeNull();

--- a/src/lib/url-normalize.ts
+++ b/src/lib/url-normalize.ts
@@ -1,0 +1,68 @@
+import { parseGithubRepoUrl } from "@/lib/github-quality";
+
+/**
+ * Normalize a user-supplied external URL for safe rendering.
+ *
+ * Accepts inputs with or without a protocol (e.g. "github.com/x/y",
+ * "//example.com", or "https://example.com") and returns a canonical
+ * `https://...` URL. Returns `null` for inputs that cannot be parsed
+ * as an absolute URL — call sites should fall back to rendering without
+ * an `<a>` wrapper rather than linking to `#`.
+ *
+ * Rejects `javascript:`, `data:`, `file:` and any other non-http(s) scheme
+ * even if explicitly typed by the user, since those are unsafe to surface
+ * in third-party UGC links.
+ *
+ * Background: project rows like Meta's SPARK saved `github.com/...` (no
+ * protocol). The browser interpreted that as a relative path, producing
+ * URLs like `https://www.vibetalent.work/profile/github.com/...`. This
+ * helper kills that class of bug at every render site.
+ */
+export function normalizeExternalUrl(
+  input: string | null | undefined,
+): string | null {
+  if (typeof input !== "string") return null;
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  let candidate = trimmed;
+  if (!/^https?:\/\//i.test(candidate)) {
+    // Handle protocol-relative ("//example.com") and bare-host inputs.
+    candidate = candidate.startsWith("//") ? `https:${candidate}` : `https://${candidate}`;
+  }
+
+  try {
+    const url = new URL(candidate);
+    if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+    if (!url.hostname || !url.hostname.includes(".")) return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Normalize a GitHub repo URL to its canonical form: `https://github.com/{owner}/{repo}`.
+ *
+ * Returns `null` if the input doesn't parse as a GitHub repo URL via the
+ * existing `parseGithubRepoUrl` validator. This is the helper render sites
+ * should use for `project.github_url` so the link is always canonical and
+ * never accidentally relative.
+ *
+ * For non-GitHub external links (live_url, social_links.website), use
+ * `normalizeExternalUrl` instead.
+ */
+export function normalizeRepoUrl(
+  input: string | null | undefined,
+): string | null {
+  if (typeof input !== "string") return null;
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  // First pass: prepend https:// if missing so parseGithubRepoUrl's
+  // `^https?://` requirement is satisfied for bare-domain inputs.
+  const withProtocol = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+  const parsed = parseGithubRepoUrl(withProtocol);
+  if (!parsed) return null;
+  return `https://github.com/${parsed.owner}/${parsed.repo}`;
+}

--- a/src/lib/url-normalize.ts
+++ b/src/lib/url-normalize.ts
@@ -25,8 +25,19 @@ export function normalizeExternalUrl(
   const trimmed = input.trim();
   if (!trimmed) return null;
 
+  // Reject explicit non-http(s) schemes BEFORE the prepend step. Without
+  // this guard, "mailto:user@example.com" survives: prepending "https://"
+  // turns it into "https://mailto:user@example.com", which `new URL()`
+  // happily parses as protocol="https:" with hostname="example.com" —
+  // bypassing the protocol check below. Same hazard for `ftp:`, `tel:`,
+  // `gopher:`, etc. Anything that looks like an explicit non-http scheme
+  // is a hard reject.
+  const isHttpScheme = /^https?:\/\//i.test(trimmed);
+  const hasExplicitScheme = /^[a-z][a-z0-9+.-]*:/i.test(trimmed);
+  if (hasExplicitScheme && !isHttpScheme) return null;
+
   let candidate = trimmed;
-  if (!/^https?:\/\//i.test(candidate)) {
+  if (!isHttpScheme) {
     // Handle protocol-relative ("//example.com") and bare-host inputs.
     candidate = candidate.startsWith("//") ? `https:${candidate}` : `https://${candidate}`;
   }

--- a/supabase/migrations/20260502_normalize_bare_domain_urls.sql
+++ b/supabase/migrations/20260502_normalize_bare_domain_urls.sql
@@ -4,35 +4,54 @@
 --   https://www.vibetalent.work/profile/github.com/owner/repo
 --
 -- Going forward, the app's write paths (POST /api/projects, dashboard form,
--- profile-setup form) canonicalize input via normalizeRepoUrl / normalizeExternalUrl
--- before persisting. This migration cleans up any pre-existing rows so the
--- auto-verify cron jobs (which call parseGithubRepoUrl directly and require
--- https:// at the start) can re-process them.
+-- profile-setup form, settings form) canonicalize input via
+-- normalizeRepoUrl / normalizeExternalUrl before persisting. This migration
+-- cleans up any pre-existing rows so the auto-verify cron jobs (which call
+-- parseGithubRepoUrl directly and require https:// at the start) can
+-- re-process them.
+--
+-- Detection notes (changed in response to review feedback):
+--   * The "no scheme" predicate must be CASE-INSENSITIVE. A row stored as
+--     `HTTPS://github.com/...` would slip past `NOT LIKE 'https://%'` and
+--     get rewritten to `https://HTTPS://...` — silent corruption. We use
+--     `!~* '^[a-z][a-z0-9+.-]*://'` so any valid URI scheme (in any case)
+--     blocks the prepend.
+--   * Use `btrim()` so leading/trailing whitespace doesn't fool the predicate
+--     and doesn't end up persisted post-migration.
+--   * The github-only `(www\.)?github\.com` filter on the first UPDATE
+--     subsumes the trailing "strip www." pass that used to live below — the
+--     `regexp_replace` here both prepends `https://` AND strips a `www.`
+--     in one pass, so non-bare rows stay untouched.
 
+-- Bare-domain GitHub URLs: prepend canonical https://github.com/ and strip
+-- any leading www. in one shot. Limited to rows that look like a github
+-- host so a stray bare domain in another table (e.g. live_url containing a
+-- non-GitHub host) doesn't get its host rewritten by accident.
 UPDATE public.projects
-SET github_url = 'https://' || github_url
+SET github_url = 'https://github.com/' ||
+                 regexp_replace(btrim(github_url), '^(www\.)?github\.com/?', '', 'i')
 WHERE github_url IS NOT NULL
-  AND github_url <> ''
-  AND github_url NOT LIKE 'http://%'
-  AND github_url NOT LIKE 'https://%';
+  AND btrim(github_url) <> ''
+  AND btrim(github_url) !~* '^[a-z][a-z0-9+.-]*://'
+  AND btrim(github_url) ~* '^(www\.)?github\.com(/|$)';
 
+-- Bare-domain live_urls: prepend https:// for any row missing a scheme.
 UPDATE public.projects
-SET live_url = 'https://' || live_url
+SET live_url = 'https://' || btrim(live_url)
 WHERE live_url IS NOT NULL
-  AND live_url <> ''
-  AND live_url NOT LIKE 'http://%'
-  AND live_url NOT LIKE 'https://%';
+  AND btrim(live_url) <> ''
+  AND btrim(live_url) !~* '^[a-z][a-z0-9+.-]*://';
 
+-- Bare-domain social_links.website: same fix.
 UPDATE public.social_links
-SET website = 'https://' || website
+SET website = 'https://' || btrim(website)
 WHERE website IS NOT NULL
-  AND website <> ''
-  AND website NOT LIKE 'http://%'
-  AND website NOT LIKE 'https://%';
+  AND btrim(website) <> ''
+  AND btrim(website) !~* '^[a-z][a-z0-9+.-]*://';
 
--- Strip a stray www. so the cron path (which matches `(?:www\.)?github\.com`
--- but rewrites to canonical github.com via parseGithubRepoUrl) isn't surprised
--- by mixed-case hosts. Touch only the rows that need it.
+-- Existing rows that already have a scheme but use `www.github.com` host:
+-- normalize to canonical github.com so the verify-cron's regex
+-- `(?:www\.)?github\.com` always rewrites to a single canonical URL.
 UPDATE public.projects
 SET github_url = regexp_replace(github_url, '^https?://www\.github\.com/', 'https://github.com/', 'i')
 WHERE github_url ~* '^https?://www\.github\.com/';

--- a/supabase/migrations/20260502_normalize_bare_domain_urls.sql
+++ b/supabase/migrations/20260502_normalize_bare_domain_urls.sql
@@ -1,0 +1,38 @@
+-- Normalize project repo / live URLs and social-link websites that were stored
+-- without a protocol (e.g. "github.com/owner/repo"). Bare-domain values render
+-- as relative paths in the browser and produce broken links such as
+--   https://www.vibetalent.work/profile/github.com/owner/repo
+--
+-- Going forward, the app's write paths (POST /api/projects, dashboard form,
+-- profile-setup form) canonicalize input via normalizeRepoUrl / normalizeExternalUrl
+-- before persisting. This migration cleans up any pre-existing rows so the
+-- auto-verify cron jobs (which call parseGithubRepoUrl directly and require
+-- https:// at the start) can re-process them.
+
+UPDATE public.projects
+SET github_url = 'https://' || github_url
+WHERE github_url IS NOT NULL
+  AND github_url <> ''
+  AND github_url NOT LIKE 'http://%'
+  AND github_url NOT LIKE 'https://%';
+
+UPDATE public.projects
+SET live_url = 'https://' || live_url
+WHERE live_url IS NOT NULL
+  AND live_url <> ''
+  AND live_url NOT LIKE 'http://%'
+  AND live_url NOT LIKE 'https://%';
+
+UPDATE public.social_links
+SET website = 'https://' || website
+WHERE website IS NOT NULL
+  AND website <> ''
+  AND website NOT LIKE 'http://%'
+  AND website NOT LIKE 'https://%';
+
+-- Strip a stray www. so the cron path (which matches `(?:www\.)?github\.com`
+-- but rewrites to canonical github.com via parseGithubRepoUrl) isn't surprised
+-- by mixed-case hosts. Touch only the rows that need it.
+UPDATE public.projects
+SET github_url = regexp_replace(github_url, '^https?://www\.github\.com/', 'https://github.com/', 'i')
+WHERE github_url ~* '^https?://www\.github\.com/';


### PR DESCRIPTION
## Summary

- Fixes Meta Alchemist's broken SPARK link (`https://www.vibetalent.work/profile/github.com/vibeforge1111/spark-cli`) — saved as `github.com/...` without a protocol, the browser treated it as a relative path
- Adds shared `normalizeExternalUrl` / `normalizeRepoUrl` helpers and applies them at every render and write site so the bug class can't recur
- Backfills existing bare-domain rows so verify-cron paths can re-process them

## Root cause

The dashboard form (insert + edit) had a local regex separate from the API's `parseGithubRepoUrl` validator. Both required `https://`, but they were stored independently — and the dashboard wrote directly via `supabase.from("projects").insert(...)`, bypassing the API entirely. When a row slipped past the dashboard regex (or arrived from an earlier version), the renderer trusted it verbatim. Same gap on `social_links.website` and `projects.live_url`.

## Layers

**1. Render-side normalization** — every external `<a href>` site now runs the value through `normalizeExternalUrl` (or `normalizeRepoUrl` for github). If the value can't be normalized to `https://...`, the icon renders without the `<a>` wrapper instead of linking to a broken target. Touched: `profile-project-card`, `project-card`, `featured-carousel`, `profile-sidebar`, `feed/page`.

**2. Write-path tightening** — `dashboard/page.tsx` (insert + edit) and `profile-setup/page.tsx` (project + social-links) replace local regexes with the shared validators and persist the canonical URL form (e.g. `https://github.com/{owner}/{repo}`), not the raw input. POST `/api/projects` already used `parseGithubRepoUrl` — now all four write paths agree.

**3. Backfill** — `supabase/migrations/20260502_normalize_bare_domain_urls.sql` prepends `https://` to bare-domain rows in `projects.github_url`, `projects.live_url`, `social_links.website`, and strips a stray `www.` from github hosts so the auto-verify cron paths (which call `parseGithubRepoUrl` directly) can re-process them.

## Test plan

- [ ] Tests: `npm test src/lib/__tests__/url-normalize.test.ts` — 15 cases pass, including the SPARK input verbatim
- [ ] Manual: log in, dashboard → "Add project" → submit `github.com/foo/bar` (no protocol) → expect inline error "GitHub URL must be a valid GitHub repo (e.g. https://github.com/username/repo)"
- [ ] Manual: same flow with `https://github.com/foo/bar` → expect saved canonically and verify-cron picks it up
- [ ] Manual: visit `/profile/vibeforge1111` → SPARK card's GitHub link resolves to `https://github.com/vibeforge1111/spark-cli`
- [ ] Manual: a project with a malformed live_url renders the icon without an `<a>` (no broken-link target)
- [ ] Run `supabase/migrations/20260502_normalize_bare_domain_urls.sql` against staging/prod via the Supabase SQL editor before merging

## Notes

- No schema changes, only data backfill. Migration is idempotent — re-runs are safe (each `UPDATE` predicate already excludes correctly-formatted rows).
- TypeScript clean, lint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic URL validation and normalization. Website links and GitHub repository URLs are now standardized for consistency and reliability.

* **Bug Fixes**
  * Fixed handling of improperly formatted URLs (missing protocol, www variations, protocol-relative formats) in profiles, projects, and social links to prevent invalid or broken links from being stored or displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->