### PR TITLE
fix(ux): permissive display name validation + dedicated /notifications page

### DIFF
--- a/src/app/notifications/layout.tsx
+++ b/src/app/notifications/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Notifications",
+  robots: { index: false, follow: false },
+};
+
+export default function NotificationsLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -36,16 +36,23 @@ export default function NotificationsPage() {
 
   useEffect(() => {
     const supabase = createClient();
-    supabase.auth.getUser().then(({ data: { user } }) => {
-      if (!user) {
-        // The login page reads `?redirect=` (not `?next=`) to decide where
-        // to send the user after a successful sign-in.
+    supabase.auth
+      .getUser()
+      .then(({ data: { user } }) => {
+        if (!user) {
+          // The login page reads `?redirect=` (not `?next=`) to decide where
+          // to send the user after a successful sign-in.
+          router.push("/auth/login?redirect=/notifications");
+          return;
+        }
+        setAuthChecking(false);
+        fetchNotifications();
+      })
+      .catch(() => {
+        // Treat a getUser rejection (network drop, transient Supabase error)
+        // as unauthenticated rather than letting authChecking stall forever.
         router.push("/auth/login?redirect=/notifications");
-        return;
-      }
-      setAuthChecking(false);
-      fetchNotifications();
-    });
+      });
   }, [fetchNotifications, router]);
 
   const unreadCount = notifications.filter(n => !n.read).length;
@@ -70,11 +77,15 @@ export default function NotificationsPage() {
   };
 
   const handleMarkRead = async (id: string) => {
-    // Snapshot for rollback — this page doesn't poll, so a silent server
-    // failure would otherwise leave the row marked read in the UI until a
-    // hard refresh, with the server still treating it as unread.
-    const previous = notifications;
+    // Snapshot only the row's prior read state — this page doesn't poll, so a
+    // silent server failure would leave the row marked read in the UI while
+    // the DB still treated it as unread. Reverting just this row (not the
+    // whole list) avoids clobbering concurrent updates from other handlers
+    // that may have fired between the optimistic write and the failure.
+    const previousRead = notifications.find(n => n.id === id)?.read ?? false;
     setNotifications(prev => prev.map(n => (n.id === id ? { ...n, read: true } : n)));
+    const revert = () =>
+      setNotifications(prev => prev.map(n => (n.id === id ? { ...n, read: previousRead } : n)));
     try {
       const res = await fetch("/api/notifications", {
         method: "PATCH",
@@ -82,12 +93,12 @@ export default function NotificationsPage() {
         body: JSON.stringify({ id }),
       });
       if (!res.ok) {
-        setNotifications(previous);
+        revert();
         return;
       }
       window.dispatchEvent(new Event("notifications-updated"));
     } catch {
-      setNotifications(previous);
+      revert();
     }
   };
 

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { Bell, ArrowLeft, ExternalLink, Check } from "lucide-react";
+import { createClient } from "@/lib/supabase/client";
+import type { Notification } from "@/lib/types/database";
+import { NOTIFICATION_ICONS, NOTIFICATION_COLORS, notificationTimeAgo } from "@/lib/notification-display";
+
+function extractLink(metadata: Record<string, unknown> | null | undefined): string | null {
+  if (!metadata) return null;
+  const link = metadata.link;
+  return typeof link === "string" && link.length > 0 ? link : null;
+}
+
+export default function NotificationsPage() {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [authChecking, setAuthChecking] = useState(true);
+  const [marking, setMarking] = useState(false);
+
+  const fetchNotifications = useCallback(async () => {
+    try {
+      const res = await fetch("/api/notifications");
+      if (!res.ok) return;
+      const data = await res.json();
+      setNotifications(data.data || []);
+    } catch {
+      // Silently fail
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const supabase = createClient();
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (!user) {
+        window.location.href = "/auth/login?next=/notifications";
+        return;
+      }
+      setAuthChecking(false);
+      fetchNotifications();
+    });
+  }, [fetchNotifications]);
+
+  const unreadCount = notifications.filter(n => !n.read).length;
+
+  const handleMarkAllRead = async () => {
+    if (unreadCount === 0) return;
+    setMarking(true);
+    try {
+      const res = await fetch("/api/notifications", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mark_all: true }),
+      });
+      if (res.ok) {
+        setNotifications(prev => prev.map(n => ({ ...n, read: true })));
+        window.dispatchEvent(new Event("notifications-updated"));
+      }
+    } catch {
+      // Silently fail
+    }
+    setMarking(false);
+  };
+
+  const handleMarkRead = async (id: string) => {
+    setNotifications(prev => prev.map(n => (n.id === id ? { ...n, read: true } : n)));
+    try {
+      await fetch("/api/notifications", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id }),
+      });
+      window.dispatchEvent(new Event("notifications-updated"));
+    } catch {
+      // Silently fail
+    }
+  };
+
+  if (authChecking) {
+    return (
+      <div className="min-h-screen flex items-center justify-center" style={{ background: "var(--bg-base)" }}>
+        <p className="text-sm font-medium text-[var(--text-muted-soft)]">Loading…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen" style={{ background: "var(--bg-base)" }}>
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 py-8 sm:py-12">
+        <Link
+          href="/dashboard"
+          className="inline-flex items-center gap-1.5 text-xs font-bold uppercase tracking-wide text-[var(--text-muted)] hover:text-[var(--foreground)] mb-6"
+        >
+          <ArrowLeft size={14} />
+          Back to dashboard
+        </Link>
+
+        <div
+          className="flex items-center justify-between gap-4 px-5 py-4 mb-6"
+          style={{
+            backgroundColor: "var(--bg-surface)",
+            border: "2px solid var(--border-hard)",
+            boxShadow: "var(--shadow-brutal-sm)",
+          }}
+        >
+          <div className="min-w-0">
+            <h1 className="text-xl sm:text-2xl font-extrabold uppercase tracking-tight text-[var(--foreground)]">
+              Notifications
+            </h1>
+            <p className="text-xs sm:text-sm font-medium text-[var(--text-muted)] mt-0.5">
+              {unreadCount > 0
+                ? `${unreadCount} unread`
+                : notifications.length > 0
+                  ? "All caught up"
+                  : "Nothing here yet"}
+            </p>
+          </div>
+          {unreadCount > 0 && (
+            <button
+              onClick={handleMarkAllRead}
+              disabled={marking}
+              className="shrink-0 px-3 py-2 text-xs font-extrabold uppercase tracking-wide text-white cursor-pointer disabled:opacity-50"
+              style={{
+                backgroundColor: "var(--accent)",
+                border: "2px solid var(--border-hard)",
+                boxShadow: "var(--shadow-brutal-xs)",
+              }}
+            >
+              Mark all read
+            </button>
+          )}
+        </div>
+
+        {loading ? (
+          <div
+            className="px-5 py-10 text-center"
+            style={{
+              backgroundColor: "var(--bg-surface)",
+              border: "2px solid var(--border-hard)",
+              boxShadow: "var(--shadow-brutal-sm)",
+            }}
+          >
+            <p className="text-sm font-medium text-[var(--text-muted-soft)]">Loading notifications…</p>
+          </div>
+        ) : notifications.length === 0 ? (
+          <div
+            className="px-5 py-12 text-center"
+            style={{
+              backgroundColor: "var(--bg-surface)",
+              border: "2px solid var(--border-hard)",
+              boxShadow: "var(--shadow-brutal-sm)",
+            }}
+          >
+            <Bell size={32} className="mx-auto mb-3 text-[var(--text-muted-soft)]" />
+            <p className="text-base font-bold text-[var(--foreground)] mb-1">No notifications yet</p>
+            <p className="text-sm text-[var(--text-muted)]">
+              You&apos;ll see streak reminders, hire requests, and milestones here.
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {notifications.map((n) => {
+              const Icon = NOTIFICATION_ICONS[n.type] || Bell;
+              const color = NOTIFICATION_COLORS[n.type] || "var(--text-muted)";
+              const link = extractLink(n.metadata as Record<string, unknown> | null);
+              return (
+                <article
+                  key={n.id}
+                  className="px-5 py-4 flex gap-3 sm:gap-4 items-start"
+                  style={{
+                    backgroundColor: n.read ? "var(--bg-surface)" : "var(--bg-surface-light, var(--bg-surface))",
+                    border: "2px solid var(--border-hard)",
+                    boxShadow: "var(--shadow-brutal-sm)",
+                    borderLeftWidth: 6,
+                    borderLeftColor: color,
+                  }}
+                >
+                  <div
+                    className="shrink-0 w-9 h-9 flex items-center justify-center"
+                    style={{ backgroundColor: `${color}1A`, color }}
+                  >
+                    <Icon size={18} />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-start gap-2 flex-wrap">
+                      <h2 className={`text-sm sm:text-base leading-snug ${n.read ? "font-bold text-[var(--text-secondary)]" : "font-extrabold text-[var(--foreground)]"}`}>
+                        {n.title}
+                      </h2>
+                      {!n.read && (
+                        <span
+                          className="mt-1 inline-block w-2 h-2 rounded-full shrink-0"
+                          style={{ backgroundColor: "var(--accent)" }}
+                          aria-label="Unread"
+                        />
+                      )}
+                    </div>
+                    <p
+                      className="text-sm mt-1.5 whitespace-pre-wrap break-words"
+                      style={{ color: n.read ? "var(--text-muted)" : "var(--text-secondary)" }}
+                    >
+                      {n.message}
+                    </p>
+                    <div className="flex items-center gap-3 mt-3 flex-wrap">
+                      <span className="text-[11px] font-bold uppercase tracking-wide text-[var(--text-muted-soft)]">
+                        {notificationTimeAgo(n.created_at)}
+                      </span>
+                      {link && (
+                        <Link
+                          href={link}
+                          onClick={() => !n.read && handleMarkRead(n.id)}
+                          className="inline-flex items-center gap-1 text-xs font-extrabold uppercase tracking-wide text-[var(--accent)] hover:underline"
+                        >
+                          Open
+                          <ExternalLink size={12} />
+                        </Link>
+                      )}
+                      {!n.read && (
+                        <button
+                          onClick={() => handleMarkRead(n.id)}
+                          className="inline-flex items-center gap-1 text-xs font-bold uppercase tracking-wide text-[var(--text-muted)] hover:text-[var(--foreground)] cursor-pointer"
+                        >
+                          <Check size={12} />
+                          Mark read
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -6,13 +6,7 @@ import { useRouter } from "next/navigation";
 import { Bell, ArrowLeft, ExternalLink, Check } from "lucide-react";
 import { createClient } from "@/lib/supabase/client";
 import type { Notification } from "@/lib/types/database";
-import { NOTIFICATION_ICONS, NOTIFICATION_COLORS, notificationTimeAgo } from "@/lib/notification-display";
-
-function extractLink(metadata: Record<string, unknown> | null | undefined): string | null {
-  if (!metadata) return null;
-  const link = metadata.link;
-  return typeof link === "string" && link.length > 0 ? link : null;
-}
+import { NOTIFICATION_ICONS, NOTIFICATION_COLORS, notificationTimeAgo, extractNotificationLink } from "@/lib/notification-display";
 
 export default function NotificationsPage() {
   const router = useRouter();
@@ -188,7 +182,7 @@ export default function NotificationsPage() {
             {notifications.map((n) => {
               const Icon = NOTIFICATION_ICONS[n.type] || Bell;
               const color = NOTIFICATION_COLORS[n.type] || "var(--text-muted)";
-              const link = extractLink(n.metadata as Record<string, unknown> | null);
+              const link = extractNotificationLink(n.metadata as Record<string, unknown> | null);
               return (
                 <article
                   key={n.id}

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { Bell, ArrowLeft, ExternalLink, Check } from "lucide-react";
 import { createClient } from "@/lib/supabase/client";
 import type { Notification } from "@/lib/types/database";
@@ -14,6 +15,7 @@ function extractLink(metadata: Record<string, unknown> | null | undefined): stri
 }
 
 export default function NotificationsPage() {
+  const router = useRouter();
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [loading, setLoading] = useState(true);
   const [authChecking, setAuthChecking] = useState(true);
@@ -36,13 +38,15 @@ export default function NotificationsPage() {
     const supabase = createClient();
     supabase.auth.getUser().then(({ data: { user } }) => {
       if (!user) {
-        window.location.href = "/auth/login?next=/notifications";
+        // The login page reads `?redirect=` (not `?next=`) to decide where
+        // to send the user after a successful sign-in.
+        router.push("/auth/login?redirect=/notifications");
         return;
       }
       setAuthChecking(false);
       fetchNotifications();
     });
-  }, [fetchNotifications]);
+  }, [fetchNotifications, router]);
 
   const unreadCount = notifications.filter(n => !n.read).length;
 
@@ -66,16 +70,24 @@ export default function NotificationsPage() {
   };
 
   const handleMarkRead = async (id: string) => {
+    // Snapshot for rollback — this page doesn't poll, so a silent server
+    // failure would otherwise leave the row marked read in the UI until a
+    // hard refresh, with the server still treating it as unread.
+    const previous = notifications;
     setNotifications(prev => prev.map(n => (n.id === id ? { ...n, read: true } : n)));
     try {
-      await fetch("/api/notifications", {
+      const res = await fetch("/api/notifications", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ id }),
       });
+      if (!res.ok) {
+        setNotifications(previous);
+        return;
+      }
       window.dispatchEvent(new Event("notifications-updated"));
     } catch {
-      // Silently fail
+      setNotifications(previous);
     }
   };
 

--- a/src/components/ui/notification-bell.tsx
+++ b/src/components/ui/notification-bell.tsx
@@ -1,49 +1,10 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import { Bell, Flame, Trophy, CheckCircle, AlertTriangle, Mail, Star, Eye, BarChart3, Zap, LinkIcon, Users } from "lucide-react";
+import { Bell } from "lucide-react";
 import { useRouter } from "next/navigation";
 import type { Notification } from "@/lib/types/database";
-
-const typeIcons: Record<string, typeof Bell> = {
-  hire_request: Mail,
-  streak_milestone: Flame,
-  streak_warning: AlertTriangle,
-  badge_earned: Trophy,
-  project_verified: CheckCircle,
-  project_flagged: AlertTriangle,
-  new_review: Star,
-  profile_view_summary: Eye,
-  weekly_digest: BarChart3,
-  vibe_score_milestone: Zap,
-  project_missing_links: LinkIcon,
-  referral_prompt: Users,
-};
-
-const typeColors: Record<string, string> = {
-  hire_request: "#FF3A00",
-  streak_milestone: "#F59E0B",
-  streak_warning: "#EF4444",
-  badge_earned: "#8B5CF6",
-  project_verified: "#10B981",
-  project_flagged: "#EF4444",
-  new_review: "#F59E0B",
-  profile_view_summary: "#3B82F6",
-  weekly_digest: "#6366F1",
-  vibe_score_milestone: "#FF3A00",
-  project_missing_links: "#F59E0B",
-  referral_prompt: "#FF3A00",
-};
-
-function timeAgo(dateStr: string): string {
-  const diff = Date.now() - new Date(dateStr).getTime();
-  const mins = Math.floor(diff / 60000);
-  if (mins < 1) return "just now";
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.floor(hrs / 24)}d ago`;
-}
+import { NOTIFICATION_ICONS, NOTIFICATION_COLORS, notificationTimeAgo } from "@/lib/notification-display";
 
 export function NotificationBell() {
   const [open, setOpen] = useState(false);
@@ -120,8 +81,10 @@ export function NotificationBell() {
       setUnreadCount(prev => Math.max(0, prev - 1));
     }
     setOpen(false);
-    const link = typeof notification.metadata?.link === "string" ? notification.metadata.link : null;
-    router.push(link || "/dashboard");
+    // Always send users to the dedicated notifications page so they can read
+    // the full message — the dropdown truncates long bodies. Deep links from
+    // metadata.link still surface there as a per-item CTA.
+    router.push("/notifications");
   };
 
   return (
@@ -182,8 +145,8 @@ export function NotificationBell() {
           ) : (
             <div>
               {notifications.slice(0, 10).map((n) => {
-                const Icon = typeIcons[n.type] || Bell;
-                const color = typeColors[n.type] || "var(--text-muted)";
+                const Icon = NOTIFICATION_ICONS[n.type] || Bell;
+                const color = NOTIFICATION_COLORS[n.type] || "var(--text-muted)";
                 return (
                   <button
                     key={n.id}
@@ -200,7 +163,7 @@ export function NotificationBell() {
                         {n.title}
                       </p>
                       <p className="text-xs mt-0.5 truncate" style={{ color: n.read ? "var(--text-muted)" : "var(--text-secondary)" }}>{n.message}</p>
-                      <p className="text-[10px] mt-1 font-medium" style={{ color: "var(--text-muted)" }}>{timeAgo(n.created_at)}</p>
+                      <p className="text-[10px] mt-1 font-medium" style={{ color: "var(--text-muted)" }}>{notificationTimeAgo(n.created_at)}</p>
                     </div>
                     {!n.read && (
                       <span
@@ -211,11 +174,15 @@ export function NotificationBell() {
                   </button>
                 );
               })}
-              {notifications.length > 10 && (
-                <p className="px-4 py-2 text-[10px] font-bold uppercase tracking-wide text-center text-[var(--text-muted-soft)] border-t-2 border-[var(--border-hard)]">
-                  Showing 10 of {notifications.length}
-                </p>
-              )}
+              <button
+                onClick={() => {
+                  setOpen(false);
+                  router.push("/notifications");
+                }}
+                className="w-full px-4 py-2.5 text-xs font-extrabold uppercase tracking-wide text-center text-[var(--accent)] border-t-2 border-[var(--border-hard)] hover:bg-[var(--bg-surface-light)] cursor-pointer"
+              >
+                View all notifications
+              </button>
             </div>
           )}
         </div>

--- a/src/lib/__tests__/notification-display.test.ts
+++ b/src/lib/__tests__/notification-display.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { notificationTimeAgo } from "../notification-display";
+import { notificationTimeAgo, extractNotificationLink } from "../notification-display";
 
 describe("notificationTimeAgo", () => {
   it("returns an empty string for unparseable input rather than 'undefined'", () => {
@@ -20,5 +20,44 @@ describe("notificationTimeAgo", () => {
     expect(notificationTimeAgo(new Date(now - 5 * 60_000).toISOString())).toBe("5m ago");
     expect(notificationTimeAgo(new Date(now - 3 * 3600_000).toISOString())).toBe("3h ago");
     expect(notificationTimeAgo(new Date(now - 2 * 86400_000).toISOString())).toBe("2d ago");
+  });
+});
+
+describe("extractNotificationLink", () => {
+  it("returns null for missing or empty metadata", () => {
+    expect(extractNotificationLink(null)).toBeNull();
+    expect(extractNotificationLink(undefined)).toBeNull();
+    expect(extractNotificationLink({})).toBeNull();
+    expect(extractNotificationLink({ link: "" })).toBeNull();
+    expect(extractNotificationLink({ link: 42 })).toBeNull();
+  });
+
+  it("accepts same-origin paths", () => {
+    expect(extractNotificationLink({ link: "/dashboard" })).toBe("/dashboard");
+    expect(extractNotificationLink({ link: "/projects/abc?ref=x" })).toBe("/projects/abc?ref=x");
+  });
+
+  it("accepts absolute http and https URLs", () => {
+    expect(extractNotificationLink({ link: "https://example.com/x" })).toBe("https://example.com/x");
+    expect(extractNotificationLink({ link: "http://example.com/x" })).toBe("http://example.com/x");
+  });
+
+  it("rejects javascript:, data:, and other dangerous schemes", () => {
+    expect(extractNotificationLink({ link: "javascript:alert(1)" })).toBeNull();
+    expect(extractNotificationLink({ link: "JaVaScRiPt:alert(1)" })).toBeNull();
+    expect(extractNotificationLink({ link: "data:text/html,<script>alert(1)</script>" })).toBeNull();
+    expect(extractNotificationLink({ link: "vbscript:msgbox(1)" })).toBeNull();
+    expect(extractNotificationLink({ link: "file:///etc/passwd" })).toBeNull();
+  });
+
+  it("rejects protocol-relative and backslash-trick URLs", () => {
+    expect(extractNotificationLink({ link: "//evil.com" })).toBeNull();
+    expect(extractNotificationLink({ link: "/\\evil.com" })).toBeNull();
+    expect(extractNotificationLink({ link: "/path\\with\\backslashes" })).toBeNull();
+  });
+
+  it("rejects garbage that is neither a path nor a parseable URL", () => {
+    expect(extractNotificationLink({ link: "not a url" })).toBeNull();
+    expect(extractNotificationLink({ link: "evil.com/x" })).toBeNull();
   });
 });

--- a/src/lib/__tests__/notification-display.test.ts
+++ b/src/lib/__tests__/notification-display.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { notificationTimeAgo } from "../notification-display";
+
+describe("notificationTimeAgo", () => {
+  it("returns an empty string for unparseable input rather than 'undefined'", () => {
+    // Pre-fix the function silently returned `undefined` for these because
+    // NaN comparisons fell through every branch.
+    expect(notificationTimeAgo("not a date")).toBe("");
+    expect(notificationTimeAgo("")).toBe("");
+  });
+
+  it("clamps future timestamps to 'just now' (clock skew tolerance)", () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    expect(notificationTimeAgo(future)).toBe("just now");
+  });
+
+  it("formats minutes, hours, and days against a recent timestamp", () => {
+    const now = Date.now();
+    expect(notificationTimeAgo(new Date(now - 5_000).toISOString())).toBe("just now");
+    expect(notificationTimeAgo(new Date(now - 5 * 60_000).toISOString())).toBe("5m ago");
+    expect(notificationTimeAgo(new Date(now - 3 * 3600_000).toISOString())).toBe("3h ago");
+    expect(notificationTimeAgo(new Date(now - 2 * 86400_000).toISOString())).toBe("2d ago");
+  });
+});

--- a/src/lib/__tests__/profanity.test.ts
+++ b/src/lib/__tests__/profanity.test.ts
@@ -42,13 +42,15 @@ describe("validateDisplayName", () => {
   });
 
   it("blocks profanity disguised with leet character substitutions", () => {
-    // containsProfanity normalizes 0→o, 1→i, 3→e, 4→a, 5→s, @→a, $→s before
-    // matching. Separator-based evasion ("f.u.c.k") is *not* caught — the
-    // normalizer collapses dots/dashes/underscores to spaces, which splits
-    // the letters into separate words. That's a known gap; see profanity.ts.
     expect(validateDisplayName("sh1t")).toMatch(/inappropriate language/);
     expect(validateDisplayName("$hit")).toMatch(/inappropriate language/);
     expect(validateDisplayName("@ss")).toMatch(/inappropriate language/);
+  });
+
+  it("blocks profanity disguised with separator characters", () => {
+    expect(validateDisplayName("f.u.c.k")).toMatch(/inappropriate language/);
+    expect(validateDisplayName("s-h-i-t")).toMatch(/inappropriate language/);
+    expect(validateDisplayName("b_i_t_c_h")).toMatch(/inappropriate language/);
   });
 });
 

--- a/src/lib/__tests__/profanity.test.ts
+++ b/src/lib/__tests__/profanity.test.ts
@@ -52,6 +52,12 @@ describe("validateDisplayName", () => {
     expect(validateDisplayName("s-h-i-t")).toMatch(/inappropriate language/);
     expect(validateDisplayName("b_i_t_c_h")).toMatch(/inappropriate language/);
   });
+
+  it("blocks profanity combining leet substitution and separators", () => {
+    expect(validateDisplayName("sh.1.t")).toMatch(/inappropriate language/);
+    expect(validateDisplayName("@.s.s")).toMatch(/inappropriate language/);
+    expect(validateDisplayName("$_h_i_t")).toMatch(/inappropriate language/);
+  });
 });
 
 describe("containsProfanity", () => {

--- a/src/lib/__tests__/profanity.test.ts
+++ b/src/lib/__tests__/profanity.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { containsProfanity, validateDisplayName } from "../profanity";
+
+describe("validateDisplayName", () => {
+  it("accepts an empty / whitespace value (display name is optional)", () => {
+    expect(validateDisplayName("")).toBeNull();
+    expect(validateDisplayName("   ")).toBeNull();
+  });
+
+  it("enforces a 2-character minimum", () => {
+    expect(validateDisplayName("a")).toMatch(/at least 2/);
+    expect(validateDisplayName(" b ")).toMatch(/at least 2/);
+  });
+
+  it("enforces a 30-character maximum", () => {
+    expect(validateDisplayName("a".repeat(30))).toBeNull();
+    expect(validateDisplayName("a".repeat(31))).toMatch(/30 characters or less/);
+  });
+
+  it("accepts names with digits — the original regression that motivated the relaxed contract", () => {
+    expect(validateDisplayName("25TH")).toBeNull();
+    expect(validateDisplayName("Bob123")).toBeNull();
+    expect(validateDisplayName("h3llo")).toBeNull();
+    expect(validateDisplayName("12345")).toBeNull();
+  });
+
+  it("accepts vowel-less ASCII names that the old gibberish heuristic rejected", () => {
+    expect(validateDisplayName("xyz")).toBeNull();
+    expect(validateDisplayName("Mr T")).toBeNull();
+    expect(validateDisplayName("JFK")).toBeNull();
+  });
+
+  it("accepts non-Latin scripts and emoji", () => {
+    expect(validateDisplayName("ニック")).toBeNull();
+    expect(validateDisplayName("🚀rocket")).toBeNull();
+    expect(validateDisplayName("北京")).toBeNull();
+  });
+
+  it("still blocks profanity", () => {
+    expect(validateDisplayName("shit head")).toMatch(/inappropriate language/);
+    expect(validateDisplayName("fuck off")).toMatch(/inappropriate language/);
+  });
+
+  it("blocks profanity disguised with leet character substitutions", () => {
+    // containsProfanity normalizes 0→o, 1→i, 3→e, 4→a, 5→s, @→a, $→s before
+    // matching. Separator-based evasion ("f.u.c.k") is *not* caught — the
+    // normalizer collapses dots/dashes/underscores to spaces, which splits
+    // the letters into separate words. That's a known gap; see profanity.ts.
+    expect(validateDisplayName("sh1t")).toMatch(/inappropriate language/);
+    expect(validateDisplayName("$hit")).toMatch(/inappropriate language/);
+    expect(validateDisplayName("@ss")).toMatch(/inappropriate language/);
+  });
+});
+
+describe("containsProfanity", () => {
+  it("returns false for empty input", () => {
+    expect(containsProfanity("")).toBe(false);
+  });
+
+  it("does not false-positive on legitimate words that contain banned substrings", () => {
+    // Word-boundary matching exists specifically so "class" / "assassin" /
+    // "Cassandra" don't get flagged for embedding "ass".
+    expect(containsProfanity("Cassandra")).toBe(false);
+    expect(containsProfanity("classroom")).toBe(false);
+    expect(containsProfanity("assassin")).toBe(false);
+  });
+
+  it("flags whole-word matches regardless of case", () => {
+    expect(containsProfanity("SHIT")).toBe(true);
+    expect(containsProfanity("Fuck this")).toBe(true);
+  });
+});

--- a/src/lib/notification-display.ts
+++ b/src/lib/notification-display.ts
@@ -31,7 +31,10 @@ export const NOTIFICATION_COLORS: Record<string, string> = {
 };
 
 export function notificationTimeAgo(dateStr: string): string {
-  const diff = Date.now() - new Date(dateStr).getTime();
+  const timestamp = new Date(dateStr).getTime();
+  if (Number.isNaN(timestamp)) return "";
+  const diff = Date.now() - timestamp;
+  if (diff < 0) return "just now"; // clock skew or future-dated row
   const mins = Math.floor(diff / 60000);
   if (mins < 1) return "just now";
   if (mins < 60) return `${mins}m ago`;

--- a/src/lib/notification-display.ts
+++ b/src/lib/notification-display.ts
@@ -30,6 +30,41 @@ export const NOTIFICATION_COLORS: Record<string, string> = {
   referral_prompt: "#FF3A00",
 };
 
+/**
+ * Returns a safe URL extracted from a notification's metadata.link, or null if
+ * the field is missing/unsafe. Defends against `javascript:`, `data:`,
+ * `vbscript:`, protocol-relative (`//evil.com`), and backslash-trick URLs.
+ *
+ * Accepted shapes:
+ *   - Same-origin paths starting with a single forward slash: "/dashboard"
+ *   - Absolute http:// or https:// URLs
+ *
+ * Notification rows are written by server code today, but metadata is a
+ * free-form jsonb column — any future write path (admin tool, migration,
+ * compromised input) could land an unsafe value here, so we filter at the
+ * render boundary rather than trust the producer.
+ */
+export function extractNotificationLink(
+  metadata: Record<string, unknown> | null | undefined
+): string | null {
+  if (!metadata) return null;
+  const link = metadata.link;
+  if (typeof link !== "string" || link.length === 0) return null;
+  // Same-origin relative path
+  if (link.startsWith("/")) {
+    if (link.startsWith("//") || link.includes("\\")) return null;
+    return link;
+  }
+  // Absolute URL — only http(s) is allowed; rejects javascript:, data:, etc.
+  try {
+    const parsed = new URL(link);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") return link;
+  } catch {
+    // unparseable
+  }
+  return null;
+}
+
 export function notificationTimeAgo(dateStr: string): string {
   const timestamp = new Date(dateStr).getTime();
   if (Number.isNaN(timestamp)) return "";

--- a/src/lib/notification-display.ts
+++ b/src/lib/notification-display.ts
@@ -1,0 +1,41 @@
+import { Bell, Flame, Trophy, CheckCircle, AlertTriangle, Mail, Star, Eye, BarChart3, Zap, LinkIcon, Users } from "lucide-react";
+
+export const NOTIFICATION_ICONS: Record<string, typeof Bell> = {
+  hire_request: Mail,
+  streak_milestone: Flame,
+  streak_warning: AlertTriangle,
+  badge_earned: Trophy,
+  project_verified: CheckCircle,
+  project_flagged: AlertTriangle,
+  new_review: Star,
+  profile_view_summary: Eye,
+  weekly_digest: BarChart3,
+  vibe_score_milestone: Zap,
+  project_missing_links: LinkIcon,
+  referral_prompt: Users,
+};
+
+export const NOTIFICATION_COLORS: Record<string, string> = {
+  hire_request: "#FF3A00",
+  streak_milestone: "#F59E0B",
+  streak_warning: "#EF4444",
+  badge_earned: "#8B5CF6",
+  project_verified: "#10B981",
+  project_flagged: "#EF4444",
+  new_review: "#F59E0B",
+  profile_view_summary: "#3B82F6",
+  weekly_digest: "#6366F1",
+  vibe_score_milestone: "#FF3A00",
+  project_missing_links: "#F59E0B",
+  referral_prompt: "#FF3A00",
+};
+
+export function notificationTimeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}

--- a/src/lib/profanity.ts
+++ b/src/lib/profanity.ts
@@ -25,14 +25,8 @@ const PROFANITY_REGEX = new RegExp(
   "i"
 );
 
-/**
- * Returns true if the text contains profanity/offensive language.
- */
-export function containsProfanity(text: string): boolean {
-  if (!text) return false;
-  // Normalize: strip special chars that might be used to evade
-  const normalized = text
-    .replace(/[_\-.\s]+/g, " ")  // underscores, dashes, dots → spaces
+function applyLeetSubstitutions(text: string): string {
+  return text
     .replace(/0/g, "o")
     .replace(/1/g, "i")
     .replace(/3/g, "e")
@@ -40,8 +34,26 @@ export function containsProfanity(text: string): boolean {
     .replace(/5/g, "s")
     .replace(/@/g, "a")
     .replace(/\$/g, "s");
+}
 
-  return PROFANITY_REGEX.test(normalized);
+/**
+ * Returns true if the text contains profanity/offensive language.
+ *
+ * Checks two normalized forms so we catch both shapes of evasion without
+ * false-positiving on legitimate words:
+ *   1. Separators (underscores/dashes/dots/whitespace) collapsed to a single
+ *      space — preserves `\bword\b` boundaries inside multi-word strings, so
+ *      "ass kicker" is caught while "Cassandra" is not.
+ *   2. Separators stripped entirely — collapses "f.u.c.k" or "s-h-i-t" back
+ *      to "fuck"/"shit" so dot/dash-obfuscated slurs trip the same regex.
+ *      Word-boundary matching still keeps "Cl.ass.room" → "Classroom" clean
+ *      since "ass" is mid-word in the stripped form.
+ */
+export function containsProfanity(text: string): boolean {
+  if (!text) return false;
+  const spaced = applyLeetSubstitutions(text.replace(/[_\-.\s]+/g, " "));
+  const stripped = applyLeetSubstitutions(text.replace(/[_\-.\s]+/g, ""));
+  return PROFANITY_REGEX.test(spaced) || PROFANITY_REGEX.test(stripped);
 }
 
 /**

--- a/src/lib/profanity.ts
+++ b/src/lib/profanity.ts
@@ -46,15 +46,14 @@ export function containsProfanity(text: string): boolean {
 
 /**
  * Validates a display name. Returns an error message or null if valid.
+ * Intentionally permissive on character content — numbers, symbols, and mixed
+ * scripts are all fine. The only hard rules are length and profanity.
  */
 export function validateDisplayName(name: string): string | null {
   const trimmed = name.trim();
   if (!trimmed) return null; // display name is optional
   if (trimmed.length < 2) return "Display name must be at least 2 characters";
   if (trimmed.length > 30) return "Display name must be 30 characters or less";
-  if (!/[aeiouyAEIOUY]/.test(trimmed)) return "Please enter a valid name";
-  // Flag strings with 4+ consecutive consonants (gibberish like "bsdjkfhsd")
-  if (/[^aeiouy\s]{5,}/i.test(trimmed)) return "Please enter a valid name";
   if (containsProfanity(trimmed)) return "Display name contains inappropriate language";
   return null;
 }


### PR DESCRIPTION
## Summary

Two user-reported issues from the @25th feedback DM:

- **Display name validation** was rejecting valid inputs like `25TH`, `Bob123`, `12345`. The validator required at least one vowel and flagged 5+ consecutive non-vowels as gibberish — both collapsed once digits entered the picture. Dropped both rules; length (2–30) and the profanity blocklist are now the only hard constraints. All-caps initialisms, names with numbers, short non-Latin scripts, and emoji-bearing names all pass.
- **Notifications were unreadable past the dropdown preview.** Clicking an item routed to `/dashboard` (or `metadata.link`, which most informational notifications don't set), losing the message entirely. Added a dedicated `/notifications` page that lists all notifications with full title + wrapped body, per-item timestamp, `Open` CTA when a deep link is present, and `Mark read` / `Mark all read` controls. The bell now routes here instead of `/dashboard`, and the dropdown has a new `View all notifications` footer link.

Shared icon / color / `timeAgo` mapping factored into `src/lib/notification-display.ts` so the bell and page stay in sync as new `NotificationType` variants land.

## Test plan

- [ ] `/settings` → enter `25TH`, `Bob123`, `12345` in Display Name → no error
- [ ] `/settings` → enter a slur → still blocked with "inappropriate language"
- [ ] `/settings` → enter `a` (1 char) → still rejected for length
- [ ] Click notification bell → click any item → lands on `/notifications` (not `/dashboard`)
- [ ] Click "View all notifications" footer in dropdown → lands on `/notifications`
- [ ] `/notifications` shows full message body (no truncation) for streak/digest/milestone notifications
- [ ] `/notifications` empty state renders cleanly for accounts with zero notifications
- [ ] `/notifications` "Mark all read" clears unread state and unread badge
- [ ] Per-item "Mark read" clears the unread dot on that row only
- [ ] Per-item "Open" CTA only renders when `metadata.link` is set, and navigates correctly
- [ ] Unauthenticated visit to `/notifications` redirects to `/auth/login?next=/notifications`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dedicated, auth-gated Notifications page with loading/empty states, unread indicators, “Mark read” and “Mark all read” actions, and per-notification “Open” links.

* **Refactor**
  * Centralized notification presentation (icons, colors, relative timestamps); notification bell now always links to the Notifications page and includes a “View all notifications” footer.
  * Display-name validation relaxed; profanity detection strengthened against evasion.

* **Tests**
  * Added tests for relative-time formatting and display-name/profanity checks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unknownking07/vibe-talent/pull/182)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->