### PR TITLE
feat(pagination): soft rounded redesign with eyebrow + count header

### DIFF
--- a/src/components/explore/explore-content.tsx
+++ b/src/components/explore/explore-content.tsx
@@ -329,12 +329,12 @@ export function ExploreContent({ users }: { users: UserWithSocials[] }) {
         </div>
       )}
 
-      {/* Results count */}
-      <p className="mb-4 text-sm font-bold uppercase tracking-wide text-[var(--text-muted)]">
-        {filteredUsers.length > PAGE_SIZE
-          ? `Showing ${(activePage - 1) * PAGE_SIZE + 1}–${Math.min(activePage * PAGE_SIZE, filteredUsers.length)} of ${filteredUsers.length} builders`
-          : `${filteredUsers.length} builder${filteredUsers.length !== 1 ? "s" : ""} found`}
-      </p>
+      {/* Results count — only shown when no pagination is needed; paginated case puts the count inside <Pagination /> */}
+      {filteredUsers.length > 0 && filteredUsers.length <= PAGE_SIZE && (
+        <p className="mb-4 text-sm font-bold uppercase tracking-wide text-[var(--text-muted)]">
+          {filteredUsers.length} builder{filteredUsers.length !== 1 ? "s" : ""} found
+        </p>
+      )}
 
       {/* Grid */}
       {filteredUsers.length > 0 ? (
@@ -347,7 +347,15 @@ export function ExploreContent({ users }: { users: UserWithSocials[] }) {
 
           {/* Pagination */}
           <div className="mt-10">
-            <Pagination currentPage={activePage} totalPages={totalPages} onPageChange={goToPage} />
+            <Pagination
+              currentPage={activePage}
+              totalPages={totalPages}
+              onPageChange={goToPage}
+              label="Builders Directory"
+              pageSize={PAGE_SIZE}
+              totalItems={filteredUsers.length}
+              itemNoun="builders"
+            />
           </div>
         </>
       ) : (

--- a/src/components/leaderboard/leaderboard-content.tsx
+++ b/src/components/leaderboard/leaderboard-content.tsx
@@ -232,14 +232,17 @@ export function LeaderboardContent({ users }: { users: UserWithSocials[] }) {
         </table>
       </div>
 
-      {/* Results count + Pagination */}
+      {/* Pagination (count + eyebrow rendered inside) */}
       {sortedUsers.length > PAGE_SIZE && (
-        <>
-          <p className="mt-4 text-sm font-bold uppercase tracking-wide text-[var(--text-muted)] text-center">
-            Showing {(activePage - 1) * PAGE_SIZE + 1}–{Math.min(activePage * PAGE_SIZE, sortedUsers.length)} of {sortedUsers.length} builders
-          </p>
-          <Pagination currentPage={activePage} totalPages={totalPages} onPageChange={goToPage} />
-        </>
+        <Pagination
+          currentPage={activePage}
+          totalPages={totalPages}
+          onPageChange={goToPage}
+          label="Leaderboard"
+          pageSize={PAGE_SIZE}
+          totalItems={sortedUsers.length}
+          itemNoun="builders"
+        />
       )}
     </>
   );

--- a/src/components/projects/projects-content.tsx
+++ b/src/components/projects/projects-content.tsx
@@ -76,9 +76,12 @@ export function ProjectsContent({ projects }: { projects: ProjectWithAuthor[] })
   }, [projects, search, sortBy, verifiedOnly, hasLiveUrl, selectedTech]);
 
   const totalPages = Math.ceil(filteredProjects.length / PAGE_SIZE);
+  // Clamp in case the projects prop refreshes (ISR / revalidation) while the
+  // user is on a page that no longer exists.
+  const activePage = currentPage > totalPages ? 1 : currentPage;
   const paginatedProjects = filteredProjects.slice(
-    (currentPage - 1) * PAGE_SIZE,
-    currentPage * PAGE_SIZE
+    (activePage - 1) * PAGE_SIZE,
+    activePage * PAGE_SIZE
   );
 
   const activeFilterCount = [verifiedOnly, hasLiveUrl, selectedTech.length > 0].filter(Boolean).length;
@@ -213,7 +216,7 @@ export function ProjectsContent({ projects }: { projects: ProjectWithAuthor[] })
       {totalPages > 1 && (
         <div className="mt-8">
           <Pagination
-            currentPage={currentPage}
+            currentPage={activePage}
             totalPages={totalPages}
             onPageChange={goToPage}
             label="Projects"

--- a/src/components/projects/projects-content.tsx
+++ b/src/components/projects/projects-content.tsx
@@ -82,8 +82,6 @@ export function ProjectsContent({ projects }: { projects: ProjectWithAuthor[] })
   );
 
   const activeFilterCount = [verifiedOnly, hasLiveUrl, selectedTech.length > 0].filter(Boolean).length;
-  const start = (currentPage - 1) * PAGE_SIZE + 1;
-  const end = Math.min(currentPage * PAGE_SIZE, filteredProjects.length);
 
   return (
     <>
@@ -183,14 +181,21 @@ export function ProjectsContent({ projects }: { projects: ProjectWithAuthor[] })
         </div>
       )}
 
-      {/* Results count */}
-      <div className="flex items-center justify-between mb-4">
-        <p className="text-sm text-[var(--text-secondary)] font-medium">
-          {filteredProjects.length === 0
-            ? "No projects found"
-            : `Showing ${start}–${end} of ${filteredProjects.length} projects`}
-        </p>
-      </div>
+      {/* Results count — only when no pagination is needed (paginated case puts the count inside <Pagination />) */}
+      {filteredProjects.length > 0 && filteredProjects.length <= PAGE_SIZE && (
+        <div className="flex items-center justify-between mb-4">
+          <p className="text-sm text-[var(--text-secondary)] font-medium">
+            Showing {filteredProjects.length} project{filteredProjects.length !== 1 ? "s" : ""}
+          </p>
+        </div>
+      )}
+      {filteredProjects.length === 0 && (
+        <div className="flex items-center justify-between mb-4">
+          <p className="text-sm text-[var(--text-secondary)] font-medium">
+            No projects found
+          </p>
+        </div>
+      )}
 
       {/* Project grid */}
       <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6 stagger-children">
@@ -211,6 +216,10 @@ export function ProjectsContent({ projects }: { projects: ProjectWithAuthor[] })
             currentPage={currentPage}
             totalPages={totalPages}
             onPageChange={goToPage}
+            label="Projects"
+            pageSize={PAGE_SIZE}
+            totalItems={filteredProjects.length}
+            itemNoun="projects"
           />
         </div>
       )}

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,19 +1,30 @@
 "use client";
 
