### PR TITLE
perf(caching): enable ISR + edge cache on public pages

### DIFF
--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -1,46 +1,15 @@
-import { createServerSupabaseClient } from "@/lib/supabase/server";
-import { getCurrentUser } from "@/lib/supabase/get-user";
-import { NavbarClient, type NavbarProfile } from "./navbar-client";
+import { NavbarClient } from "./navbar-client";
 
-// Server wrapper: resolves auth + profile during SSR so the navbar paints in
-// the right state on first byte. Without this, the client component flashed
-// the logged-out CTA (and a "??" avatar) for a frame on every refresh while
-// it waited for `getUser()` to round-trip.
+// Render the navbar with a logged-out initial state and let NavbarClient
+// resolve auth client-side after hydration. The previous version called
+// `getCurrentUser()` (which reads cookies via the Supabase server client)
+// during SSR — that single call marked every page in the root layout as
+// dynamic, silently disabling ISR on `/`, `/explore`, `/leaderboard`, etc.
+// and forcing every request through the Vercel origin in iad1.
 //
-// `getCurrentUser` is React.cache'd — when the homepage's HeroCTA also calls
-// it during the same render, they share one Supabase round-trip instead of
-// duplicating the request.
-export async function Navbar() {
-  const user = await getCurrentUser();
-
-  let initialProfile: NavbarProfile | null = null;
-  if (user) {
-    const supabase = await createServerSupabaseClient();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const sb = supabase as any;
-    const { data: profile } = await sb
-      .from("users")
-      .select("username, avatar_url, github_username, display_name")
-      .eq("id", user.id)
-      .single();
-    if (profile?.username) {
-      initialProfile = {
-        username: profile.username,
-        avatar_url: profile.avatar_url ?? null,
-        github_username: profile.github_username ?? null,
-        display_name: profile.display_name ?? null,
-      };
-    } else if (user.email) {
-      // Mirror the client-side fallback: an authenticated user without a
-      // `users` row still gets an avatar (initials) instead of "??".
-      initialProfile = {
-        username: user.email.split("@")[0],
-        avatar_url: null,
-        github_username: null,
-        display_name: null,
-      };
-    }
-  }
-
-  return <NavbarClient initialIsLoggedIn={!!user} initialProfile={initialProfile} />;
+// Tradeoff: logged-in users see the logged-out CTA briefly during the
+// client-side getUser() round-trip on a hard refresh. NavbarClient handles
+// the post-hydration state swap (see useEffect calling supabase.auth.getUser).
+export function Navbar() {
+  return <NavbarClient initialIsLoggedIn={false} initialProfile={null} />;
 }

--- a/src/components/ui/hero-cta.tsx
+++ b/src/components/ui/hero-cta.tsx
@@ -1,11 +1,11 @@
-import { getCurrentUser } from "@/lib/supabase/get-user";
 import { HeroCTAClient } from "./hero-cta-client";
 
-// Server wrapper: resolves auth at SSR time so the hero CTA renders with the
-// correct label ("Go to Dashboard" vs "Create Your Profile") on first paint.
-// `getCurrentUser` is React.cache'd, so the navbar's call earlier in the same
-// render is reused — no extra Supabase round-trip on the homepage.
-export async function HeroCTA(props: { className?: string; style?: React.CSSProperties }) {
-  const user = await getCurrentUser();
-  return <HeroCTAClient {...props} initialIsLoggedIn={!!user} />;
+// Render with a logged-out initial state and let HeroCTAClient resolve auth
+// client-side. Calling `getCurrentUser()` here reads cookies during SSR, which
+// marks the homepage as dynamic and bypasses the `revalidate = 60` ISR cache —
+// every visit then pays the full origin round-trip. The brief CTA label swap
+// for logged-in users on hard refresh is an acceptable cost for letting the
+// page render from edge cache.
+export function HeroCTA(props: { className?: string; style?: React.CSSProperties }) {
+  return <HeroCTAClient {...props} initialIsLoggedIn={false} />;
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,19 @@
 import { updateSession } from "@/lib/supabase/middleware";
 import { NextResponse, type NextRequest } from "next/server";
 
+const AUTH_COOKIE_PREFIX = "sb-";
+const AUTH_COOKIE_SUFFIX = "-auth-token";
+
+function hasSupabaseAuthCookie(request: NextRequest): boolean {
+  return request.cookies
+    .getAll()
+    .some(
+      (c) =>
+        c.name.startsWith(AUTH_COOKIE_PREFIX) &&
+        c.name.endsWith(AUTH_COOKIE_SUFFIX),
+    );
+}
+
 export async function middleware(request: NextRequest) {
   // Catch Supabase auth error redirects (e.g. identity_already_exists)
   // Supabase redirects to the site root with error params when OAuth fails
@@ -14,15 +27,24 @@ export async function middleware(request: NextRequest) {
     // If the user has a Supabase session cookie they're already logged in
     // (e.g. linking GitHub from profile-setup/settings) → send to settings.
     // Otherwise they were signing up/logging in → send to login page.
-    const hasSession = request.cookies
-      .getAll()
-      .some((c) => c.name.startsWith("sb-") && c.name.endsWith("-auth-token"));
-    const dest = hasSession ? "/settings" : "/auth/login";
+    const dest = hasSupabaseAuthCookie(request) ? "/settings" : "/auth/login";
 
     const redirectUrl = new URL(dest, request.url);
     redirectUrl.searchParams.set("error_code", errorCode);
     redirectUrl.searchParams.set("error_description", errorDescription);
     return NextResponse.redirect(redirectUrl);
+  }
+
+  // Anonymous visitors on non-protected routes skip updateSession entirely.
+  // updateSession calls supabase.auth.getUser() and writes Set-Cookie, which
+  // forces `cache-control: no-store` and bypasses both Vercel ISR and the
+  // Cloudflare edge — meaning every visit pays the full origin round-trip
+  // (Vercel iad1). With no auth cookie there's nothing to refresh anyway.
+  // Authenticated users still hit the full code path so the cookie-refresh
+  // fix from the previous regression remains intact.
+  const isProtectedRoute = request.nextUrl.pathname.startsWith("/dashboard");
+  if (!isProtectedRoute && !hasSupabaseAuthCookie(request)) {
+    return NextResponse.next({ request });
   }
 
   return await updateSession(request);


### PR DESCRIPTION
## Summary

- Navbar and HeroCTA called `getCurrentUser()` during SSR (which reads cookies via the Supabase server client). That single read marked every page in the layout tree as `ƒ Dynamic`, silently disabling `revalidate = 60` on `/`, `/explore`, `/leaderboard`, `/feed`, etc. — so Vercel ISR was off and Cloudflare could only proxy transparently.
- Middleware also wrote `Set-Cookie` on every anonymous request via `updateSession`, forcing `cache-control: private, no-cache, no-store` on the response.
- Result: every visit paid a full Vercel origin round-trip from `iad1` (US-East), giving a 4.3s page load to users outside the US.

## What changed

- `src/middleware.ts` — skip `updateSession()` for anonymous visitors on non-protected routes. With no auth cookie there's nothing to refresh, so the response stays cacheable. Authenticated users still go through the same code path, so the prior session-expiry regression doesn't return.
- `src/components/layout/navbar.tsx` — render `NavbarClient` with `initialIsLoggedIn={false}` and let it resolve auth client-side via its existing `useEffect` hook.
- `src/components/ui/hero-cta.tsx` — same treatment for `HeroCTAClient`.

## After

Every public top-level route flips from `ƒ Dynamic` → `○ Static` with `s-maxage=60, stale-while-revalidate=31535940`:

```
┌ ○ /                                            1m      1y
├ ○ /_not-found                                  1m      1y
├ ○ /explore                                     1m      1y
├ ○ /feed                                        1m      1y
├ ○ /leaderboard                                 1m      1y
├ ○ /projects                                    1m      1y
└ ○ /pricing                                     1m      1y
```

Local `next start` TTFB: **3ms** (was 4,279ms in CF analytics).

## Tradeoff

Logged-in users see the logged-out CTA / generic avatar briefly (~200–500ms) on a hard refresh of a public page while `NavbarClient` hydrates and calls `supabase.auth.getUser()`. Follow-up: cache the user state in `localStorage` to eliminate the flash for returning sessions.

## Test plan

- [ ] Open `/` as anonymous in incognito → page renders, hero CTA says "Create Your Profile", navbar shows logged-out state
- [ ] Open `/explore`, `/leaderboard`, `/feed`, `/projects`, `/pricing` as anonymous → all render
- [ ] Sign in → open `/` (hard refresh) → expect brief logged-out flash, then auth state appears
- [ ] Signed-in: `/dashboard` works as before
- [ ] Signed-out: `/dashboard` still redirects to `/auth/login` (middleware protected-route path)
- [ ] Trigger an OAuth error (or visit `/?error_code=test&error_description=foo`) → still redirects to `/auth/login`
- [ ] In Vercel preview: `curl -I` the deployed URL → `cache-control: s-maxage=60, stale-while-revalidate=...` and `x-vercel-cache: HIT` after the second request

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized authentication state initialization to resolve client-side instead of server-side, improving initial load performance.
  * Updated middleware to skip redundant session checks for unauthenticated users on certain routes.

* **Performance**
  * Streamlined authentication processing for faster page loads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unknownking07/vibe-talent/pull/184)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->