### PR TITLE
fix: project verify backfill, github-sync starvation, reviews header, agent skill freshen

### DIFF
--- a/scripts/admin/debug-verify-project.ts
+++ b/scripts/admin/debug-verify-project.ts
@@ -137,10 +137,15 @@ async function diagnoseOne(user: UserRow, unstick: boolean, verbose = true): Pro
 
 async function runAll(unstick: boolean) {
   console.log(`\n── Scanning all users with at least one project ──`);
+  // PostgREST caps .select() at 1,000 rows by default. Without an explicit
+  // .range() the --all scan would silently miss anyone past the first 1k
+  // users — bad for a diagnostic that's supposed to be exhaustive.
+  const MAX_USERS = 100_000;
   const { data: users, error: usersErr } = await sb
     .from("users")
     .select("id, username, github_username, created_at")
-    .order("created_at", { ascending: true });
+    .order("created_at", { ascending: true })
+    .range(0, MAX_USERS - 1);
   if (usersErr) {
     console.error("Failed to fetch users:", usersErr.message);
     process.exit(1);
@@ -148,6 +153,11 @@ async function runAll(unstick: boolean) {
   if (!users || users.length === 0) {
     console.log("No users found.");
     return;
+  }
+  if (users.length === MAX_USERS) {
+    console.warn(
+      `[warn] hit MAX_USERS=${MAX_USERS} cap — bump if the platform has grown beyond that.`
+    );
   }
 
   let totalUnstuck = 0;

--- a/scripts/admin/debug-verify-project.ts
+++ b/scripts/admin/debug-verify-project.ts
@@ -1,0 +1,248 @@
+/**
+ * Diagnose why projects aren't getting verified.
+ *
+ * Usage:
+ *   npx tsx scripts/admin/debug-verify-project.ts <username>           # one user
+ *   npx tsx scripts/admin/debug-verify-project.ts <username> --unstick # one user, clear stale stamps
+ *   npx tsx scripts/admin/debug-verify-project.ts --all                # every user, summary
+ *   npx tsx scripts/admin/debug-verify-project.ts --all --unstick      # every user, clear stale stamps
+ *
+ * Per-project diagnoses:
+ *   already_verified — verified=true with quality_metrics populated. Nothing to do.
+ *   owner_match      — repo owner matches users.github_username. Should be verified;
+ *                      if it isn't, the cron is stuck (stamp blocks retry, or analyze
+ *                      keeps failing). --unstick clears last_verify_attempt_at.
+ *   owner_mismatch   — repo owner != users.github_username. Cannot auto-verify;
+ *                      user must add a .vibetalent file to the repo and click Verify.
+ *   missing_username — users.github_username is null. Will retry on next cron run
+ *                      after the user links GitHub (now unstamped after the fix).
+ *   bad_url / no_github_url — project URL is unparseable or missing.
+ */
+import { createClient } from "@supabase/supabase-js";
+import { parseGithubRepoUrl } from "../../src/lib/github-quality";
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!url || !serviceRoleKey) {
+  console.error(
+    "Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in env. " +
+      "Source .env.local or export them before running."
+  );
+  process.exit(1);
+}
+
+const sb = createClient(url, serviceRoleKey);
+
+type Diagnosis =
+  | "already_verified"
+  | "owner_match"
+  | "owner_mismatch"
+  | "bad_url"
+  | "missing_username"
+  | "no_github_url";
+
+interface ProjectRow {
+  id: string;
+  title: string;
+  github_url: string | null;
+  verified: boolean;
+  quality_score: number | null;
+  quality_metrics: unknown | null;
+  last_verify_attempt_at: string | null;
+  created_at: string;
+}
+
+function diagnose(p: ProjectRow, githubUsername: string | null): Diagnosis {
+  if (p.verified && p.quality_metrics) return "already_verified";
+  if (!p.github_url) return "no_github_url";
+  const parsed = parseGithubRepoUrl(p.github_url);
+  if (!parsed) return "bad_url";
+  if (!githubUsername) return "missing_username";
+  return parsed.owner.toLowerCase() === githubUsername.toLowerCase()
+    ? "owner_match"
+    : "owner_mismatch";
+}
+
+interface UserRow {
+  id: string;
+  username: string;
+  github_username: string | null;
+  created_at: string;
+}
+
+async function diagnoseOne(user: UserRow, unstick: boolean, verbose = true): Promise<string[]> {
+  const { data: projects, error: projErr } = await sb
+    .from("projects")
+    .select(
+      "id, title, github_url, verified, quality_score, quality_metrics, last_verify_attempt_at, created_at"
+    )
+    .eq("user_id", user.id)
+    .order("created_at", { ascending: true });
+
+  if (projErr) {
+    console.error(`Failed to fetch projects for ${user.username}:`, projErr.message);
+    return [];
+  }
+  if (!projects || projects.length === 0) {
+    if (verbose) console.log("\nNo projects for this user.");
+    return [];
+  }
+
+  const stuck: string[] = [];
+  if (verbose) console.log(`\n── Projects (${projects.length}) ──`);
+  for (const p of projects as ProjectRow[]) {
+    const dx = diagnose(p, user.github_username);
+    const parsed = parseGithubRepoUrl(p.github_url ?? "");
+    const owner = parsed?.owner ?? "(unparseable)";
+    if (verbose) {
+      console.log(`\n  ${p.title} (${p.id})`);
+      console.log(`    github_url:             ${p.github_url ?? "(null)"}`);
+      console.log(`    repo owner:             ${owner}`);
+      console.log(`    verified:               ${p.verified}`);
+      console.log(`    quality_score:          ${p.quality_score ?? "(null)"}`);
+      console.log(`    quality_metrics null?   ${p.quality_metrics === null}`);
+      console.log(`    last_verify_attempt_at: ${p.last_verify_attempt_at ?? "(null)"}`);
+      console.log(`    diagnosis:              ${dx}`);
+    }
+
+    if (
+      (dx === "owner_match" || dx === "missing_username") &&
+      !p.verified &&
+      p.last_verify_attempt_at
+    ) {
+      stuck.push(p.id);
+      if (verbose) console.log("    -> recoverable; clearing last_verify_attempt_at would let cron retry.");
+    } else if (dx === "owner_mismatch" && verbose) {
+      console.log(
+        `    -> user must add a .vibetalent file at github.com/${owner}/.../.vibetalent ` +
+          `containing "${user.github_username ?? user.id}", then click Verify.`
+      );
+    }
+  }
+
+  if (unstick && stuck.length > 0) {
+    const { error: updErr } = await sb
+      .from("projects")
+      .update({ last_verify_attempt_at: null })
+      .in("id", stuck);
+    if (updErr) {
+      console.error(`Update failed for ${user.username}:`, updErr.message);
+    } else if (verbose) {
+      console.log(`\n  Unstuck ${stuck.length} project(s) for ${user.username}.`);
+    }
+  }
+  return stuck;
+}
+
+async function runAll(unstick: boolean) {
+  console.log(`\n── Scanning all users with at least one project ──`);
+  const { data: users, error: usersErr } = await sb
+    .from("users")
+    .select("id, username, github_username, created_at")
+    .order("created_at", { ascending: true });
+  if (usersErr) {
+    console.error("Failed to fetch users:", usersErr.message);
+    process.exit(1);
+  }
+  if (!users || users.length === 0) {
+    console.log("No users found.");
+    return;
+  }
+
+  let totalUnstuck = 0;
+  let usersWithStuck = 0;
+  let usersWithMismatch = 0;
+  let usersWithMatchVerified = 0;
+  for (const user of users as UserRow[]) {
+    const { data: projects } = await sb
+      .from("projects")
+      .select(
+        "id, title, github_url, verified, quality_score, quality_metrics, last_verify_attempt_at, created_at"
+      )
+      .eq("user_id", user.id);
+    if (!projects || projects.length === 0) continue;
+
+    const rows = projects as ProjectRow[];
+    const diagnoses = rows.map((p) => diagnose(p, user.github_username));
+    const hasMatchVerified = rows.some((p, i) => diagnoses[i] === "already_verified");
+    const hasMatchUnverified = rows.some((p, i) => diagnoses[i] === "owner_match" && !p.verified);
+    const hasMismatch = diagnoses.includes("owner_mismatch");
+
+    if (hasMatchVerified) usersWithMatchVerified++;
+    if (hasMismatch) usersWithMismatch++;
+
+    if (hasMatchUnverified) {
+      console.log(
+        `\n  STUCK: ${user.username} (gh=${user.github_username ?? "null"}) — owner-match but not verified:`
+      );
+      const stuck = await diagnoseOne(user, unstick, false);
+      for (const p of rows) {
+        const dx = diagnose(p, user.github_username);
+        if (dx === "owner_match" && !p.verified) {
+          console.log(
+            `    - ${p.title} (${p.id}) repo=${p.github_url} stamped=${p.last_verify_attempt_at ?? "null"}`
+          );
+        }
+      }
+      if (stuck.length > 0) {
+        totalUnstuck += stuck.length;
+        usersWithStuck++;
+      }
+    }
+  }
+  console.log(`\n── Scan summary ──`);
+  console.log(`  users scanned:                ${users.length}`);
+  console.log(`  users with verified projects: ${usersWithMatchVerified}`);
+  console.log(`  users with owner-mismatch:    ${usersWithMismatch}  (need .vibetalent file)`);
+  console.log(`  users with stuck verifications: ${usersWithStuck}`);
+  if (unstick) {
+    console.log(`  projects unstuck this run:    ${totalUnstuck}  (next cron run will retry)`);
+  } else if (usersWithStuck > 0) {
+    console.log(`  re-run with --unstick to clear stale last_verify_attempt_at on stuck rows.`);
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const unstick = args.includes("--unstick");
+  const all = args.includes("--all");
+  const username = args.find((a) => !a.startsWith("--"));
+
+  if (all) {
+    await runAll(unstick);
+    return;
+  }
+
+  if (!username) {
+    console.error(
+      "Usage:\n" +
+        "  npx tsx scripts/admin/debug-verify-project.ts <username> [--unstick]\n" +
+        "  npx tsx scripts/admin/debug-verify-project.ts --all [--unstick]"
+    );
+    process.exit(1);
+  }
+
+  const { data: user, error: userErr } = await sb
+    .from("users")
+    .select("id, username, github_username, created_at")
+    .eq("username", username)
+    .single();
+
+  if (userErr || !user) {
+    console.error(`User "${username}" not found:`, userErr?.message);
+    process.exit(1);
+  }
+
+  console.log("\n── User ──");
+  console.log(`  username:        ${user.username}`);
+  console.log(`  id:              ${user.id}`);
+  console.log(`  github_username: ${user.github_username ?? "(null)"}`);
+  console.log(`  created_at:      ${user.created_at}`);
+  await diagnoseOne(user as UserRow, unstick);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/admin/sync-user-streak.ts
+++ b/scripts/admin/sync-user-streak.ts
@@ -32,6 +32,17 @@ if (!url || !serviceRoleKey) {
   process.exit(1);
 }
 
+if (!process.env.GITHUB_TOKEN) {
+  // fetchGitHubContributions hits github.com HTML and doesn't use the API
+  // token, but printing a clear pre-flight warning saves debugging time when
+  // a future code path adds events-API calls and silently rate-limits.
+  console.warn(
+    "[warn] GITHUB_TOKEN not set in env. Anonymous GitHub HTML fetches " +
+      "rarely rate-limit at small batch sizes, but if you see 429s or " +
+      "0-day skips, export GITHUB_TOKEN (any unscoped GitHub PAT) and retry."
+  );
+}
+
 const sb = createClient(url, serviceRoleKey);
 
 const RATE_LIMIT_DELAY_MS = 800;
@@ -193,13 +204,20 @@ async function main() {
   // lifetime_contributions DESC so the heaviest accounts — the ones whose
   // streaks you actually care about being fresh — go first. The production
   // cron does the opposite (ASC) which is why meta_alchemist's row was stale.
+  //
+  // PostgREST defaults to a 1,000-row cap on .select() unless you opt into
+  // a larger range, which would silently truncate the platform once the
+  // user count crosses 1k. Use .range(0, MAX_USERS - 1) so the script
+  // genuinely processes every row.
+  const MAX_USERS = 100_000;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { data: users, error } = await (sb as any)
     .from("users")
     .select("id, username, github_username, streak, longest_streak, vibe_score, lifetime_contributions")
     .not("github_username", "is", null)
     .neq("github_username", "")
-    .order("lifetime_contributions", { ascending: false, nullsFirst: false });
+    .order("lifetime_contributions", { ascending: false, nullsFirst: false })
+    .range(0, MAX_USERS - 1);
   if (error) {
     console.error("Failed to fetch users:", error.message);
     process.exit(1);
@@ -207,6 +225,11 @@ async function main() {
   if (!users || users.length === 0) {
     console.log("No users with a github_username found.");
     return;
+  }
+  if (users.length === MAX_USERS) {
+    console.warn(
+      `[warn] hit MAX_USERS=${MAX_USERS} cap — bump the constant if the platform has grown beyond that.`
+    );
   }
 
   console.log(`\n── Syncing ${users.length} user(s)${dryRun ? " (dry-run, no writes)" : ""} ──\n`);

--- a/scripts/admin/sync-user-streak.ts
+++ b/scripts/admin/sync-user-streak.ts
@@ -1,0 +1,249 @@
+/**
+ * Force a fresh GitHub sync for every active user without going through
+ * the github-sync cron queue. Use when the production cron's ASC ordering
+ * by lifetime_contributions keeps timing out before reaching heavy users
+ * at the back of the list, leaving them with stale streaks.
+ *
+ * Usage:
+ *   npx tsx scripts/admin/sync-user-streak.ts          # sync everyone
+ *   npx tsx scripts/admin/sync-user-streak.ts --dry-run # report-only, no writes
+ *
+ * What it does for each user with a github_username:
+ *   1. Fetch the live GitHub contribution heatmap (public HTML endpoint)
+ *   2. Batch-upsert every active date into streak_logs (one round-trip)
+ *   3. Update users.lifetime_contributions / contributions_30d
+ *   4. Call the update_user_streak() RPC to recompute streak + vibe_score
+ *   5. Print before/after streak so you can see who actually moved
+ *
+ * Iteration order is DESC by lifetime_contributions so heavy users — the
+ * ones the production cron starves — get processed first.
+ */
+import { createClient } from "@supabase/supabase-js";
+import { fetchGitHubContributions, sumLastNDays } from "../../src/lib/github-contributions";
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!url || !serviceRoleKey) {
+  console.error(
+    "Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in env. " +
+      "Source .env.local or export them before running."
+  );
+  process.exit(1);
+}
+
+const sb = createClient(url, serviceRoleKey);
+
+const RATE_LIMIT_DELAY_MS = 800;
+
+function cleanGithubUsername(raw: string): string {
+  return raw
+    .replace(/^@/, "")
+    .replace(/^https?:\/\/(?:www\.)?github\.com\//, "")
+    .replace(/\/+$/, "")
+    .trim();
+}
+
+interface UserRow {
+  id: string;
+  username: string;
+  github_username: string | null;
+  streak: number;
+  longest_streak: number;
+  vibe_score: number;
+  lifetime_contributions: number | null;
+}
+
+type SyncResult =
+  | {
+      kind: "synced";
+      user: string;
+      before: { streak: number; longest_streak: number; vibe_score: number };
+      after: { streak: number; longest_streak: number; vibe_score: number };
+      dates_logged: number;
+      lifetime: number;
+      last30d: number;
+    }
+  | { kind: "skipped"; user: string; reason: string }
+  | { kind: "error"; user: string; reason: string };
+
+async function syncOne(user: UserRow, dryRun: boolean): Promise<SyncResult> {
+  let handle = user.github_username;
+  if (!handle) {
+    // Fall back to social_links.github
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: link } = await (sb as any)
+      .from("social_links")
+      .select("github")
+      .eq("user_id", user.id)
+      .single();
+    handle = link?.github ?? null;
+  }
+  if (!handle) {
+    return { kind: "skipped", user: user.username, reason: "no github username" };
+  }
+  const cleaned = cleanGithubUsername(handle);
+  if (!cleaned) {
+    return { kind: "skipped", user: user.username, reason: "github username unparseable" };
+  }
+
+  // 1. Fetch live contributions from GitHub
+  const { contributions, total: heatmapTotal } = await fetchGitHubContributions(cleaned);
+  const activeDates = Object.entries(contributions).filter(([, c]) => c > 0) as [
+    string,
+    number
+  ][];
+  if (activeDates.length === 0) {
+    return {
+      kind: "skipped",
+      user: user.username,
+      reason: "GitHub heatmap returned 0 active days",
+    };
+  }
+  const lifetime =
+    heatmapTotal > 0 ? heatmapTotal : activeDates.reduce((s, [, c]) => s + c, 0);
+  const last30d = sumLastNDays(contributions, 30);
+
+  if (dryRun) {
+    return {
+      kind: "synced",
+      user: user.username,
+      before: {
+        streak: user.streak,
+        longest_streak: user.longest_streak,
+        vibe_score: user.vibe_score,
+      },
+      after: {
+        streak: user.streak,
+        longest_streak: user.longest_streak,
+        vibe_score: user.vibe_score,
+      },
+      dates_logged: activeDates.length,
+      lifetime,
+      last30d,
+    };
+  }
+
+  // 2. Batch upsert streak_logs — single round-trip instead of N. The
+  // per-row loop in the production cron is exactly what's timing out for
+  // heavy users like meta_alchemist.
+  const rows = activeDates.map(([activity_date, commit_count]) => ({
+    user_id: user.id,
+    activity_date,
+    commit_count,
+  }));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error: upsertErr } = await (sb as any)
+    .from("streak_logs")
+    .upsert(rows, { onConflict: "user_id,activity_date" });
+  if (upsertErr) {
+    return { kind: "error", user: user.username, reason: `streak_logs upsert: ${upsertErr.message}` };
+  }
+
+  // 3. Refresh denormalized totals on users
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error: updateErr } = await (sb as any)
+    .from("users")
+    .update({ lifetime_contributions: lifetime, contributions_30d: last30d })
+    .eq("id", user.id);
+  if (updateErr) {
+    return { kind: "error", user: user.username, reason: `users update: ${updateErr.message}` };
+  }
+
+  // 4. Recompute streak + vibe_score via DB function
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error: rpcErr } = await (sb as any).rpc("update_user_streak", {
+    p_user_id: user.id,
+  });
+  if (rpcErr) {
+    return { kind: "error", user: user.username, reason: `update_user_streak: ${rpcErr.message}` };
+  }
+
+  // 5. Read back so the output reflects what actually changed
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: after } = await (sb as any)
+    .from("users")
+    .select("streak, longest_streak, vibe_score")
+    .eq("id", user.id)
+    .single();
+
+  return {
+    kind: "synced",
+    user: user.username,
+    before: {
+      streak: user.streak,
+      longest_streak: user.longest_streak,
+      vibe_score: user.vibe_score,
+    },
+    after: {
+      streak: after?.streak ?? -1,
+      longest_streak: after?.longest_streak ?? -1,
+      vibe_score: after?.vibe_score ?? -1,
+    },
+    dates_logged: rows.length,
+    lifetime,
+    last30d,
+  };
+}
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+
+  // Pull every user who has a github_username set. Order by
+  // lifetime_contributions DESC so the heaviest accounts — the ones whose
+  // streaks you actually care about being fresh — go first. The production
+  // cron does the opposite (ASC) which is why meta_alchemist's row was stale.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: users, error } = await (sb as any)
+    .from("users")
+    .select("id, username, github_username, streak, longest_streak, vibe_score, lifetime_contributions")
+    .not("github_username", "is", null)
+    .neq("github_username", "")
+    .order("lifetime_contributions", { ascending: false, nullsFirst: false });
+  if (error) {
+    console.error("Failed to fetch users:", error.message);
+    process.exit(1);
+  }
+  if (!users || users.length === 0) {
+    console.log("No users with a github_username found.");
+    return;
+  }
+
+  console.log(`\n── Syncing ${users.length} user(s)${dryRun ? " (dry-run, no writes)" : ""} ──\n`);
+
+  let synced = 0;
+  let skipped = 0;
+  let errored = 0;
+  let bumped = 0;
+  for (const u of users as UserRow[]) {
+    const r = await syncOne(u, dryRun);
+    if (r.kind === "error") {
+      errored++;
+      console.log(`  ✗ ${r.user.padEnd(28)}  ${r.reason}`);
+    } else if (r.kind === "skipped") {
+      skipped++;
+      console.log(`  − ${r.user.padEnd(28)}  skipped (${r.reason})`);
+    } else {
+      synced++;
+      const moved =
+        r.after.streak !== r.before.streak || r.after.vibe_score !== r.before.vibe_score;
+      if (moved) bumped++;
+      console.log(
+        `  ${moved ? "✓" : "·"} ${r.user.padEnd(28)}  ` +
+          `streak ${r.before.streak}→${r.after.streak}, ` +
+          `vibe ${r.before.vibe_score}→${r.after.vibe_score}, ` +
+          `${r.dates_logged} dates, lifetime ${r.lifetime}`
+      );
+    }
+    await new Promise((res) => setTimeout(res, RATE_LIMIT_DELAY_MS));
+  }
+
+  console.log(
+    `\nDone: ${synced} synced (${bumped} actually moved), ${skipped} skipped, ${errored} errored.`
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/agent/page.tsx
+++ b/src/app/agent/page.tsx
@@ -205,7 +205,7 @@ export default function AgentHubPage() {
             <code className="text-xs font-mono font-bold text-[var(--accent)]">GET</code>
             <p className="text-sm font-extrabold text-[var(--foreground)] mt-1">/api/v1/builders</p>
             <p className="text-xs text-[var(--text-muted)] font-medium mt-1">
-              Search builders by skills, streak, vibe score. Filter by <code>verified_only=true</code> to surface only GitHub-verified builders.
+              Search builders by skills, streak, vibe score. Filter by <code>verified_only=true</code> to surface builders with at least one GitHub-verified project.
             </p>
           </div>
           <div

--- a/src/app/agent/page.tsx
+++ b/src/app/agent/page.tsx
@@ -205,7 +205,7 @@ export default function AgentHubPage() {
             <code className="text-xs font-mono font-bold text-[var(--accent)]">GET</code>
             <p className="text-sm font-extrabold text-[var(--foreground)] mt-1">/api/v1/builders</p>
             <p className="text-xs text-[var(--text-muted)] font-medium mt-1">
-              Search builders by skills, streak, vibe score. Supports sorting and filtering.
+              Search builders by skills, streak, vibe score. Filter by <code>verified_only=true</code> to surface only GitHub-verified builders.
             </p>
           </div>
           <div
@@ -215,7 +215,7 @@ export default function AgentHubPage() {
             <code className="text-xs font-mono font-bold text-[var(--accent)]">GET</code>
             <p className="text-sm font-extrabold text-[var(--foreground)] mt-1">/api/v1/builders/:username</p>
             <p className="text-xs text-[var(--text-muted)] font-medium mt-1">
-              Get full builder profile with projects, social links, and stats.
+              Full profile + projects with verification status, quality scores, live-URL health, endorsements, and review aggregates.
             </p>
           </div>
           <div

--- a/src/app/api/cron/github-sync/route.ts
+++ b/src/app/api/cron/github-sync/route.ts
@@ -63,16 +63,18 @@ export async function GET(req: NextRequest) {
 
   try {
     // Fetch users with github_username set. Order by lifetime_contributions
-    // ASC NULLS FIRST so unpopulated users get processed first — if the
-    // function still times out, the next run picks up where this one left
-    // off instead of re-doing the same prefix.
+    // DESC NULLS LAST so the platform's heavy users — the ones whose
+    // streaks visibly drive the leaderboard / featured grid — get synced
+    // first. The previous ASC ordering meant if the function timed out
+    // partway through, the back of the queue (heavy users) was the first
+    // thing dropped, leaving them stuck for days.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { data: usersWithGithub, error: usersError } = await (supabase as any)
       .from("users")
       .select("id, username, github_username, lifetime_contributions")
       .not("github_username", "is", null)
       .neq("github_username", "")
-      .order("lifetime_contributions", { ascending: true, nullsFirst: true });
+      .order("lifetime_contributions", { ascending: false, nullsFirst: false });
 
     if (usersError) {
       console.error("Failed to fetch users:", usersError);
@@ -280,20 +282,27 @@ export async function GET(req: NextRequest) {
               return { userInfo, status: "skipped", reason: "No GitHub activity in last year" };
             }
 
-            // Upsert streak_logs with real per-day counts. Only writes dates
-            // that have new data; existing entries past the cron window stay
-            // unchanged and continue contributing to the streak calculation.
-            let loggedCount = 0;
-            for (const [activityDate, count] of dateCounts.entries()) {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              const { error } = await (supabase as any)
-                .from("streak_logs")
-                .upsert(
-                  { user_id: userInfo.userId, activity_date: activityDate, commit_count: count },
-                  { onConflict: "user_id,activity_date" }
-                );
-
-              if (!error) loggedCount++;
+            // Upsert streak_logs with real per-day counts in a single batch
+            // round-trip. The previous per-row loop fired N sequential
+            // requests (200+ for heavy users), which routinely blew the
+            // 5-min serverless budget and starved the back of the queue.
+            const streakRows = Array.from(dateCounts.entries()).map(
+              ([activity_date, commit_count]) => ({
+                user_id: userInfo.userId,
+                activity_date,
+                commit_count,
+              })
+            );
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const { error: streakUpsertError } = await (supabase as any)
+              .from("streak_logs")
+              .upsert(streakRows, { onConflict: "user_id,activity_date" });
+            const loggedCount = streakUpsertError ? 0 : streakRows.length;
+            if (streakUpsertError) {
+              console.error(
+                `streak_logs batch upsert failed for ${userInfo.githubUsername}:`,
+                streakUpsertError
+              );
             }
 
             // Update denormalized totals on users so update_user_streak can

--- a/src/app/api/cron/github-sync/route.ts
+++ b/src/app/api/cron/github-sync/route.ts
@@ -297,13 +297,22 @@ export async function GET(req: NextRequest) {
             const { error: streakUpsertError } = await (supabase as any)
               .from("streak_logs")
               .upsert(streakRows, { onConflict: "user_id,activity_date" });
-            const loggedCount = streakUpsertError ? 0 : streakRows.length;
             if (streakUpsertError) {
+              // Bail out: running update_user_streak against stale streak_logs
+              // would either return the existing (incorrect) streak or compute
+              // from partial data. Better to surface the failure to the cron
+              // summary so the next run retries cleanly.
               console.error(
                 `streak_logs batch upsert failed for ${userInfo.githubUsername}:`,
                 streakUpsertError
               );
+              return {
+                userInfo,
+                status: "error",
+                reason: `streak_logs upsert failed: ${streakUpsertError.message}`,
+              };
             }
+            const loggedCount = streakRows.length;
 
             // Update denormalized totals on users so update_user_streak can
             // read them when computing the volume bonus.

--- a/src/app/api/cron/verify-backfill/route.ts
+++ b/src/app/api/cron/verify-backfill/route.ts
@@ -56,6 +56,32 @@ export async function GET(req: NextRequest) {
     // projects once the stuck backlog exceeds MAX_PROJECTS_PER_RUN.
     const retryWindow = new Date(Date.now() - RETRY_WINDOW_DAYS * 24 * 60 * 60 * 1000).toISOString();
 
+    // Pre-fetch the set of user IDs that actually have a github_username set,
+    // so the candidate query can exclude projects whose owner can't be
+    // owner-matched anyway. Without this prefilter, the LIMIT(MAX_PROJECTS_PER_RUN)
+    // budget could be entirely consumed by missing-username rows that we now
+    // skip without stamping (which would let them re-enter the next run forever),
+    // starving legitimate owner-mismatch retries.
+    const { data: linkedUserRows, error: linkedUsersError } = await sb
+      .from("users")
+      .select("id, github_username")
+      .not("github_username", "is", null)
+      .neq("github_username", "");
+
+    if (linkedUsersError) {
+      console.error("verify-backfill: failed to fetch linked users:", linkedUsersError);
+      return NextResponse.json({ error: "Failed to fetch users" }, { status: 500 });
+    }
+
+    const usernameById = new Map<string, string>();
+    for (const row of (linkedUserRows ?? []) as { id: string; github_username: string }[]) {
+      if (row.github_username) usernameById.set(row.id, row.github_username);
+    }
+
+    if (usernameById.size === 0) {
+      return NextResponse.json({ message: "No users with github_username set", verified: 0 });
+    }
+
     // Two classes of candidates:
     //   1. verified=false — never (successfully) verified yet.
     //   2. verified=true AND quality_metrics IS NULL — legacy rows from the
@@ -71,6 +97,7 @@ export async function GET(req: NextRequest) {
       .not("github_url", "is", null)
       .neq("github_url", "")
       .or(`last_verify_attempt_at.is.null,last_verify_attempt_at.lt.${retryWindow}`)
+      .in("user_id", Array.from(usernameById.keys()))
       .order("created_at", { ascending: true })
       .limit(MAX_PROJECTS_PER_RUN);
 
@@ -81,22 +108,6 @@ export async function GET(req: NextRequest) {
 
     if (!candidates || candidates.length === 0) {
       return NextResponse.json({ message: "No unverified projects to check", verified: 0 });
-    }
-
-    // Resolve each candidate's GitHub handle from the authoritative DB column.
-    // One query for all users referenced by the batch avoids per-project lookups.
-    const userIds: string[] = Array.from(
-      new Set(candidates.map((p: { user_id: string }) => p.user_id))
-    );
-    const { data: userRows } = await sb
-      .from("users")
-      .select("id, github_username")
-      .in("id", userIds)
-      .not("github_username", "is", null);
-
-    const usernameById = new Map<string, string>();
-    for (const row of (userRows ?? []) as { id: string; github_username: string }[]) {
-      if (row.github_username) usernameById.set(row.id, row.github_username);
     }
 
     // Stamp non-verifiable-via-owner-match projects so the next run skips them
@@ -135,10 +146,12 @@ export async function GET(req: NextRequest) {
 
               const githubUsername = usernameById.get(project.user_id);
               if (!githubUsername) {
+                // Defensive: the SQL prefilter above narrows candidates to
+                // user_ids that have a github_username, so this should be
+                // unreachable unless the user row was deleted mid-run. Skip
+                // without stamping — if the user re-appears with a username,
+                // the next run will pick this project up immediately.
                 skipped++;
-                // Don't stamp last_verify_attempt_at — missing github_username
-                // is recoverable (user links GitHub later). Stamping forces a
-                // 7-day wait even after the user fixes it on their end.
                 return;
               }
 

--- a/src/app/api/cron/verify-backfill/route.ts
+++ b/src/app/api/cron/verify-backfill/route.ts
@@ -6,6 +6,12 @@ import { createNotification } from "@/lib/notifications";
 const BATCH_SIZE = 5;
 const BATCH_DELAY_MS = 2500;
 const MAX_PROJECTS_PER_RUN = 200;
+// Hard ceiling on the linked-users prefetch. PostgREST silently caps
+// .select() at 1,000 rows by default; without an explicit .range() the
+// prefilter would start missing legitimate users once the platform crosses
+// 1k. 100k is several orders of magnitude above current size and still
+// well under any sensible memory limit.
+const MAX_LINKED_USERS = 100_000;
 // How long to wait before re-attempting a project that we couldn't verify
 // (owner mismatch, missing github_username, unparseable URL). Transient
 // GitHub API failures don't bump this timestamp so they retry next run.
@@ -66,7 +72,9 @@ export async function GET(req: NextRequest) {
       .from("users")
       .select("id, github_username")
       .not("github_username", "is", null)
-      .neq("github_username", "");
+      .neq("github_username", "")
+      .order("id", { ascending: true })
+      .range(0, MAX_LINKED_USERS - 1);
 
     if (linkedUsersError) {
       console.error("verify-backfill: failed to fetch linked users:", linkedUsersError);
@@ -80,6 +88,12 @@ export async function GET(req: NextRequest) {
 
     if (usernameById.size === 0) {
       return NextResponse.json({ message: "No users with github_username set", verified: 0 });
+    }
+
+    if (usernameById.size === MAX_LINKED_USERS) {
+      console.warn(
+        `verify-backfill: hit MAX_LINKED_USERS=${MAX_LINKED_USERS} cap on the user prefetch — bump the constant if the platform has grown beyond that.`
+      );
     }
 
     // Two classes of candidates:

--- a/src/app/api/cron/verify-backfill/route.ts
+++ b/src/app/api/cron/verify-backfill/route.ts
@@ -136,7 +136,9 @@ export async function GET(req: NextRequest) {
               const githubUsername = usernameById.get(project.user_id);
               if (!githubUsername) {
                 skipped++;
-                await markAttempted(project.id);
+                // Don't stamp last_verify_attempt_at — missing github_username
+                // is recoverable (user links GitHub later). Stamping forces a
+                // 7-day wait even after the user fixes it on their end.
                 return;
               }
 

--- a/src/app/api/projects/verify/route.ts
+++ b/src/app/api/projects/verify/route.ts
@@ -1,7 +1,36 @@
 import { NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { createNotification } from "@/lib/notifications";
 import { analyzeRepository, checkLiveUrl, parseGithubRepoUrl } from "@/lib/github-quality";
+
+/**
+ * Invalidate the cached profile read so the new "Verified" badge appears
+ * immediately instead of waiting up to 60s for the unstable_cache TTL on
+ * fetchUserByUsernameCached. Returns silently if the username can't be
+ * resolved — caching is best-effort.
+ */
+async function invalidateProfileCache(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sb: any,
+  userId: string
+): Promise<void> {
+  try {
+    const { data: userRow } = await sb
+      .from("users")
+      .select("username")
+      .eq("id", userId)
+      .single();
+    if (userRow?.username) {
+      // Mirror the call shape used by /api/endorsements: { expire: 0 } forces
+      // the tagged cache entry to be evicted immediately rather than on its
+      // next read. Next.js 16 made the second arg required.
+      revalidateTag(`user-${userRow.username}`, { expire: 0 });
+    }
+  } catch (err) {
+    console.error("Failed to revalidate profile cache after verify:", err);
+  }
+}
 
 export async function POST(request: Request) {
   try {
@@ -155,6 +184,10 @@ export async function POST(request: Request) {
         metadata: { project_id, quality_score: qualityScore },
       }).catch(console.error);
 
+      // Bust the profile cache so the new badge appears on the next page
+      // visit instead of waiting up to 60s for unstable_cache to expire.
+      await invalidateProfileCache(sb, user.id);
+
       return NextResponse.json({
         verified: true,
         reason: "Repository owner matches your GitHub username.",
@@ -242,6 +275,10 @@ export async function POST(request: Request) {
             message: `Your project has been verified via verification file. Quality score: ${qualityScore}/100.`,
             metadata: { project_id, quality_score: qualityScore },
           }).catch(console.error);
+
+          // Bust the profile cache so the new badge appears immediately
+          // instead of waiting up to 60s for unstable_cache to expire.
+          await invalidateProfileCache(sb, user.id);
 
           return NextResponse.json({
             verified: true,

--- a/src/app/api/v1/builders/[username]/route.ts
+++ b/src/app/api/v1/builders/[username]/route.ts
@@ -39,7 +39,7 @@ export async function GET(
     const [
       { data: projects, error: projectsError },
       { data: socialLinks, error: socialLinksError },
-      { data: reviews },
+      { data: reviews, error: reviewsError },
     ] = await Promise.all([
       (supabase as any)
         .from("projects")
@@ -73,6 +73,17 @@ export async function GET(
       console.error("Failed to fetch social links:", socialLinksError);
       return NextResponse.json(
         { error: "Failed to fetch social links" },
+        { status: 500, headers: corsHeaders }
+      );
+    }
+
+    if (reviewsError) {
+      // Don't silently treat a transient DB failure as "0 trusted reviews" —
+      // an agent making a hire decision based on review_count would otherwise
+      // see false-zeros that look identical to a builder with no reviews.
+      console.error("Failed to fetch reviews:", reviewsError);
+      return NextResponse.json(
+        { error: "Failed to fetch reviews" },
         { status: 500, headers: corsHeaders }
       );
     }

--- a/src/app/api/v1/builders/[username]/route.ts
+++ b/src/app/api/v1/builders/[username]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { extractSocialHandle } from "@/lib/social-handles";
+import { getSiteUrl } from "@/lib/seo";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -33,12 +34,18 @@ export async function GET(
       );
     }
 
-    // Fetch projects and social links in parallel
+    // Fetch projects, social links, and review aggregates in parallel
     /* eslint-disable @typescript-eslint/no-explicit-any */
-    const [{ data: projects, error: projectsError }, { data: socialLinks, error: socialLinksError }] = await Promise.all([
+    const [
+      { data: projects, error: projectsError },
+      { data: socialLinks, error: socialLinksError },
+      { data: reviews },
+    ] = await Promise.all([
       (supabase as any)
         .from("projects")
-        .select("id, title, description, tech_stack, live_url, github_url, image_url, build_time, tags, created_at")
+        .select(
+          "id, title, description, tech_stack, live_url, github_url, image_url, build_time, tags, verified, quality_score, quality_metrics, live_url_ok, endorsement_count, created_at"
+        )
         .eq("user_id", user.id)
         .eq("flagged", false)
         .order("created_at", { ascending: false }),
@@ -47,6 +54,10 @@ export async function GET(
         .select("twitter, telegram, github, website, farcaster")
         .eq("user_id", user.id)
         .single(),
+      (supabase as any)
+        .from("reviews")
+        .select("rating, trust_score")
+        .eq("builder_id", user.id),
     ]);
     /* eslint-enable @typescript-eslint/no-explicit-any */
 
@@ -66,8 +77,26 @@ export async function GET(
       );
     }
 
+    // Average only trust-scored reviews (>= 30) to mirror the public profile.
+    const trustedReviews = (reviews || []).filter(
+      (r: { trust_score?: number | null }) => (r.trust_score ?? 100) >= 30
+    );
+    const averageRating =
+      trustedReviews.length > 0
+        ? Math.round(
+            (trustedReviews.reduce(
+              (sum: number, r: { rating: number }) => sum + r.rating,
+              0
+            ) /
+              trustedReviews.length) *
+              10
+          ) / 10
+        : null;
+
+    const siteUrl = getSiteUrl();
     const builder = {
       username: user.username,
+      profile_url: `${siteUrl}/profile/${user.username}`,
       bio: user.bio,
       avatar_url: user.avatar_url,
       vibe_score: user.vibe_score,
@@ -75,6 +104,8 @@ export async function GET(
       longest_streak: user.longest_streak,
       badge_level: user.badge_level,
       created_at: user.created_at,
+      review_count: trustedReviews.length,
+      average_rating: averageRating,
       projects: (projects || []).map(
         (p: {
           id: string;
@@ -86,6 +117,11 @@ export async function GET(
           image_url: string | null;
           build_time: string | null;
           tags: string[];
+          verified: boolean;
+          quality_score: number | null;
+          quality_metrics: Record<string, unknown> | null;
+          live_url_ok: boolean | null;
+          endorsement_count: number;
           created_at: string;
         }) => ({
           id: p.id,
@@ -97,6 +133,11 @@ export async function GET(
           image_url: p.image_url,
           build_time: p.build_time,
           tags: p.tags,
+          verified: p.verified,
+          quality_score: p.quality_score,
+          quality_metrics: p.quality_metrics,
+          live_url_ok: p.live_url_ok,
+          endorsement_count: p.endorsement_count,
           created_at: p.created_at,
         })
       ),

--- a/src/app/api/v1/builders/route.ts
+++ b/src/app/api/v1/builders/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { buildersLimiter, checkRateLimit, getIP } from "@/lib/rate-limit";
+import { getSiteUrl } from "@/lib/seo";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -22,6 +23,7 @@ export async function GET(req: NextRequest) {
     const skills = searchParams.get("skills");
     const minStreak = searchParams.get("min_streak");
     const minVibeScore = searchParams.get("min_vibe_score");
+    const verifiedOnly = searchParams.get("verified_only") === "true";
     const sort = searchParams.get("sort") || "vibe_score";
     const limitParam = Math.min(
       Math.max(parseInt(searchParams.get("limit") || "20", 10) || 20, 1),
@@ -72,7 +74,7 @@ export async function GET(req: NextRequest) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { data: projects, error: projectsError } = await (supabase as any)
       .from("projects")
-      .select("user_id, tech_stack")
+      .select("user_id, tech_stack, verified")
       .in("user_id", userIds)
       .eq("flagged", false);
 
@@ -86,18 +88,24 @@ export async function GET(req: NextRequest) {
 
     // Build per-user project counts and aggregated tech stacks
     const projectCountMap: Record<string, number> = {};
+    const verifiedCountMap: Record<string, number> = {};
     const techStackMap: Record<string, Set<string>> = {};
     for (const p of projects || []) {
       projectCountMap[p.user_id] = (projectCountMap[p.user_id] || 0) + 1;
+      if (p.verified) {
+        verifiedCountMap[p.user_id] = (verifiedCountMap[p.user_id] || 0) + 1;
+      }
       if (!techStackMap[p.user_id]) techStackMap[p.user_id] = new Set();
       for (const tech of p.tech_stack || []) {
         techStackMap[p.user_id].add(tech);
       }
     }
 
+    const siteUrl = getSiteUrl();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let builders = users.map((user: any) => ({
       username: user.username,
+      profile_url: `${siteUrl}/profile/${user.username}`,
       bio: user.bio,
       avatar_url: user.avatar_url,
       vibe_score: user.vibe_score,
@@ -105,8 +113,16 @@ export async function GET(req: NextRequest) {
       longest_streak: user.longest_streak,
       badge_level: user.badge_level,
       projects_count: projectCountMap[user.id] || 0,
+      verified_projects_count: verifiedCountMap[user.id] || 0,
       tech_stack: Array.from(techStackMap[user.id] || []),
     }));
+
+    // Filter to builders with at least one verified project, if requested
+    if (verifiedOnly) {
+      builders = builders.filter(
+        (b: { verified_projects_count: number }) => b.verified_projects_count > 0
+      );
+    }
 
     // Filter by skills if provided
     if (skills) {

--- a/src/app/api/v1/builders/route.ts
+++ b/src/app/api/v1/builders/route.ts
@@ -44,6 +44,36 @@ export async function GET(req: NextRequest) {
       query = query.gte("vibe_score", isNaN(parsed) ? 0 : parsed);
     }
 
+    // Apply verified_only at the SQL level so LIMIT counts post-filter rows.
+    // Doing it after the limit (as we do for skills/sort=projects below) would
+    // underfill responses — agents asking for limit=20 verified builders could
+    // get back 3 because the in-memory filter dropped the rest.
+    if (verifiedOnly) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data: verifiedRows, error: verifiedErr } = await (supabase as any)
+        .from("projects")
+        .select("user_id")
+        .eq("verified", true)
+        .eq("flagged", false);
+      if (verifiedErr) {
+        console.error("Failed to resolve verified user_ids:", verifiedErr);
+        return NextResponse.json(
+          { error: "Failed to apply verified_only filter" },
+          { status: 500, headers: corsHeaders }
+        );
+      }
+      const verifiedUserIds = Array.from(
+        new Set((verifiedRows || []).map((r: { user_id: string }) => r.user_id))
+      );
+      if (verifiedUserIds.length === 0) {
+        return NextResponse.json(
+          { builders: [], total: 0 },
+          { headers: corsHeaders }
+        );
+      }
+      query = query.in("id", verifiedUserIds);
+    }
+
     const sortColumn =
       sort === "streak"
         ? "streak"
@@ -117,12 +147,8 @@ export async function GET(req: NextRequest) {
       tech_stack: Array.from(techStackMap[user.id] || []),
     }));
 
-    // Filter to builders with at least one verified project, if requested
-    if (verifiedOnly) {
-      builders = builders.filter(
-        (b: { verified_projects_count: number }) => b.verified_projects_count > 0
-      );
-    }
+    // verified_only is now applied at the SQL level above (so LIMIT counts
+    // post-filter rows) — no in-memory filter needed here.
 
     // Filter by skills if provided
     if (skills) {

--- a/src/app/api/v1/builders/route.ts
+++ b/src/app/api/v1/builders/route.ts
@@ -49,17 +49,30 @@ export async function GET(req: NextRequest) {
     // underfill responses — agents asking for limit=20 verified builders could
     // get back 3 because the in-memory filter dropped the rest.
     if (verifiedOnly) {
+      // PostgREST defaults to a 1,000-row cap on .select() — without an
+      // explicit .range() the verified-projects fanout would silently
+      // truncate once the platform crosses 1k verified projects (one heavy
+      // builder × multiple verified projects gets there fast). 100k ceiling
+      // is well above current scale and still trivial to deduplicate in JS.
+      const MAX_VERIFIED_PROJECTS = 100_000;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const { data: verifiedRows, error: verifiedErr } = await (supabase as any)
         .from("projects")
         .select("user_id")
         .eq("verified", true)
-        .eq("flagged", false);
+        .eq("flagged", false)
+        .order("user_id", { ascending: true })
+        .range(0, MAX_VERIFIED_PROJECTS - 1);
       if (verifiedErr) {
         console.error("Failed to resolve verified user_ids:", verifiedErr);
         return NextResponse.json(
           { error: "Failed to apply verified_only filter" },
           { status: 500, headers: corsHeaders }
+        );
+      }
+      if ((verifiedRows?.length ?? 0) === MAX_VERIFIED_PROJECTS) {
+        console.warn(
+          `v1/builders: hit MAX_VERIFIED_PROJECTS=${MAX_VERIFIED_PROJECTS} cap — bump if the platform has grown beyond that.`
         );
       }
       const verifiedUserIds = Array.from(

--- a/src/app/api/v1/openapi/route.ts
+++ b/src/app/api/v1/openapi/route.ts
@@ -51,6 +51,13 @@ export async function GET() {
               schema: { type: "integer" },
             },
             {
+              name: "verified_only",
+              in: "query",
+              description:
+                "If true, only return builders with at least one GitHub-verified project (recommended for hire decisions).",
+              schema: { type: "boolean", default: false },
+            },
+            {
               name: "sort",
               in: "query",
               description: "Sort field",
@@ -184,6 +191,11 @@ export async function GET() {
           type: "object",
           properties: {
             username: { type: "string" },
+            profile_url: {
+              type: "string",
+              format: "uri",
+              description: "Direct URL to the builder's public profile.",
+            },
             bio: { type: "string", nullable: true },
             avatar_url: { type: "string", nullable: true },
             vibe_score: { type: "integer" },
@@ -194,6 +206,11 @@ export async function GET() {
               enum: ["none", "bronze", "silver", "gold", "diamond"],
             },
             projects_count: { type: "integer" },
+            verified_projects_count: {
+              type: "integer",
+              description:
+                "How many of the builder's projects are GitHub-verified (owner-match or .vibetalent file).",
+            },
             tech_stack: { type: "array", items: { type: "string" } },
           },
         },
@@ -201,6 +218,7 @@ export async function GET() {
           type: "object",
           properties: {
             username: { type: "string" },
+            profile_url: { type: "string", format: "uri" },
             bio: { type: "string", nullable: true },
             avatar_url: { type: "string", nullable: true },
             vibe_score: { type: "integer" },
@@ -211,6 +229,15 @@ export async function GET() {
               enum: ["none", "bronze", "silver", "gold", "diamond"],
             },
             created_at: { type: "string", format: "date-time" },
+            review_count: {
+              type: "integer",
+              description: "Trust-scored review count (anti-abuse filter applied).",
+            },
+            average_rating: {
+              type: "number",
+              nullable: true,
+              description: "Average of trust-scored reviews (1-5), null if no reviews.",
+            },
             projects: {
               type: "array",
               items: { $ref: "#/components/schemas/Project" },
@@ -233,6 +260,33 @@ export async function GET() {
             image_url: { type: "string", nullable: true },
             build_time: { type: "string", nullable: true },
             tags: { type: "array", items: { type: "string" } },
+            verified: {
+              type: "boolean",
+              description:
+                "True when GitHub ownership is verified (owner-match or .vibetalent file).",
+            },
+            quality_score: {
+              type: "integer",
+              nullable: true,
+              description:
+                "Composite 0-100 score from public GitHub signals (community, substance, maintenance).",
+            },
+            quality_metrics: {
+              type: "object",
+              nullable: true,
+              description:
+                "Raw signals — stars, forks, contributors, total_commits, has_tests, has_ci, has_readme, sub-scores, analyzed_at.",
+              additionalProperties: true,
+            },
+            live_url_ok: {
+              type: "boolean",
+              nullable: true,
+              description: "True if the live_url responded healthily on the last check.",
+            },
+            endorsement_count: {
+              type: "integer",
+              description: "Public endorsements from other builders.",
+            },
             created_at: { type: "string", format: "date-time" },
           },
         },

--- a/src/app/skill.md/route.ts
+++ b/src/app/skill.md/route.ts
@@ -34,12 +34,13 @@ GET ${SITE_URL}/api/v1/builders
 - \`skills\` (string, comma-separated) — Filter by tech stack (e.g. "react,python,nextjs")
 - \`min_streak\` (number) — Minimum streak days (e.g. 7)
 - \`min_vibe_score\` (number) — Minimum vibe score (e.g. 20)
+- \`verified_only\` (boolean) — If \`true\`, return only builders with at least one GitHub-verified project. Recommended for hire decisions.
 - \`sort\` (string) — Sort by: "vibe_score" (default), "streak", or "projects"
 - \`limit\` (number) — Results per page, max 100 (default 20)
 
 **Example:**
 \`\`\`
-GET ${SITE_URL}/api/v1/builders?skills=react,nextjs&min_streak=7&sort=vibe_score&limit=10
+GET ${SITE_URL}/api/v1/builders?skills=react,nextjs&min_streak=7&verified_only=true&sort=vibe_score&limit=10
 \`\`\`
 
 **Response:**
@@ -48,6 +49,7 @@ GET ${SITE_URL}/api/v1/builders?skills=react,nextjs&min_streak=7&sort=vibe_score
   "builders": [
     {
       "username": "abhinav",
+      "profile_url": "${SITE_URL}/profile/abhinav",
       "bio": "Full stack builder shipping daily",
       "avatar_url": "https://...",
       "vibe_score": 25,
@@ -55,8 +57,8 @@ GET ${SITE_URL}/api/v1/builders?skills=react,nextjs&min_streak=7&sort=vibe_score
       "longest_streak": 10,
       "badge_level": "none",
       "projects_count": 3,
-      "tech_stack": ["react", "nextjs", "python"],
-      "profile_url": "${SITE_URL}/profile/abhinav"
+      "verified_projects_count": 2,
+      "tech_stack": ["react", "nextjs", "python"]
     }
   ],
   "total": 1
@@ -79,31 +81,46 @@ GET ${SITE_URL}/api/v1/builders/abhinav
 **Response:**
 \`\`\`json
 {
-  "username": "abhinav",
-  "bio": "Full stack builder shipping daily",
-  "avatar_url": "https://...",
-  "vibe_score": 25,
-  "streak": 5,
-  "longest_streak": 10,
-  "badge_level": "none",
-  "created_at": "2026-03-15T...",
-  "projects": [
-    {
-      "title": "Doomscrolling Alarm",
-      "description": "Stay locked in on building",
-      "tech_stack": ["python"],
-      "live_url": null,
-      "github_url": "https://github.com/...",
-      "build_time": "1 day",
-      "tags": ["fun"]
+  "builder": {
+    "username": "abhinav",
+    "profile_url": "${SITE_URL}/profile/abhinav",
+    "bio": "Full stack builder shipping daily",
+    "avatar_url": "https://...",
+    "vibe_score": 25,
+    "streak": 5,
+    "longest_streak": 10,
+    "badge_level": "none",
+    "created_at": "2026-03-15T...",
+    "review_count": 2,
+    "average_rating": 4.5,
+    "projects": [
+      {
+        "id": "uuid-here",
+        "title": "Doomscrolling Alarm",
+        "description": "Stay locked in on building",
+        "tech_stack": ["python"],
+        "live_url": "https://example.com",
+        "github_url": "https://github.com/owner/repo",
+        "build_time": "1 day",
+        "tags": ["fun"],
+        "verified": true,
+        "quality_score": 72,
+        "quality_metrics": {
+          "stars": 14, "forks": 2, "contributors": 1, "total_commits": 42,
+          "has_tests": true, "has_ci": true, "has_readme": true,
+          "community_score": 60, "substance_score": 78, "maintenance_score": 80
+        },
+        "live_url_ok": true,
+        "endorsement_count": 3,
+        "created_at": "2026-03-20T..."
+      }
+    ],
+    "social_links": {
+      "twitter": "abhiontwt",
+      "github": "unknownking07",
+      "website": null
     }
-  ],
-  "social_links": {
-    "twitter": "abhiontwt",
-    "github": "unknownking07",
-    "website": null
-  },
-  "profile_url": "${SITE_URL}/profile/abhinav"
+  }
 }
 \`\`\`
 
@@ -163,12 +180,41 @@ Formula: \`(current_streak * 2) + (projects * 5) + badge_bonus\`
 - **Gold**: 180+ days (bonus: +30)
 - **Diamond**: 365+ days (bonus: +40)
 
+### Project Verification (\`verified\`)
+A project is \`verified: true\` when its GitHub repo ownership is proven — either the
+repo owner matches the builder's linked GitHub username, or the repo contains a
+\`.vibetalent\` file with the builder's username/user ID. **Strongly prefer verified
+projects** when evaluating builders — unverified projects are unproven claims.
+
+### Quality Score (\`quality_score\`, 0-100)
+Composite score derived from public GitHub signals — community (stars, forks,
+external contributors), substance (languages, file structure, tests, CI, README),
+and maintenance (commit cadence, recency). Hard to game. Available on verified
+projects.
+
+\`quality_metrics\` exposes the raw signals (stars, forks, contributors,
+total_commits, has_tests, has_ci, has_readme, plus sub-scores) so agents can
+weight them differently if they want.
+
+### Live URL Health (\`live_url_ok\`)
+\`true\` if the project's \`live_url\` responded healthily on the most recent check.
+\`false\` means the deployment is broken or unreachable. \`null\` means no live URL.
+
+### Endorsements (\`endorsement_count\`)
+Peer endorsements from other builders on the platform. Social-proof signal.
+
+### Reviews (\`review_count\`, \`average_rating\`)
+Reviews are filtered by an anti-abuse trust score before averaging — only
+\`trust_score >= 30\` reviews count. \`average_rating\` is null when the builder
+has no trusted reviews.
+
 ### How to Pick the Best Builder
-1. Sort by \`vibe_score\` for overall best
-2. Check \`streak\` for consistency
-3. Look at \`tech_stack\` for skill match
-4. Review \`projects\` for relevant experience
-5. Higher badge = proven long-term builder
+1. Filter with \`verified_only=true\` to skip unverified claims
+2. Sort by \`vibe_score\` for overall activity, but cross-check with \`verified_projects_count\`
+3. Pull the full profile and check each project's \`quality_score\` and \`live_url_ok\`
+4. Look at \`endorsement_count\` and \`average_rating\` for social proof
+5. Match \`tech_stack\` to your project requirements
+6. Higher badge level = longer-proven consistency
 
 ---
 
@@ -183,7 +229,11 @@ Formula: \`(current_streak * 2) + (projects * 5) + badge_bonus\`
 ## Tips for AI Agents
 
 - Always search with specific skills to get relevant results
+- Pass \`verified_only=true\` to skip builders whose project ownership is unproven
 - Use \`min_streak=3\` to filter out inactive builders
+- Pull the full profile (\`/builders/:username\`) before deciding — \`projects_count\` and
+  \`tech_stack\` summary aren't enough; check each project's \`verified\`, \`quality_score\`,
+  and \`live_url_ok\`
 - Include a clear project description in hire requests for better response rates
 - The chat_url returned from hire requests can be shared with your human for follow-up
 - Budget field is optional but builders respond faster when it's included

--- a/src/app/skill.md/route.ts
+++ b/src/app/skill.md/route.ts
@@ -198,7 +198,9 @@ weight them differently if they want.
 
 ### Live URL Health (\`live_url_ok\`)
 \`true\` if the project's \`live_url\` responded healthily on the most recent check.
-\`false\` means the deployment is broken or unreachable. \`null\` means no live URL.
+\`false\` means the deployment is broken or unreachable. \`null\` means either no
+\`live_url\` is set or the first health check hasn't run yet — treat null as
+"unknown" rather than "healthy" or "broken".
 
 ### Endorsements (\`endorsement_count\`)
 Peer endorsements from other builders on the platform. Social-proof signal.

--- a/src/components/explore/explore-content.tsx
+++ b/src/components/explore/explore-content.tsx
@@ -329,12 +329,12 @@ export function ExploreContent({ users }: { users: UserWithSocials[] }) {
         </div>
       )}
 
-      {/* Results count */}
-      <p className="mb-4 text-sm font-bold uppercase tracking-wide text-[var(--text-muted)]">
-        {filteredUsers.length > PAGE_SIZE
-          ? `Showing ${(activePage - 1) * PAGE_SIZE + 1}–${Math.min(activePage * PAGE_SIZE, filteredUsers.length)} of ${filteredUsers.length} builders`
-          : `${filteredUsers.length} builder${filteredUsers.length !== 1 ? "s" : ""} found`}
-      </p>
+      {/* Results count — only shown when no pagination is needed; paginated case puts the count inside <Pagination /> */}
+      {filteredUsers.length > 0 && filteredUsers.length <= PAGE_SIZE && (
+        <p className="mb-4 text-sm font-bold uppercase tracking-wide text-[var(--text-muted)]">
+          {filteredUsers.length} builder{filteredUsers.length !== 1 ? "s" : ""} found
+        </p>
+      )}
 
       {/* Grid */}
       {filteredUsers.length > 0 ? (
@@ -347,7 +347,15 @@ export function ExploreContent({ users }: { users: UserWithSocials[] }) {
 
           {/* Pagination */}
           <div className="mt-10">
-            <Pagination currentPage={activePage} totalPages={totalPages} onPageChange={goToPage} />
+            <Pagination
+              currentPage={activePage}
+              totalPages={totalPages}
+              onPageChange={goToPage}
+              label="Builders Directory"
+              pageSize={PAGE_SIZE}
+              totalItems={filteredUsers.length}
+              itemNoun="builders"
+            />
           </div>
         </>
       ) : (

--- a/src/components/leaderboard/leaderboard-content.tsx
+++ b/src/components/leaderboard/leaderboard-content.tsx
@@ -232,14 +232,17 @@ export function LeaderboardContent({ users }: { users: UserWithSocials[] }) {
         </table>
       </div>
 
-      {/* Results count + Pagination */}
+      {/* Pagination (count + eyebrow rendered inside) */}
       {sortedUsers.length > PAGE_SIZE && (
-        <>
-          <p className="mt-4 text-sm font-bold uppercase tracking-wide text-[var(--text-muted)] text-center">
-            Showing {(activePage - 1) * PAGE_SIZE + 1}–{Math.min(activePage * PAGE_SIZE, sortedUsers.length)} of {sortedUsers.length} builders
-          </p>
-          <Pagination currentPage={activePage} totalPages={totalPages} onPageChange={goToPage} />
-        </>
+        <Pagination
+          currentPage={activePage}
+          totalPages={totalPages}
+          onPageChange={goToPage}
+          label="Leaderboard"
+          pageSize={PAGE_SIZE}
+          totalItems={sortedUsers.length}
+          itemNoun="builders"
+        />
       )}
     </>
   );

--- a/src/components/profile/profile-project-card.tsx
+++ b/src/components/profile/profile-project-card.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { ExternalLink, Flag, CheckCircle, Undo2, Github } from "lucide-react";
+import { ExternalLink, Flag, CheckCircle, Undo2, Github, ShieldCheck } from "lucide-react";
+import { useRouter } from "next/navigation";
 import Image from "next/image";
 import type { Project } from "@/lib/types/database";
 import { QualityScoreBadge } from "@/components/ui/quality-score-badge";
@@ -35,12 +36,38 @@ function clearReportData(projectId: string) {
 }
 
 export function ProfileProjectCard({ project, verified = false, isOwner = false }: ProfileProjectCardProps) {
+  const router = useRouter();
   const [showReportMenu, setShowReportMenu] = useState(false);
   const [reported, setReported] = useState(() => !!getReportData(project.id));
   const [undoing, setUndoing] = useState(false);
   const [expanded, setExpanded] = useState(false);
+  const [verifying, setVerifying] = useState(false);
+  const [verifyMessage, setVerifyMessage] = useState<{ success: boolean; text: string } | null>(null);
   const reportRef = useRef<HTMLDivElement>(null);
   const isLongDescription = (project.description?.length ?? 0) > 280;
+
+  async function handleVerify() {
+    if (verifying) return;
+    setVerifying(true);
+    setVerifyMessage(null);
+    try {
+      const res = await fetch("/api/projects/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ project_id: project.id }),
+      });
+      const data = await res.json();
+      if (data.verified) {
+        setVerifyMessage({ success: true, text: data.reason || "Project verified!" });
+        router.refresh();
+      } else {
+        setVerifyMessage({ success: false, text: data.reason || data.error || "Verification failed." });
+      }
+    } catch {
+      setVerifyMessage({ success: false, text: "Verification request failed." });
+    }
+    setVerifying(false);
+  }
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
@@ -248,6 +275,29 @@ export function ProfileProjectCard({ project, verified = false, isOwner = false 
           </span>
         ))}
       </div>
+
+      {isOwner && !verified && project.github_url && (
+        <div className="mt-2 flex flex-col gap-1.5">
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); handleVerify(); }}
+            disabled={verifying}
+            className="self-start inline-flex items-center gap-1 px-2.5 py-1 text-[10px] font-bold uppercase text-[var(--foreground)] border-2 border-[var(--border-hard)] bg-[var(--bg-surface)] hover:bg-[var(--bg-surface-light)] transition-colors disabled:opacity-50"
+            title="Verify GitHub ownership"
+          >
+            <ShieldCheck size={12} />
+            {verifying ? "Verifying..." : "Verify"}
+          </button>
+          {verifyMessage && (
+            <p
+              className={`text-[11px] font-bold ${verifyMessage.success ? "text-green-700" : "text-red-600"}`}
+              role="status"
+            >
+              {verifyMessage.text}
+            </p>
+          )}
+        </div>
+      )}
 
       {reportStatus === "success" && (
         <p className="text-xs font-bold text-green-700 mt-2">Thanks for the report! We&apos;ll review this project shortly.</p>

--- a/src/components/profile/reviews-section.tsx
+++ b/src/components/profile/reviews-section.tsx
@@ -266,7 +266,12 @@ export default function ReviewsSection({ builderId, isOwner = false }: ReviewsSe
         </h3>
         <div className="flex items-center gap-3">
           {reviews.length > 0 && (
-            <span className="text-[var(--text-muted)] text-sm">({reviews.length})</span>
+            <span
+              className="text-[var(--text-muted)] text-sm"
+              aria-label={`${reviews.length} ${reviews.length === 1 ? "review" : "reviews"}`}
+            >
+              ({reviews.length})
+            </span>
           )}
           {!isOwner && !showForm && !(isLoggedIn && reviews.some((r) => r.reviewer_email === formEmail)) && (
             <button

--- a/src/components/profile/reviews-section.tsx
+++ b/src/components/profile/reviews-section.tsx
@@ -84,7 +84,6 @@ function timeAgo(dateStr: string): string {
 
 export default function ReviewsSection({ builderId, isOwner = false }: ReviewsSectionProps) {
   const [reviews, setReviews] = useState<Review[]>([]);
-  const [avgRating, setAvgRating] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
 
@@ -132,7 +131,6 @@ export default function ReviewsSection({ builderId, isOwner = false }: ReviewsSe
         if (res.ok) {
           const data = await res.json();
           setReviews(data.reviews || []);
-          setAvgRating(data.average_rating || 0);
         } else {
           setError(true);
         }
@@ -181,7 +179,6 @@ export default function ReviewsSection({ builderId, isOwner = false }: ReviewsSe
         if (reviewsRes.ok) {
           const data = await reviewsRes.json();
           setReviews(data.reviews || []);
-          setAvgRating(data.average_rating || 0);
         }
 
         setTimeout(() => setSubmitSuccess(false), 3000);
@@ -224,7 +221,6 @@ export default function ReviewsSection({ builderId, isOwner = false }: ReviewsSe
         if (reviewsRes.ok) {
           const data = await reviewsRes.json();
           setReviews(data.reviews || []);
-          setAvgRating(data.average_rating || 0);
         }
       } else {
         const data = await res.json();
@@ -270,11 +266,7 @@ export default function ReviewsSection({ builderId, isOwner = false }: ReviewsSe
         </h3>
         <div className="flex items-center gap-3">
           {reviews.length > 0 && (
-            <div className="flex items-center gap-2">
-              <StarRating rating={Math.round(avgRating)} size={18} />
-              <span className="font-mono font-bold text-[var(--foreground)]">{avgRating}</span>
-              <span className="text-[var(--text-muted)] text-sm">({reviews.length})</span>
-            </div>
+            <span className="text-[var(--text-muted)] text-sm">({reviews.length})</span>
           )}
           {!isOwner && !showForm && !(isLoggedIn && reviews.some((r) => r.reviewer_email === formEmail)) && (
             <button

--- a/src/components/projects/projects-content.tsx
+++ b/src/components/projects/projects-content.tsx
@@ -76,9 +76,12 @@ export function ProjectsContent({ projects }: { projects: ProjectWithAuthor[] })
   }, [projects, search, sortBy, verifiedOnly, hasLiveUrl, selectedTech]);
 
   const totalPages = Math.ceil(filteredProjects.length / PAGE_SIZE);
+  // Clamp in case the projects prop refreshes (ISR / revalidation) while the
+  // user is on a page that no longer exists.
+  const activePage = currentPage > totalPages ? 1 : currentPage;
   const paginatedProjects = filteredProjects.slice(
-    (currentPage - 1) * PAGE_SIZE,
-    currentPage * PAGE_SIZE
+    (activePage - 1) * PAGE_SIZE,
+    activePage * PAGE_SIZE
   );
 
   const activeFilterCount = [verifiedOnly, hasLiveUrl, selectedTech.length > 0].filter(Boolean).length;
@@ -213,7 +216,7 @@ export function ProjectsContent({ projects }: { projects: ProjectWithAuthor[] })
       {totalPages > 1 && (
         <div className="mt-8">
           <Pagination
-            currentPage={currentPage}
+            currentPage={activePage}
             totalPages={totalPages}
             onPageChange={goToPage}
             label="Projects"

--- a/src/components/projects/projects-content.tsx
+++ b/src/components/projects/projects-content.tsx
@@ -82,8 +82,6 @@ export function ProjectsContent({ projects }: { projects: ProjectWithAuthor[] })
   );
 
   const activeFilterCount = [verifiedOnly, hasLiveUrl, selectedTech.length > 0].filter(Boolean).length;
-  const start = (currentPage - 1) * PAGE_SIZE + 1;
-  const end = Math.min(currentPage * PAGE_SIZE, filteredProjects.length);
 
   return (
     <>
@@ -183,14 +181,21 @@ export function ProjectsContent({ projects }: { projects: ProjectWithAuthor[] })
         </div>
       )}
 
-      {/* Results count */}
-      <div className="flex items-center justify-between mb-4">
-        <p className="text-sm text-[var(--text-secondary)] font-medium">
-          {filteredProjects.length === 0
-            ? "No projects found"
-            : `Showing ${start}–${end} of ${filteredProjects.length} projects`}
-        </p>
-      </div>
+      {/* Results count — only when no pagination is needed (paginated case puts the count inside <Pagination />) */}
+      {filteredProjects.length > 0 && filteredProjects.length <= PAGE_SIZE && (
+        <div className="flex items-center justify-between mb-4">
+          <p className="text-sm text-[var(--text-secondary)] font-medium">
+            Showing {filteredProjects.length} project{filteredProjects.length !== 1 ? "s" : ""}
+          </p>
+        </div>
+      )}
+      {filteredProjects.length === 0 && (
+        <div className="flex items-center justify-between mb-4">
+          <p className="text-sm text-[var(--text-secondary)] font-medium">
+            No projects found
+          </p>
+        </div>
+      )}
 
       {/* Project grid */}
       <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6 stagger-children">
@@ -211,6 +216,10 @@ export function ProjectsContent({ projects }: { projects: ProjectWithAuthor[] })
             currentPage={currentPage}
             totalPages={totalPages}
             onPageChange={goToPage}
+            label="Projects"
+            pageSize={PAGE_SIZE}
+            totalItems={filteredProjects.length}
+            itemNoun="projects"
           />
         </div>
       )}

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,19 +1,30 @@
 "use client";
 
-import { useState } from "react";
+import { useId, useState } from "react";
 import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from "lucide-react";
 
-interface PaginationProps {
+type PaginationBaseProps = {
   currentPage: number;
   totalPages: number;
   onPageChange: (page: number) => void;
+};
 
-  /** Optional header — render eyebrow + count line above the controls. All four must be provided together. */
-  label?: string;
-  pageSize?: number;
-  totalItems?: number;
-  itemNoun?: string;
-}
+type PaginationHeader = {
+  label: string;
+  pageSize: number;
+  totalItems: number;
+  itemNoun: string;
+};
+
+// Discriminated union: callers must provide either all four header fields or none.
+type PaginationProps =
+  | (PaginationBaseProps & PaginationHeader)
+  | (PaginationBaseProps & {
+      label?: never;
+      pageSize?: never;
+      totalItems?: never;
+      itemNoun?: never;
+    });
 
 function getPageNumbers(current: number, total: number): (number | "...")[] {
   if (total <= 7) {
@@ -57,6 +68,8 @@ export function Pagination({
   itemNoun,
 }: PaginationProps) {
   const [jumpValue, setJumpValue] = useState("");
+  const reactId = useId();
+  const jumpInputId = `${reactId}-pagination-jump-input`;
 
   if (totalPages <= 1) return null;
 
@@ -70,11 +83,16 @@ export function Pagination({
     }
   };
 
+  // The discriminated union guarantees these four come together; destructuring
+  // strips that narrowing, so we re-check each individually for the type guard.
   const showHeader =
-    !!label && pageSize != null && totalItems != null && !!itemNoun;
+    label !== undefined &&
+    pageSize !== undefined &&
+    totalItems !== undefined &&
+    itemNoun !== undefined;
 
   return (
-    <div className="flex flex-col items-center gap-6 mt-4">
+    <nav aria-label="Pagination" className="flex flex-col items-center gap-6 mt-4">
       {showHeader && (
         <div className="flex flex-col items-center gap-2">
           <span className="text-xs font-bold uppercase tracking-[0.2em] text-[var(--text-muted)]">
@@ -83,8 +101,8 @@ export function Pagination({
           <p className="text-base text-[var(--text-muted)]">
             Showing{" "}
             <span className="font-bold text-[var(--foreground)]">
-              {(currentPage - 1) * pageSize! + 1}
-              –{Math.min(currentPage * pageSize!, totalItems!)}
+              {(currentPage - 1) * pageSize + 1}
+              –{Math.min(currentPage * pageSize, totalItems)}
             </span>
             {" of "}
             <span className="font-bold text-[var(--foreground)]">
@@ -197,20 +215,19 @@ export function Pagination({
           }}
         >
           <label
-            htmlFor="pagination-jump-input"
+            htmlFor={jumpInputId}
             className="text-xs font-bold uppercase tracking-[0.15em] text-[var(--text-muted)]"
           >
             Go to page
           </label>
           <input
-            id="pagination-jump-input"
+            id={jumpInputId}
             type="number"
             min={1}
             max={totalPages}
             value={jumpValue}
             onChange={(e) => setJumpValue(e.target.value)}
             placeholder={`1–${totalPages}`}
-            aria-label="Jump to page"
             className="w-24 h-10 px-3 rounded-lg text-center text-sm font-bold focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
             style={{
               backgroundColor: "var(--background)",
@@ -227,6 +244,6 @@ export function Pagination({
           </button>
         </form>
       )}
-    </div>
+    </nav>
   );
 }

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -7,22 +7,22 @@ interface PaginationProps {
   currentPage: number;
   totalPages: number;
   onPageChange: (page: number) => void;
+
+  /** Optional header — render eyebrow + count line above the controls. All four must be provided together. */
+  label?: string;
+  pageSize?: number;
+  totalItems?: number;
+  itemNoun?: string;
 }
 
-/**
- * Build the list of page numbers to display, with ellipsis gaps.
- * Always shows: first page, last page, and up to 2 pages around the current page.
- * Example for page 5 of 20: [1, "...", 4, 5, 6, "...", 20]
- */
 function getPageNumbers(current: number, total: number): (number | "...")[] {
   if (total <= 7) {
     return Array.from({ length: total }, (_, i) => i + 1);
   }
 
   const pages: (number | "...")[] = [];
-  const siblings = 1; // pages on each side of current
+  const siblings = 1;
 
-  // Always include first page
   pages.push(1);
 
   const rangeStart = Math.max(2, current - siblings);
@@ -36,16 +36,26 @@ function getPageNumbers(current: number, total: number): (number | "...")[] {
 
   if (rangeEnd < total - 1) pages.push("...");
 
-  // Always include last page
   pages.push(total);
 
   return pages;
 }
 
 const btnBase =
-  "flex items-center justify-center w-10 h-10 font-extrabold uppercase transition-all";
+  "flex items-center justify-center w-12 h-12 rounded-xl font-bold transition-all";
 
-export function Pagination({ currentPage, totalPages, onPageChange }: PaginationProps) {
+const ACTIVE_GLOW =
+  "0 0 0 4px rgba(255, 58, 0, 0.18), 0 8px 24px rgba(255, 58, 0, 0.35)";
+
+export function Pagination({
+  currentPage,
+  totalPages,
+  onPageChange,
+  label,
+  pageSize,
+  totalItems,
+  itemNoun,
+}: PaginationProps) {
   const [jumpValue, setJumpValue] = useState("");
 
   if (totalPages <= 1) return null;
@@ -60,128 +70,163 @@ export function Pagination({ currentPage, totalPages, onPageChange }: Pagination
     }
   };
 
+  const showHeader =
+    !!label && pageSize != null && totalItems != null && !!itemNoun;
+
   return (
-    <div className="flex flex-col items-center gap-3 mt-4">
-    <div className="flex items-center justify-center gap-2">
-      {/* First page */}
-      <button
-        onClick={() => onPageChange(1)}
-        disabled={currentPage === 1}
-        className={`${btnBase} disabled:opacity-30 disabled:cursor-not-allowed`}
-        style={{
-          backgroundColor: "var(--bg-surface)",
-          border: "2px solid var(--border-hard)",
-          boxShadow: "var(--shadow-brutal-sm)",
-        }}
-        aria-label="First page"
-      >
-        <ChevronsLeft size={16} />
-      </button>
-
-      {/* Previous page */}
-      <button
-        onClick={() => onPageChange(currentPage - 1)}
-        disabled={currentPage === 1}
-        className={`${btnBase} disabled:opacity-30 disabled:cursor-not-allowed`}
-        style={{
-          backgroundColor: "var(--bg-surface)",
-          border: "2px solid var(--border-hard)",
-          boxShadow: "var(--shadow-brutal-sm)",
-        }}
-        aria-label="Previous page"
-      >
-        <ChevronLeft size={16} />
-      </button>
-
-      {/* Page numbers */}
-      {pages.map((page, idx) =>
-        page === "..." ? (
-          <span
-            key={`ellipsis-${idx}`}
-            className="flex items-center justify-center w-10 h-10 text-sm font-extrabold text-[var(--text-muted)] select-none"
-          >
-            ...
+    <div className="flex flex-col items-center gap-6 mt-4">
+      {showHeader && (
+        <div className="flex flex-col items-center gap-2">
+          <span className="text-xs font-bold uppercase tracking-[0.2em] text-[var(--text-muted)]">
+            {label}
           </span>
-        ) : (
-          <button
-            key={page}
-            onClick={() => onPageChange(page)}
-            className={`${btnBase} text-sm`}
-            style={{
-              backgroundColor: currentPage === page ? "var(--accent)" : "var(--bg-surface)",
-              color: currentPage === page ? "#FFFFFF" : "var(--foreground)",
-              border: "2px solid var(--border-hard)",
-              boxShadow: currentPage === page ? "none" : "var(--shadow-brutal-sm)",
-            }}
-            aria-label={`Page ${page}`}
-            aria-current={currentPage === page ? "page" : undefined}
-          >
-            {page}
-          </button>
-        )
+          <p className="text-base text-[var(--text-muted)]">
+            Showing{" "}
+            <span className="font-bold text-[var(--foreground)]">
+              {(currentPage - 1) * pageSize! + 1}
+              –{Math.min(currentPage * pageSize!, totalItems!)}
+            </span>
+            {" of "}
+            <span className="font-bold text-[var(--foreground)]">
+              {totalItems}
+            </span>{" "}
+            {itemNoun}
+          </p>
+        </div>
       )}
 
-      {/* Next page */}
-      <button
-        onClick={() => onPageChange(currentPage + 1)}
-        disabled={currentPage === totalPages}
-        className={`${btnBase} disabled:opacity-30 disabled:cursor-not-allowed`}
-        style={{
-          backgroundColor: "var(--bg-surface)",
-          border: "2px solid var(--border-hard)",
-          boxShadow: "var(--shadow-brutal-sm)",
-        }}
-        aria-label="Next page"
-      >
-        <ChevronRight size={16} />
-      </button>
-
-      {/* Last page */}
-      <button
-        onClick={() => onPageChange(totalPages)}
-        disabled={currentPage === totalPages}
-        className={`${btnBase} disabled:opacity-30 disabled:cursor-not-allowed`}
-        style={{
-          backgroundColor: "var(--bg-surface)",
-          border: "2px solid var(--border-hard)",
-          boxShadow: "var(--shadow-brutal-sm)",
-        }}
-        aria-label="Last page"
-      >
-        <ChevronsRight size={16} />
-      </button>
-    </div>
-
-    {/* Go to page */}
-    {totalPages > 7 && (
-      <form
-        onSubmit={(e) => { e.preventDefault(); handleJump(); }}
-        className="flex items-center gap-2"
-      >
-        <label className="text-xs font-bold uppercase tracking-wide text-[var(--text-muted)]">
-          Go to page
-        </label>
-        <input
-          type="number"
-          min={1}
-          max={totalPages}
-          value={jumpValue}
-          onChange={(e) => setJumpValue(e.target.value)}
-          placeholder={`1–${totalPages}`}
-          className="input-brutal w-24 text-center text-sm"
-        />
+      <div className="flex items-center justify-center gap-2">
         <button
-          type="submit"
-          className="px-3 py-2 text-xs font-extrabold uppercase tracking-wide text-white transition-colors hover:bg-[#E03300]"
+          onClick={() => onPageChange(1)}
+          disabled={currentPage === 1}
+          className={`${btnBase} text-[var(--text-muted)] hover:bg-[var(--bg-surface-light)] disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-[var(--bg-surface)]`}
           style={{
-            backgroundColor: "var(--accent)",
-            border: "2px solid var(--border-hard)",
+            backgroundColor: "var(--bg-surface)",
+            border: "1px solid var(--border-subtle)",
+          }}
+          aria-label="First page"
+        >
+          <ChevronsLeft size={16} />
+        </button>
+
+        <button
+          onClick={() => onPageChange(currentPage - 1)}
+          disabled={currentPage === 1}
+          className={`${btnBase} text-[var(--text-muted)] hover:bg-[var(--bg-surface-light)] disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-[var(--bg-surface)]`}
+          style={{
+            backgroundColor: "var(--bg-surface)",
+            border: "1px solid var(--border-subtle)",
+          }}
+          aria-label="Previous page"
+        >
+          <ChevronLeft size={16} />
+        </button>
+
+        {pages.map((page, idx) =>
+          page === "..." ? (
+            <span
+              key={`ellipsis-${idx}`}
+              className="flex items-center justify-center w-12 h-12 text-sm font-bold text-[var(--text-muted)] select-none"
+            >
+              …
+            </span>
+          ) : (
+            <button
+              key={page}
+              onClick={() => onPageChange(page)}
+              className={`${btnBase} text-sm ${
+                currentPage === page
+                  ? ""
+                  : "hover:bg-[var(--bg-surface-light)]"
+              }`}
+              style={{
+                backgroundColor:
+                  currentPage === page ? "var(--accent)" : "var(--bg-surface)",
+                color: currentPage === page ? "#FFFFFF" : "var(--foreground)",
+                border:
+                  currentPage === page
+                    ? "1px solid var(--accent)"
+                    : "1px solid var(--border-subtle)",
+                boxShadow: currentPage === page ? ACTIVE_GLOW : "none",
+              }}
+              aria-label={`Page ${page}`}
+              aria-current={currentPage === page ? "page" : undefined}
+            >
+              {page}
+            </button>
+          )
+        )}
+
+        <button
+          onClick={() => onPageChange(currentPage + 1)}
+          disabled={currentPage === totalPages}
+          className={`${btnBase} text-[var(--text-muted)] hover:bg-[var(--bg-surface-light)] disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-[var(--bg-surface)]`}
+          style={{
+            backgroundColor: "var(--bg-surface)",
+            border: "1px solid var(--border-subtle)",
+          }}
+          aria-label="Next page"
+        >
+          <ChevronRight size={16} />
+        </button>
+
+        <button
+          onClick={() => onPageChange(totalPages)}
+          disabled={currentPage === totalPages}
+          className={`${btnBase} text-[var(--text-muted)] hover:bg-[var(--bg-surface-light)] disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-[var(--bg-surface)]`}
+          style={{
+            backgroundColor: "var(--bg-surface)",
+            border: "1px solid var(--border-subtle)",
+          }}
+          aria-label="Last page"
+        >
+          <ChevronsRight size={16} />
+        </button>
+      </div>
+
+      {totalPages > 5 && (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleJump();
+          }}
+          className="flex items-center gap-3 p-2 pl-5 rounded-2xl"
+          style={{
+            backgroundColor: "var(--bg-surface)",
+            border: "1px solid var(--border-subtle)",
           }}
         >
-          Go
-        </button>
-      </form>
-    )}
+          <label
+            htmlFor="pagination-jump-input"
+            className="text-xs font-bold uppercase tracking-[0.15em] text-[var(--text-muted)]"
+          >
+            Go to page
+          </label>
+          <input
+            id="pagination-jump-input"
+            type="number"
+            min={1}
+            max={totalPages}
+            value={jumpValue}
+            onChange={(e) => setJumpValue(e.target.value)}
+            placeholder={`1–${totalPages}`}
+            aria-label="Jump to page"
+            className="w-24 h-10 px-3 rounded-lg text-center text-sm font-bold focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+            style={{
+              backgroundColor: "var(--background)",
+              border: "1px solid var(--border-subtle)",
+              color: "var(--foreground)",
+            }}
+          />
+          <button
+            type="submit"
+            className="px-5 h-10 rounded-lg text-xs font-extrabold uppercase tracking-[0.1em] text-white transition-opacity hover:opacity-90"
+            style={{ backgroundColor: "var(--accent)" }}
+          >
+            Jump
+          </button>
+        </form>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Three loosely-connected fixes that came out of investigating why @meta_alchemist's SPARK project wasn't verified and his streak was stale despite daily commits.

### 1. Project verification (`fix(verify)`)

- **Reviews header** ([reviews-section.tsx](src/components/profile/reviews-section.tsx)): drops the empty 5-star aggregate + literal "0" on profiles that have reviews — per-review stars below already carry the signal. The "(N)" count stays.
- **Profile project card** ([profile-project-card.tsx](src/components/profile/profile-project-card.tsx)): adds a self-serve "Verify" button + inline failure-reason for owners on unverified projects, mirroring the dashboard flow. Lets users with owner-mismatch get the `.vibetalent` file instructions without going through support.
- **verify-backfill cron** ([verify-backfill/route.ts](src/app/api/cron/verify-backfill/route.ts)): no longer stamps `last_verify_attempt_at` when the skip reason is "missing github_username" — that condition is recoverable on the next cron run after the user links GitHub. The old behavior locked out users who linked GitHub late by 7 days.
- **scripts/admin/debug-verify-project.ts**: new diagnostic. Prints per-project diagnosis (owner_match / owner_mismatch / bad_url / missing_username / already_verified). `--all` scans the platform; `--unstick` clears stale stamps so the next cron run picks them up.

### 2. github-sync starvation (`fix(cron)`)

The github-sync cron was leaving heavy users — meta_alchemist (17,941 contributions, 207 active days), apoorv, fahmin, etc. — stale for days while light users got synced fine.

- **Batch streak_logs upserts**: was one round-trip per active date (~200 sequential Supabase calls per heavy user); now one batched upsert per user. Drops the per-user DB cost from ~10s to ~50ms.
- **Reverse user ordering** to `lifetime_contributions DESC`. The old ASC ordering put heavy users at the back of the queue, so any timeout dropped them first — every day, deterministically. Now the leaderboard's flagship users sync first; long-tail zero-contribution users drop off the end if anything has to.
- **scripts/admin/sync-user-streak.ts**: ad-hoc all-users sync that bypasses the cron queue entirely. First run today moved 21 users — meta_alchemist 0→15 streak, apoorv 0→20, fahmin 1→25, plus several heavy users gaining accurate current streaks for the first time.

### 3. AI agent skill freshen (`feat(agent)`)

The `/skill.md`, OpenAPI spec, and `/api/v1/builders` endpoints didn't expose verified/quality signals, so AI agents using the public API couldn't tell verified builders from unverified.

- **v1 builders list**: adds `profile_url`, `verified_projects_count`, plus a `verified_only=true` filter param.
- **v1 builder profile**: adds `profile_url`, `review_count`, `average_rating`, and per-project `verified`, `quality_score`, `quality_metrics`, `live_url_ok`, `endorsement_count`.
- **OpenAPI spec + skill.md**: documents all the new fields with a "How to pick the best builder" section telling agents to prefer verified projects.
- **Agents page** ([agent/page.tsx](src/app/agent/page.tsx)): updated copy reflecting the new fields.

## Test plan

- [x] meta_alchemist's SPARK confirmed verified after `last_verify_attempt_at` was nulled and the cron re-ran (in production)
- [x] All 21 stale streaks bumped after manual sync-user-streak.ts run
- [x] `npx tsc --project tsconfig.json --noEmit` passes
- [x] `/api/v1/builders/meta_alchemist` returns the new `verified`, `quality_score`, `endorsement_count`, `review_count` fields
- [ ] After deploy: tomorrow's 6 AM UTC daily cron keeps meta_alchemist's streak fresh on its own (no manual run needed)
- [ ] After deploy: any new user who signs up + adds a public-repo project + links GitHub gets auto-verified within 24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Builders API supports verified_only filtering; builder summaries include profile_url and verified_projects_count
  * Builder profiles include review counts and average ratings; projects expose verification, quality, live-URL health, and endorsement info
  * Project owners can verify GitHub ownership from the profile UI; verified badge appears immediately after verification

* **Improvements**
  * Pagination UI and results-count behavior refined across explore, leaderboard, and projects views
  * OpenAPI and in-app docs updated to reflect new query params and response fields

* **Bug Fixes**
  * Fixed pagination empty-page behavior when filtered results change
  * Adjusted verification/backfill logic to avoid stamping attempts for missing GitHub handles
<!-- end of auto-generated comment: release notes by coderabbit.ai -->