-import { useState } from "react";
+import { useId, useState } from "react";
 import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from "lucide-react";
 
-interface PaginationProps {
+type PaginationBaseProps = {
   currentPage: number;
   totalPages: number;
   onPageChange: (page: number) => void;
+};
 
-  /** Optional header — render eyebrow + count line above the controls. All four must be provided together. */
-  label?: string;
-  pageSize?: number;
-  totalItems?: number;
-  itemNoun?: string;
-}
+type PaginationHeader = {
+  label: string;
+  pageSize: number;
+  totalItems: number;
+  itemNoun: string;
+};
+
+// Discriminated union: callers must provide either all four header fields or none.
+type PaginationProps =
+  | (PaginationBaseProps & PaginationHeader)
+  | (PaginationBaseProps & {
+      label?: never;
+      pageSize?: never;
+      totalItems?: never;
+      itemNoun?: never;
+    });
 
 function getPageNumbers(current: number, total: number): (number | "...")[] {
   if (total <= 7) {
@@ -57,6 +68,8 @@ export function Pagination({
   itemNoun,
 }: PaginationProps) {
   const [jumpValue, setJumpValue] = useState("");
+  const reactId = useId();
+  const jumpInputId = `${reactId}-pagination-jump-input`;
 
   if (totalPages <= 1) return null;
 
@@ -70,11 +83,16 @@ export function Pagination({
     }
   };
 
+  // The discriminated union guarantees these four come together; destructuring
+  // strips that narrowing, so we re-check each individually for the type guard.
   const showHeader =
-    !!label && pageSize != null && totalItems != null && !!itemNoun;
+    label !== undefined &&
+    pageSize !== undefined &&
+    totalItems !== undefined &&
+    itemNoun !== undefined;
 
   return (
-    <div className="flex flex-col items-center gap-6 mt-4">
+    <nav aria-label="Pagination" className="flex flex-col items-center gap-6 mt-4">
       {showHeader && (
         <div className="flex flex-col items-center gap-2">
           <span className="text-xs font-bold uppercase tracking-[0.2em] text-[var(--text-muted)]">
@@ -83,8 +101,8 @@ export function Pagination({
           <p className="text-base text-[var(--text-muted)]">
             Showing{" "}
             <span className="font-bold text-[var(--foreground)]">
-              {(currentPage - 1) * pageSize! + 1}
-              –{Math.min(currentPage * pageSize!, totalItems!)}
+              {(currentPage - 1) * pageSize + 1}
+              –{Math.min(currentPage * pageSize, totalItems)}
             </span>
             {" of "}
             <span className="font-bold text-[var(--foreground)]">
@@ -197,20 +215,19 @@ export function Pagination({
           }}
         >
           <label
-            htmlFor="pagination-jump-input"
+            htmlFor={jumpInputId}
             className="text-xs font-bold uppercase tracking-[0.15em] text-[var(--text-muted)]"
           >
             Go to page
           </label>
           <input
-            id="pagination-jump-input"
+            id={jumpInputId}
             type="number"
             min={1}
             max={totalPages}
             value={jumpValue}
             onChange={(e) => setJumpValue(e.target.value)}
             placeholder={`1–${totalPages}`}
-            aria-label="Jump to page"
             className="w-24 h-10 px-3 rounded-lg text-center text-sm font-bold focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
             style={{
               backgroundColor: "var(--background)",
@@ -227,6 +244,6 @@ export function Pagination({
           </button>
         </form>
       )}
-    </div>
+    </nav>
   );
 }

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -7,22 +7,22 @@ interface PaginationProps {
   currentPage: number;
   totalPages: number;
   onPageChange: (page: number) => void;
+
+  /** Optional header — render eyebrow + count line above the controls. All four must be provided together. */
+  label?: string;
+  pageSize?: number;
+  totalItems?: number;
+  itemNoun?: string;
 }
 
-/**
- * Build the list of page numbers to display, with ellipsis gaps.
- * Always shows: first page, last page, and up to 2 pages around the current page.
- * Example for page 5 of 20: [1, "...", 4, 5, 6, "...", 20]
- */
 function getPageNumbers(current: number, total: number): (number | "...")[] {
   if (total <= 7) {
     return Array.from({ length: total }, (_, i) => i + 1);
   }
 
   const pages: (number | "...")[] = [];
-  const siblings = 1; // pages on each side of current
+  const siblings = 1;
 
-  // Always include first page
   pages.push(1);
 
   const rangeStart = Math.max(2, current - siblings);
@@ -36,16 +36,26 @@ function getPageNumbers(current: number, total: number): (number | "...")[] {
 
   if (rangeEnd < total - 1) pages.push("...");
 
-  // Always include last page
   pages.push(total);
 
   return pages;
 }
 
 const btnBase =
-  "flex items-center justify-center w-10 h-10 font-extrabold uppercase transition-all";
+  "flex items-center justify-center w-12 h-12 rounded-xl font-bold transition-all";
 
-export function Pagination({ currentPage, totalPages, onPageChange }: PaginationProps) {
+const ACTIVE_GLOW =
+  "0 0 0 4px rgba(255, 58, 0, 0.18), 0 8px 24px rgba(255, 58, 0, 0.35)";
+
+export function Pagination({
+  currentPage,
+  totalPages,
+  onPageChange,
+  label,
+  pageSize,
+  totalItems,
+  itemNoun,
+}: PaginationProps) {
   const [jumpValue, setJumpValue] = useState("");
 
   if (totalPages <= 1) return null;
@@ -60,128 +70,163 @@ export function Pagination({ currentPage, totalPages, onPageChange }: Pagination
     }
   };
 
+  const showHeader =
+    !!label && pageSize != null && totalItems != null && !!itemNoun;
+
   return (
-    <div className="flex flex-col items-center gap-3 mt-4">
-    <div className="flex items-center justify-center gap-2">
-      {/* First page */}
-      <button
-        onClick={() => onPageChange(1)}
-        disabled={currentPage === 1}
-        className={`${btnBase} disabled:opacity-30 disabled:cursor-not-allowed`}
-        style={{
-          backgroundColor: "var(--bg-surface)",
-          border: "2px solid var(--border-hard)",
-          boxShadow: "var(--shadow-brutal-sm)",
-        }}
-        aria-label="First page"
-      >
-        <ChevronsLeft size={16} />
-      </button>
-
-      {/* Previous page */}
-      <button
-        onClick={() => onPageChange(currentPage - 1)}
-        disabled={currentPage === 1}
-        className={`${btnBase} disabled:opacity-30 disabled:cursor-not-allowed`}
-        style={{
-          backgroundColor: "var(--bg-surface)",
-          border: "2px solid var(--border-hard)",
-          boxShadow: "var(--shadow-brutal-sm)",
-        }}
-        aria-label="Previous page"
-      >
-        <ChevronLeft size={16} />
-      </button>
-
-      {/* Page numbers */}
-      {pages.map((page, idx) =>
-        page === "..." ? (
-          <span
-            key={`ellipsis-${idx}`}
-            className="flex items-center justify-center w-10 h-10 text-sm font-extrabold text-[var(--text-muted)] select-none"
-          >
-            ...
+    <div className="flex flex-col items-center gap-6 mt-4">
+      {showHeader && (
+        <div className="flex flex-col items-center gap-2">
+          <span className="text-xs font-bold uppercase tracking-[0.2em] text-[var(--text-muted)]">
+            {label}
           </span>
-        ) : (
-          <button
-            key={page}
-            onClick={() => onPageChange(page)}
-            className={`${btnBase} text-sm`}
-            style={{
-              backgroundColor: currentPage === page ? "var(--accent)" : "var(--bg-surface)",
-              color: currentPage === page ? "#FFFFFF" : "var(--foreground)",
-              border: "2px solid var(--border-hard)",
-              boxShadow: currentPage === page ? "none" : "var(--shadow-brutal-sm)",
-            }}
-            aria-label={`Page ${page}`}
-            aria-current={currentPage === page ? "page" : undefined}
-          >
-            {page}
-          </button>
-        )
+          <p className="text-base text-[var(--text-muted)]">
+            Showing{" "}
+            <span className="font-bold text-[var(--foreground)]">
+              {(currentPage - 1) * pageSize! + 1}
+              –{Math.min(currentPage * pageSize!, totalItems!)}
+            </span>
+            {" of "}
+            <span className="font-bold text-[var(--foreground)]">
+              {totalItems}
+            </span>{" "}
+            {itemNoun}
+          </p>
+        </div>
       )}
 
-      {/* Next page */}
-      <button
-        onClick={() => onPageChange(currentPage + 1)}
-        disabled={currentPage === totalPages}
-        className={`${btnBase} disabled:opacity-30 disabled:cursor-not-allowed`}
-        style={{
-          backgroundColor: "var(--bg-surface)",
-          border: "2px solid var(--border-hard)",
-          boxShadow: "var(--shadow-brutal-sm)",
-        }}
-        aria-label="Next page"
-      >
-        <ChevronRight size={16} />
-      </button>
-
-      {/* Last page */}
-      <button
-        onClick={() => onPageChange(totalPages)}
-        disabled={currentPage === totalPages}
-        className={`${btnBase} disabled:opacity-30 disabled:cursor-not-allowed`}
-        style={{
-          backgroundColor: "var(--bg-surface)",
-          border: "2px solid var(--border-hard)",
-          boxShadow: "var(--shadow-brutal-sm)",
-        }}
-        aria-label="Last page"
-      >
-        <ChevronsRight size={16} />
-      </button>
-    </div>
-
-    {/* Go to page */}
-    {totalPages > 7 && (
-      <form
-        onSubmit={(e) => { e.preventDefault(); handleJump(); }}
-        className="flex items-center gap-2"
-      >
-        <label className="text-xs font-bold uppercase tracking-wide text-[var(--text-muted)]">
-          Go to page
-        </label>
-        <input
-          type="number"
-          min={1}
-          max={totalPages}
-          value={jumpValue}
-          onChange={(e) => setJumpValue(e.target.value)}
-          placeholder={`1–${totalPages}`}
-          className="input-brutal w-24 text-center text-sm"
-        />
+      <div className="flex items-center justify-center gap-2">
         <button
-          type="submit"
-          className="px-3 py-2 text-xs font-extrabold uppercase tracking-wide text-white transition-colors hover:bg-[#E03300]"
+          onClick={() => onPageChange(1)}
+          disabled={currentPage === 1}
+          className={`${btnBase} text-[var(--text-muted)] hover:bg-[var(--bg-surface-light)] disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-[var(--bg-surface)]`}
           style={{
-            backgroundColor: "var(--accent)",
-            border: "2px solid var(--border-hard)",
+            backgroundColor: "var(--bg-surface)",
+            border: "1px solid var(--border-subtle)",
+          }}
+          aria-label="First page"
+        >
+          <ChevronsLeft size={16} />
+        </button>
+
+        <button
+          onClick={() => onPageChange(currentPage - 1)}
+          disabled={currentPage === 1}
+          className={`${btnBase} text-[var(--text-muted)] hover:bg-[var(--bg-surface-light)] disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-[var(--bg-surface)]`}
+          style={{
+            backgroundColor: "var(--bg-surface)",
+            border: "1px solid var(--border-subtle)",
+          }}
+          aria-label="Previous page"
+        >
+          <ChevronLeft size={16} />
+        </button>
+
+        {pages.map((page, idx) =>
+          page === "..." ? (
+            <span
+              key={`ellipsis-${idx}`}
+              className="flex items-center justify-center w-12 h-12 text-sm font-bold text-[var(--text-muted)] select-none"
+            >
+              …
+            </span>
+          ) : (
+            <button
+              key={page}
+              onClick={() => onPageChange(page)}
+              className={`${btnBase} text-sm ${
+                currentPage === page
+                  ? ""
+                  : "hover:bg-[var(--bg-surface-light)]"
+              }`}
+              style={{
+                backgroundColor:
+                  currentPage === page ? "var(--accent)" : "var(--bg-surface)",
+                color: currentPage === page ? "#FFFFFF" : "var(--foreground)",
+                border:
+                  currentPage === page
+                    ? "1px solid var(--accent)"
+                    : "1px solid var(--border-subtle)",
+                boxShadow: currentPage === page ? ACTIVE_GLOW : "none",
+              }}
+              aria-label={`Page ${page}`}
+              aria-current={currentPage === page ? "page" : undefined}
+            >
+              {page}
+            </button>
+          )
+        )}
+
+        <button
+          onClick={() => onPageChange(currentPage + 1)}
+          disabled={currentPage === totalPages}
+          className={`${btnBase} text-[var(--text-muted)] hover:bg-[var(--bg-surface-light)] disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-[var(--bg-surface)]`}
+          style={{
+            backgroundColor: "var(--bg-surface)",
+            border: "1px solid var(--border-subtle)",
+          }}
+          aria-label="Next page"
+        >
+          <ChevronRight size={16} />
+        </button>
+
+        <button
+          onClick={() => onPageChange(totalPages)}
+          disabled={currentPage === totalPages}
+          className={`${btnBase} text-[var(--text-muted)] hover:bg-[var(--bg-surface-light)] disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-[var(--bg-surface)]`}
+          style={{
+            backgroundColor: "var(--bg-surface)",
+            border: "1px solid var(--border-subtle)",
+          }}
+          aria-label="Last page"
+        >
+          <ChevronsRight size={16} />
+        </button>
+      </div>
+
+      {totalPages > 5 && (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleJump();
+          }}
+          className="flex items-center gap-3 p-2 pl-5 rounded-2xl"
+          style={{
+            backgroundColor: "var(--bg-surface)",
+            border: "1px solid var(--border-subtle)",
           }}
         >
-          Go
-        </button>
-      </form>
-    )}
+          <label
+            htmlFor="pagination-jump-input"
+            className="text-xs font-bold uppercase tracking-[0.15em] text-[var(--text-muted)]"
+          >
+            Go to page
+          </label>
+          <input
+            id="pagination-jump-input"
+            type="number"
+            min={1}
+            max={totalPages}
+            value={jumpValue}
+            onChange={(e) => setJumpValue(e.target.value)}
+            placeholder={`1–${totalPages}`}
+            aria-label="Jump to page"
+            className="w-24 h-10 px-3 rounded-lg text-center text-sm font-bold focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+            style={{
+              backgroundColor: "var(--background)",
+              border: "1px solid var(--border-subtle)",
+              color: "var(--foreground)",
+            }}
+          />
+          <button
+            type="submit"
+            className="px-5 h-10 rounded-lg text-xs font-extrabold uppercase tracking-[0.1em] text-white transition-opacity hover:opacity-90"
+            style={{ backgroundColor: "var(--accent)" }}
+          >
+            Jump
+          </button>
+        </form>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replaces the brutalist pagination (sharp 2px borders, hard offset shadows) with a softer rounded design — rounded-xl buttons, 1px subtle borders, an orange glow halo on the active page, and a pill-wrapped "Go to page" jump form.
- Adds four optional header props (`label`, `pageSize`, `totalItems`, `itemNoun`) so the eyebrow + bold-numbers count line ("BUILDERS DIRECTORY / Showing **1–15** of **121** builders") renders inside the component.
- Wires the header up on `/explore` (Builders Directory), `/leaderboard`, and `/projects`. Featured section continues to render without a header.

## Changes
- `src/components/ui/pagination.tsx` — full redesign + new optional props
- `src/components/explore/explore-content.tsx` — passes `label="Builders Directory"`, removed redundant top-of-grid count for the paginated case
- `src/components/leaderboard/leaderboard-content.tsx` — passes `label="Leaderboard"`
- `src/components/projects/projects-content.tsx` — passes `label="Projects"`, removed unused `start`/`end` locals

## Test plan
- [ ] Load `/explore` in dark mode — confirm eyebrow + count renders, page 1 has orange glow halo, first/prev disabled
- [ ] Click page 2 — count updates to "16–30 of 121", smooth scroll to top fires
- [ ] Type a page number in the JUMP input + click Jump — page advances, input clears
- [ ] Repeat on `/leaderboard` (eyebrow: "LEADERBOARD") and `/projects` (eyebrow: "PROJECTS", PAGE_SIZE 12)
- [ ] Toggle light mode — confirm orange + glow still read correctly
- [ ] Confirm featured section homepage carousel pagination still works (no header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Improvements to Pagination and Results Display

* **User Interface Improvements**
  * Enhanced pagination controls with improved visual styling and clearer "showing X–Y of Z items" messaging
  * Simplified results count display across Explore, Leaderboard, and Projects sections
  * Updated pagination component with consistent formatting and better navigation thresholds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->