### PR TITLE
fix(github-sync): username drift detection + Hobby tier batch tuning

### DIFF
--- a/src/app/api/cron/github-sync/route.ts
+++ b/src/app/api/cron/github-sync/route.ts
@@ -177,6 +177,42 @@ export async function GET(req: NextRequest) {
                   : `HTTP ${response.status}`;
               } else {
                 const events = await response.json();
+
+                // Detect GitHub username drift. When a user renames their
+                // GitHub handle, /users/{old}/events redirects transparently,
+                // but actor.login on the response carries the new canonical
+                // handle. Compare against what we have stored — if it's
+                // changed, refresh users.github_username and social_links.github
+                // so verify-backfill, share cards, and profile links stop
+                // pointing at the old name. Without this, the only way to
+                // sync was for the user to log out + back in via GitHub OAuth.
+                const canonicalLogin: string | undefined = events[0]?.actor?.login;
+                if (
+                  canonicalLogin &&
+                  canonicalLogin.toLowerCase() !== userInfo.githubUsername.toLowerCase()
+                ) {
+                  console.log(
+                    `[github-sync] username drift for user ${userInfo.userId}: ` +
+                    `stored="${userInfo.githubUsername}" → canonical="${canonicalLogin}"`
+                  );
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  await (supabase as any)
+                    .from("users")
+                    .update({ github_username: canonicalLogin })
+                    .eq("id", userInfo.userId);
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  await (supabase as any)
+                    .from("social_links")
+                    .upsert(
+                      { user_id: userInfo.userId, github: canonicalLogin },
+                      { onConflict: "user_id" }
+                    );
+                  // Use the canonical handle for the rest of this iteration —
+                  // mostly cosmetic since GitHub redirects, but keeps
+                  // fetchGitHubContributions and log lines on the right name.
+                  userInfo.githubUsername = canonicalLogin;
+                }
+
                 const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
                 recentEvents = events.filter(
                   (event: { type: string; created_at: string }) =>

--- a/src/app/api/cron/github-sync/route.ts
+++ b/src/app/api/cron/github-sync/route.ts
@@ -2,15 +2,18 @@ import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { fetchGitHubContributions, sumLastNDays } from "@/lib/github-contributions";
 
-// Bump function timeout to 5 minutes — at ~100 users × ~3-5s each (events
-// API + heatmap fetch + per-day upserts) we'd routinely hit the default
-// 60s and leave 60+ users un-synced. Pro plan caps maxDuration at 300s.
+// Declared as 300s for Pro but Vercel silently caps Hobby at 60s. The batch
+// constants below are tuned to finish the full queue inside the 60s envelope
+// — with GITHUB_TOKEN set we get 5000 req/hr, so the 2s inter-batch delay
+// inherited from the anonymous-API days is no longer needed. A wall-clock
+// budget guards against pathological slow users (8s events timeout × N).
 export const maxDuration = 300;
 
 const QUALIFYING_EVENTS = ["PushEvent", "CreateEvent", "PullRequestEvent", "IssuesEvent"];
-const BATCH_SIZE = 5;
-const BATCH_DELAY_MS = 2000;
+const BATCH_SIZE = 20;
+const BATCH_DELAY_MS = 0;
 const EVENTS_API_TIMEOUT_MS = 8000;
+const WALL_CLOCK_BUDGET_MS = 50_000;
 
 function cleanGithubUsername(raw: string): string {
   return raw
@@ -139,10 +142,24 @@ export async function GET(req: NextRequest) {
     let synced = 0;
     let skipped = 0;
     let errors = 0;
+    let unattempted = 0;
     const details: { user: string; github: string; status: string; dates_logged?: number; lifetime?: number; last30d?: number; events_api_error?: string }[] = [];
+    const loopStart = Date.now();
 
     // Process in batches
     for (let i = 0; i < usersToSync.length; i += BATCH_SIZE) {
+      // Stop cleanly if we're approaching the function timeout. Without this
+      // guard the platform kills the function mid-batch and any writes still
+      // in flight are lost. Better to return what we have and let the next
+      // run pick up the tail.
+      if (Date.now() - loopStart > WALL_CLOCK_BUDGET_MS) {
+        unattempted = usersToSync.length - i;
+        console.warn(
+          `[github-sync] wall-clock budget hit after ${i}/${usersToSync.length} users — ${unattempted} unattempted`
+        );
+        break;
+      }
+
       const batch = usersToSync.slice(i, i + BATCH_SIZE);
 
       const batchResults = await Promise.allSettled(
@@ -418,19 +435,23 @@ export async function GET(req: NextRequest) {
         }
       }
 
-      // Delay between batches to respect GitHub rate limits
-      if (i + BATCH_SIZE < usersToSync.length) {
+      // Delay between batches to respect GitHub rate limits. Set to 0 once
+      // GITHUB_TOKEN is in place since the 5000/hr ceiling is far above what
+      // this loop generates — kept as a tunable for future no-token rollback.
+      if (BATCH_DELAY_MS > 0 && i + BATCH_SIZE < usersToSync.length) {
         await sleep(BATCH_DELAY_MS);
       }
     }
 
-    console.log(`GitHub sync complete: ${synced} synced, ${skipped} skipped, ${errors} errors`);
+    const budgetNote = unattempted > 0 ? `, ${unattempted} unattempted (budget)` : "";
+    console.log(`GitHub sync complete: ${synced} synced, ${skipped} skipped, ${errors} errors${budgetNote}`);
 
     return NextResponse.json({
-      message: `GitHub sync complete: ${synced} synced, ${skipped} skipped, ${errors} errors`,
+      message: `GitHub sync complete: ${synced} synced, ${skipped} skipped, ${errors} errors${budgetNote}`,
       synced,
       skipped,
       errors,
+      unattempted,
       details,
     });
   } catch (error) {


### PR DESCRIPTION
## Summary

Two fixes to make github-sync survive on the Vercel Hobby tier — both small, both touch the same cron route. Activity feed has been dark since May 9 because the cron was being killed after ~15 of 128 users.

- **Hobby tier batch tuning** — Vercel silently caps function timeout at 60s on Hobby. Prior batch params (`BATCH_SIZE=5`, `BATCH_DELAY_MS=2000`) needed ~100s for the current 128-user queue. Bumped to `BATCH_SIZE=20` + zero delay (safe because `GITHUB_TOKEN` is set and the 5000 req/hr ceiling has ample headroom), plus a 50s wall-clock budget that exits cleanly with partial results rather than being killed mid-write. Typical run drops from ~100s → ~21s.
- **GitHub username drift detection** — When a builder renames their GitHub handle, `actor.login` on the events API response carries the new canonical name. We now detect the mismatch and update `users.github_username` + `social_links.github` automatically. Previously the only fix was for the user to log out + GitHub OAuth re-link.

## Test plan
- [ ] Vercel preview build passes
- [ ] After deploy, manually trigger `/api/cron/github-sync` with CRON_SECRET — response should show ~128 synced, 0 unattempted
- [ ] Confirm `feed_events` table has fresh rows with today's timestamps
- [ ] After next 06:00 UTC cron run, verify activity feed UI loads recent commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * GitHub synchronization now properly detects and handles GitHub username changes, ensuring stored profile information remains accurate.
  * Improved reliability and efficiency of background synchronization processes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unknownking07/vibe-talent/pull/181)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->