### PR TITLE
feat(featured): claim-click pulse + @username/tech pills (follow-up to #172)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -197,6 +197,25 @@ html {
   clip-path: polygon(0 0, calc(100% - 14px) 0, 100% 14px, 100% 100%, 0 100%);
 }
 
+/* Brief outline ripple on the Feature-Your-Project card after a user clicks
+   "Claim This Spot" on an empty slot. The empty card scrolls/focuses the
+   feature card, but the cards already share a viewport — without this pulse
+   the click looks dead. Uses outline (not box-shadow) so it doesn't fight
+   .card-brutal's hard offset shadow. */
+.claim-pulse {
+  animation: claim-pulse 1.2s ease-out;
+}
+@keyframes claim-pulse {
+  0% {
+    outline: 4px solid var(--accent);
+    outline-offset: -2px;
+  }
+  100% {
+    outline: 4px solid transparent;
+    outline-offset: 16px;
+  }
+}
+
 /* Featured promo card hover/focus overlay
    Reveals a centered "View Project" CTA when the parent card is hovered or
    keyboard-focused. Uses an explicit class so it doesn't depend on Tailwind's

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -205,6 +205,16 @@ html {
 .claim-pulse {
   animation: claim-pulse 1.2s ease-out;
 }
+/* Reduced-motion users still get a visible "your click landed" hint —
+   a static accent outline shown for as long as the JS keeps the class
+   on the node (handleClaim removes it via setTimeout). */
+@media (prefers-reduced-motion: reduce) {
+  .claim-pulse {
+    animation: none;
+    outline: 3px solid var(--accent);
+    outline-offset: 2px;
+  }
+}
 @keyframes claim-pulse {
   0% {
     outline: 4px solid var(--accent);

--- a/src/components/ui/featured/featured-project-card.tsx
+++ b/src/components/ui/featured/featured-project-card.tsx
@@ -1,6 +1,5 @@
 import Image from "next/image";
 import Link from "next/link";
-import { ChainDot } from "./chain-dot";
 import type { EnrichedPromotion } from "@/lib/featured-promotions";
 
 // Reject anything that isn't plain http(s). User-submitted live_url values
@@ -86,18 +85,6 @@ export function FeaturedProjectCard({ promo }: { promo: EnrichedPromotion }) {
             {description}
           </p>
         )}
-
-        <div className="flex-1 min-h-3" />
-
-        <div
-          className="mt-3 pt-3 flex items-center justify-between"
-          style={{ borderTop: "1px solid var(--border-subtle)" }}
-        >
-          <span className="text-[10px] font-bold uppercase tracking-wider text-[var(--text-muted)]">
-            Network
-          </span>
-          <ChainDot chain="base" withLabel />
-        </div>
       </div>
 
       {/* Hover/focus overlay — see .featured-card-overlay in globals.css */}

--- a/src/components/ui/featured/featured-project-card.tsx
+++ b/src/components/ui/featured/featured-project-card.tsx
@@ -29,7 +29,10 @@ export function FeaturedProjectCard({ promo }: { promo: EnrichedPromotion }) {
   const description = promo.project?.description || "";
   const imageUrl = promo.project?.image_url || null;
   const username = promo.author?.username || null;
-  const techStack = promo.project?.tech_stack ?? [];
+  // Dedupe — tech_stack is just a string[] with no uniqueness constraint, so
+  // duplicates from the source data would render duplicate pills AND collide
+  // on the React key. Set preserves insertion order.
+  const techStack = Array.from(new Set(promo.project?.tech_stack ?? []));
   const { href, external } = destinationFor(promo);
 
   const linkProps = external

--- a/src/components/ui/featured/featured-project-card.tsx
+++ b/src/components/ui/featured/featured-project-card.tsx
@@ -20,10 +20,16 @@ function destinationFor(promo: EnrichedPromotion): { href: string; external: boo
   return { href: `/explore?q=${encodeURIComponent(promo.projectName)}`, external: false };
 }
 
+// How many tech-stack pills to surface inline before collapsing to "+N".
+// Four keeps the row to one line on the typical card width.
+const MAX_TECH_PILLS = 4;
+
 export function FeaturedProjectCard({ promo }: { promo: EnrichedPromotion }) {
   const title = promo.project?.title || promo.projectName;
   const description = promo.project?.description || "";
   const imageUrl = promo.project?.image_url || null;
+  const username = promo.author?.username || null;
+  const techStack = promo.project?.tech_stack ?? [];
   const { href, external } = destinationFor(promo);
 
   const linkProps = external
@@ -80,10 +86,41 @@ export function FeaturedProjectCard({ promo }: { promo: EnrichedPromotion }) {
         <h3 className="mt-2 text-base font-extrabold uppercase text-[var(--foreground)] line-clamp-1 leading-tight">
           {title}
         </h3>
+        {username && (
+          <p className="mt-0.5 text-[11px] font-mono text-[var(--text-muted)] line-clamp-1">
+            @{username}
+          </p>
+        )}
         {description && (
-          <p className="mt-1 text-xs text-[var(--text-secondary)] line-clamp-2 leading-snug">
+          <p className="mt-2 text-xs text-[var(--text-secondary)] line-clamp-2 leading-snug">
             {description}
           </p>
+        )}
+        {/* Tech stack — plain text pills are kept non-interactive on purpose.
+            The whole-card link captures clicks (rendering nested anchors here
+            would break HTML semantics and the focus order). mt-auto pushes
+            this row to the bottom of the content area so it fills the space
+            the old Network row used to occupy. */}
+        {techStack.length > 0 && (
+          <div className="mt-auto pt-4 flex flex-wrap gap-1.5">
+            {techStack.slice(0, MAX_TECH_PILLS).map((tech) => (
+              <span
+                key={tech}
+                className="px-2 py-0.5 text-[9px] font-mono font-bold uppercase tracking-wider text-[var(--text-muted)]"
+                style={{
+                  backgroundColor: "var(--bg-surface-light)",
+                  border: "1px solid var(--border-subtle)",
+                }}
+              >
+                {tech}
+              </span>
+            ))}
+            {techStack.length > MAX_TECH_PILLS && (
+              <span className="px-2 py-0.5 text-[9px] font-mono font-bold uppercase tracking-wider text-[var(--text-muted)]">
+                +{techStack.length - MAX_TECH_PILLS}
+              </span>
+            )}
+          </div>
         )}
       </div>
 

--- a/src/components/ui/featured/featured-section.tsx
+++ b/src/components/ui/featured/featured-section.tsx
@@ -94,9 +94,17 @@ export function FeaturedSection() {
     node.focus({ preventScroll: true });
     // Briefly pulse the card so users see where the click landed — without
     // this, if both cards already share a viewport, the click looks dead.
-    // Restart the animation by removing/re-adding the class on the next frame.
+    // The offsetWidth read forces a synchronous reflow between remove + add
+    // so the browser registers a class change instead of batching the two
+    // ops into a no-op (the canonical "restart CSS animation" pattern).
+    // rAF would also work but stalls on hidden tabs; reflow is universal.
+    // setTimeout cleanup matches the 1.2s animation + buffer, and also
+    // handles the prefers-reduced-motion path where no animationend fires
+    // (the static outline stays visible until the class is removed).
     node.classList.remove("claim-pulse");
-    requestAnimationFrame(() => node.classList.add("claim-pulse"));
+    void node.offsetWidth;
+    node.classList.add("claim-pulse");
+    window.setTimeout(() => node.classList.remove("claim-pulse"), 1400);
   }, []);
 
   return (

--- a/src/components/ui/featured/featured-section.tsx
+++ b/src/components/ui/featured/featured-section.tsx
@@ -92,6 +92,11 @@ export function FeaturedSection() {
     if (!node) return;
     node.scrollIntoView({ behavior: "smooth", block: "center" });
     node.focus({ preventScroll: true });
+    // Briefly pulse the card so users see where the click landed — without
+    // this, if both cards already share a viewport, the click looks dead.
+    // Restart the animation by removing/re-adding the class on the next frame.
+    node.classList.remove("claim-pulse");
+    requestAnimationFrame(() => node.classList.add("claim-pulse"));
   }, []);
 
   return (


### PR DESCRIPTION
## Summary

The squash-merge of [#172](https://github.com/unknownking07/vibe-talent/pull/172) landed at commit `bdd47f3` and missed the final two polish commits I pushed after the CodeRabbit-fix round. This PR re-applies them on top of main.

**Two commits cherry-picked from the original branch:**

- `1241879` — **claim-click feedback + drop Network row**
  - The empty-slot card was already a clickable `<button>`, but `scrollIntoView` is a no-op when the target is already on screen, so clicks looked dead. Added a 1.2s outline-ripple animation (`.claim-pulse` in globals.css) on the Feature-Your-Project card so users see the click landed.
  - Dropped the `Network / Base` row from the paid project card. We only support Base for the promo contract today; the row was visual noise.

- `c9548be` — **@username + tech-stack pills on project card**
  - `@username` under the project title (plain text — the whole card already wraps a single anchor; nesting another would break HTML semantics + focus order)
  - Up to 4 tech-stack pills along the bottom, with `+N` overflow
  - Verified live render against the OF BLOCK DMS promotion: shows `@abhinav` and `JAVASCRIPT / CSS / HTML / SHELL` pills, no console errors

## Test plan

- [ ] Hard refresh `/` — featured card shows `@username` under title and tech-stack pills along the bottom; no Network row
- [ ] Click an empty slot's "Claim This Spot" — the Feature-Your-Project card briefly outline-pulses orange
- [ ] No console errors
- [ ] Mobile viewport: pills wrap cleanly, username doesn't overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Featured project cards now display author usernames and project technology stacks as visual tags with an overflow indicator.
  * Added visual pulse animation feedback when claiming projects.

* **Style**
  * Reorganized featured card layouts with improved spacing and information hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->