### PR TITLE
fix(github-sync): auto-detect renamed GitHub usernames

### DIFF
--- a/src/app/api/cron/github-sync/route.ts
+++ b/src/app/api/cron/github-sync/route.ts
@@ -177,6 +177,42 @@ export async function GET(req: NextRequest) {
                   : `HTTP ${response.status}`;
               } else {
                 const events = await response.json();
+
+                // Detect GitHub username drift. When a user renames their
+                // GitHub handle, /users/{old}/events redirects transparently,
+                // but actor.login on the response carries the new canonical
+                // handle. Compare against what we have stored — if it's
+                // changed, refresh users.github_username and social_links.github
+                // so verify-backfill, share cards, and profile links stop
+                // pointing at the old name. Without this, the only way to
+                // sync was for the user to log out + back in via GitHub OAuth.
+                const canonicalLogin: string | undefined = events[0]?.actor?.login;
+                if (
+                  canonicalLogin &&
+                  canonicalLogin.toLowerCase() !== userInfo.githubUsername.toLowerCase()
+                ) {
+                  console.log(
+                    `[github-sync] username drift for user ${userInfo.userId}: ` +
+                    `stored="${userInfo.githubUsername}" → canonical="${canonicalLogin}"`
+                  );
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  await (supabase as any)
+                    .from("users")
+                    .update({ github_username: canonicalLogin })
+                    .eq("id", userInfo.userId);
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  await (supabase as any)
+                    .from("social_links")
+                    .upsert(
+                      { user_id: userInfo.userId, github: canonicalLogin },
+                      { onConflict: "user_id" }
+                    );
+                  // Use the canonical handle for the rest of this iteration —
+                  // mostly cosmetic since GitHub redirects, but keeps
+                  // fetchGitHubContributions and log lines on the right name.
+                  userInfo.githubUsername = canonicalLogin;
+                }
+
                 const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
                 recentEvents = events.filter(
                   (event: { type: string; created_at: string }) =>


### PR DESCRIPTION
## Summary
- When a user renames their GitHub handle, `users.github_username` only refreshes the next time they go through the OAuth flow at `/auth/callback`. Until then VibeTalent shows the old @handle everywhere, and verify-backfill silently fails owner-match for any new repos they add.
- Detect drift inside the existing 6-hour `github-sync` cron at **zero extra GitHub API cost**: GitHub redirects `/users/{old}/events/public` transparently, but `events[0].actor.login` carries the canonical handle. Compare and update both `users.github_username` and `social_links.github` if they've diverged.
- No effect for users with no recent public activity (empty events array) — but those users aren't actively pushing repos that need re-verification anyway. They'll re-sync on next login as before.

## Tradeoffs
- Zero new API calls — piggybacks on the events fetch the cron already does for everyone every 6h.
- Worst-case lag: 6h between rename and refresh (vs. the prior "until next OAuth login").
- Safe against deleted-then-reassigned GitHub usernames: if the stored username 404s, we already short-circuit via `userNotFound`. If it returns the new owner's events under the same name, no drift is detected (correctly — that's still the same handle).

## Test plan
- [ ] Manually flip a test user's `users.github_username` to an outdated value → trigger the cron → confirm both `users.github_username` and `social_links.github` are updated to canonical
- [ ] User with no public activity → confirm cron skips drift check without errors
- [ ] User who 404s on the events API → confirm `userNotFound` path still triggers (no regression)
- [ ] Watch the cron logs for `[github-sync] username drift for user ...` lines after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)