### PR TITLE
feat: social visibility pack (leaderboard, share cards, receipts, reviewer rep)

### DIFF
--- a/scripts/seed-social-visibility.ts
+++ b/scripts/seed-social-visibility.ts
@@ -1,0 +1,58 @@
+// scripts/seed-social-visibility.ts
+// Usage: npx tsx scripts/seed-social-visibility.ts
+//
+// Inserts last-Monday snapshot rows for the top N active users, so the weekly
+// leaderboard shows climbers immediately without waiting for the next Monday cron tick.
+//
+// Run from a checkout with NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY in env
+// (load .env.local before invoking).
+import { createAdminClient } from "../src/lib/supabase/admin";
+import { mondayOf } from "../src/lib/cron-jobs/weekly-snapshot";
+
+async function main() {
+  const sb = createAdminClient();
+  const today = new Date();
+  const lastMonday = (() => {
+    const d = mondayOf(today);
+    d.setUTCDate(d.getUTCDate() - 7);
+    return d.toISOString().slice(0, 10);
+  })();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: users } = await (sb as any)
+    .from("users")
+    .select("id, username, vibe_score")
+    .gt("vibe_score", 50)
+    .order("vibe_score", { ascending: false })
+    .limit(8);
+
+  if (!users || users.length < 2) {
+    console.error("Need at least 2 users with vibe_score > 50 in DB to seed climber data.");
+    process.exit(1);
+  }
+
+  // Synthesize "last week" by knocking each user's score down 50-130 points and
+  // assigning previous ranks in reverse (so they all show as climbers).
+  const rows = (users as Array<{ id: string; username: string; vibe_score: number }>).map((u, i) => ({
+    user_id: u.id,
+    week_start: lastMonday,
+    vibe_score: Math.max(100, u.vibe_score - 50 - i * 10),
+    rank: users.length - i,
+    commits_7d: 0,
+  }));
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (sb as any)
+    .from("vibe_score_weekly_snapshots")
+    .upsert(rows, { onConflict: "user_id,week_start" });
+
+  if (error) {
+    console.error("Failed to seed snapshots:", error);
+    process.exit(1);
+  }
+
+  console.log(`Seeded ${rows.length} snapshot rows for week_start=${lastMonday}.`);
+  console.log(`Visit http://localhost:3000/leaderboard — weekly tab should now show climbers.`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/src/app/api/cron/daily/route.ts
+++ b/src/app/api/cron/daily/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSiteUrl } from "@/lib/seo";
+import { runReviewerCalibration } from "@/lib/cron-jobs/reviewer-calibration";
 
 // Daily orchestrator awaits each child cron sequentially, so its own
 // timeout has to be long enough to cover the slowest child plus all
@@ -52,9 +53,20 @@ export async function GET(req: NextRequest) {
   const summary = Object.entries(results).map(([name, r]: [string, { status: number }]) => `${name}:${r.status}`).join(", ");
   console.log(`Daily cron completed: ${summary}`);
 
+  // Run reviewer calibration in-process after the fan-out so we don't burn
+  // another Vercel cron slot. Isolated try/catch: a calibration failure must
+  // not mask the orchestrator's primary results.
+  let reviewerCalibration: { updated: number; skipped: number } | null = null;
+  try {
+    reviewerCalibration = await runReviewerCalibration();
+  } catch (error) {
+    console.error("Daily cron reviewer-calibration error:", error);
+  }
+
   return NextResponse.json({
     message: "Daily cron completed",
     results,
+    reviewerCalibration,
     ran_at: new Date().toISOString(),
   });
 }

--- a/src/app/api/cron/quality-rescore/route.ts
+++ b/src/app/api/cron/quality-rescore/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { analyzeRepository, checkLiveUrl, parseGithubRepoUrl } from "@/lib/github-quality";
+import { runWeeklySnapshot } from "@/lib/cron-jobs/weekly-snapshot";
 
 // Each project costs 4 api.github.com calls. At 50 projects per run that's
 // 200 calls — well over the 60/hr anonymous limit. Plus default 60s Vercel
@@ -69,8 +70,29 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: "Failed to fetch projects" }, { status: 500 });
     }
 
+    // Monday-only weekly snapshot of all users' vibe scores so we can compute
+    // "climbed since last Monday" deltas. Runs in-process after rescoring (or
+    // the no-op skip path) to avoid burning another Vercel cron slot. Isolated
+    // try/catch: a snapshot failure must not mask the rescore result.
+    const today = new Date();
+    const isMondayUTC = today.getUTCDay() === 1;
+    const runSnapshot = async (): Promise<{ inserted: number } | null> => {
+      if (!isMondayUTC) return null;
+      try {
+        return await runWeeklySnapshot(today);
+      } catch (err) {
+        console.error("quality-rescore weekly-snapshot error:", err);
+        return null;
+      }
+    };
+
     if (needsRescore.length === 0) {
-      return NextResponse.json({ message: "No projects need rescoring", rescored: 0 });
+      const weeklySnapshot = await runSnapshot();
+      return NextResponse.json({
+        message: "No projects need rescoring",
+        rescored: 0,
+        weeklySnapshot,
+      });
     }
 
     let rescored = 0;
@@ -137,11 +159,14 @@ export async function GET(req: NextRequest) {
 
     console.log(`Quality rescore complete: ${rescored} rescored, ${errors} errors`);
 
+    const weeklySnapshot = await runSnapshot();
+
     return NextResponse.json({
       message: `Quality rescore complete: ${rescored} rescored, ${errors} errors`,
       rescored,
       errors,
       total_checked: needsRescore.length,
+      weeklySnapshot,
     });
   } catch (error) {
     console.error("Quality rescore cron error:", error);

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -23,18 +23,20 @@ export async function GET(request: NextRequest) {
 
       const { data: logs } = await sb
         .from("streak_logs")
-        .select("user_id, activity_date")
+        .select("user_id, activity_date, commit_count")
         .gte("activity_date", windowStartStr);
 
-      // Aggregate distinct dates per user
+      // Aggregate distinct dates AND sum commit counts per user
       const datesByUser = new Map<string, Set<string>>();
-      for (const log of (logs ?? []) as Array<{ user_id: string; activity_date: string }>) {
+      const commitsByUser = new Map<string, number>();
+      for (const log of (logs ?? []) as Array<{ user_id: string; activity_date: string; commit_count: number }>) {
         let s = datesByUser.get(log.user_id);
         if (!s) {
           s = new Set();
           datesByUser.set(log.user_id, s);
         }
         s.add(log.activity_date);
+        commitsByUser.set(log.user_id, (commitsByUser.get(log.user_id) ?? 0) + (log.commit_count ?? 1));
       }
       const activeDaysByUserId = new Map<string, number>();
       for (const [uid, dates] of datesByUser) activeDaysByUserId.set(uid, dates.size);
@@ -58,9 +60,6 @@ export async function GET(request: NextRequest) {
         .in("id", topUserIds)
         .not("username", "is", null);
 
-      // Assign live ranks from a separate query (overall vibe_score ranking)
-      // For simplicity, rank within the active set by vibe_score for now —
-      // current_rank is informational ("rank #38") so set it relative to all users.
       const { data: allRanked } = await sb
         .from("users")
         .select("id")
@@ -78,7 +77,7 @@ export async function GET(request: NextRequest) {
         rank: rankByUserId.get(u.id) ?? 9999,
       }));
 
-      const builders = computeActiveBuilders(activeDaysByUserId, enriched).slice(0, limit);
+      const builders = computeActiveBuilders(activeDaysByUserId, commitsByUser, enriched).slice(0, limit);
 
       return NextResponse.json(
         { leaderboard: builders, range: "week", mode: "active" },

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -15,15 +15,16 @@ export async function GET(request: NextRequest) {
     const sb = supabase as any;
 
     if (range === "week") {
-      // Last 7 days inclusive
-      const sevenDaysAgo = new Date();
-      sevenDaysAgo.setUTCDate(sevenDaysAgo.getUTCDate() - 7);
-      const sevenDaysAgoStr = sevenDaysAgo.toISOString().slice(0, 10);
+      // Last 7 days inclusive of today: today + 6 prior days = 7 calendar dates.
+      // (Using -7 here would span 8 distinct dates, which is wrong.)
+      const windowStart = new Date();
+      windowStart.setUTCDate(windowStart.getUTCDate() - 6);
+      const windowStartStr = windowStart.toISOString().slice(0, 10);
 
       const { data: logs } = await sb
         .from("streak_logs")
         .select("user_id, activity_date")
-        .gte("activity_date", sevenDaysAgoStr);
+        .gte("activity_date", windowStartStr);
 
       // Aggregate distinct dates per user
       const datesByUser = new Map<string, Set<string>>();

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,16 +1,53 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { computeClimbers, MIN_VIBE_FLOOR } from "@/lib/leaderboard/weekly";
+import { mondayOf } from "@/lib/cron-jobs/weekly-snapshot";
 
-// GET /api/leaderboard?sort=vibe_score|streak|projects&limit=10
+// GET /api/leaderboard?sort=vibe_score|streak|projects&limit=10&range=all|week
 export async function GET(request: NextRequest) {
   const sort = request.nextUrl.searchParams.get("sort") || "vibe_score";
   const rawLimit = parseInt(request.nextUrl.searchParams.get("limit") || "10");
   const limit = Math.min(Math.max(isNaN(rawLimit) ? 10 : rawLimit, 1), 100);
+  const range = request.nextUrl.searchParams.get("range") || "all";
 
   try {
     const supabase = await createServerSupabaseClient();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sb = supabase as any;
+
+    if (range === "week") {
+      const monday = mondayOf(new Date()).toISOString().slice(0, 10);
+
+      const { data: snapshots } = await sb
+        .from("vibe_score_weekly_snapshots")
+        .select("user_id, rank, vibe_score")
+        .eq("week_start", monday);
+
+      const { data: current } = await sb
+        .from("users")
+        .select("id, username, avatar_url, vibe_score")
+        .not("username", "is", null)
+        .gte("vibe_score", MIN_VIBE_FLOOR)
+        .order("vibe_score", { ascending: false });
+
+      const ranked = (current ?? []).map(
+        (u: { id: string; username: string; avatar_url: string | null; vibe_score: number }, i: number) => ({
+          ...u,
+          rank: i + 1,
+        })
+      );
+
+      const climbers = computeClimbers(snapshots ?? [], ranked).slice(0, limit);
+
+      return NextResponse.json(
+        { leaderboard: climbers, range: "week", week_start: monday },
+        {
+          headers: {
+            "Cache-Control": "public, s-maxage=60, stale-while-revalidate=120",
+          },
+        }
+      );
+    }
 
     const orderColumn = sort === "projects" ? "vibe_score" : sort === "streak" ? "longest_streak" : "vibe_score";
     const { data: users, error } = await sb

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
-import { computeClimbers, MIN_VIBE_FLOOR } from "@/lib/leaderboard/weekly";
-import { mondayOf } from "@/lib/cron-jobs/weekly-snapshot";
+import { computeActiveBuilders } from "@/lib/leaderboard/weekly";
 
 // GET /api/leaderboard?sort=vibe_score|streak|projects&limit=10&range=all|week
 export async function GET(request: NextRequest) {
@@ -16,36 +15,73 @@ export async function GET(request: NextRequest) {
     const sb = supabase as any;
 
     if (range === "week") {
-      const monday = mondayOf(new Date()).toISOString().slice(0, 10);
+      // Last 7 days inclusive
+      const sevenDaysAgo = new Date();
+      sevenDaysAgo.setUTCDate(sevenDaysAgo.getUTCDate() - 7);
+      const sevenDaysAgoStr = sevenDaysAgo.toISOString().slice(0, 10);
 
-      const { data: snapshots } = await sb
-        .from("vibe_score_weekly_snapshots")
-        .select("user_id, rank, vibe_score")
-        .eq("week_start", monday);
+      const { data: logs } = await sb
+        .from("streak_logs")
+        .select("user_id, activity_date")
+        .gte("activity_date", sevenDaysAgoStr);
 
-      const { data: current } = await sb
+      // Aggregate distinct dates per user
+      const datesByUser = new Map<string, Set<string>>();
+      for (const log of (logs ?? []) as Array<{ user_id: string; activity_date: string }>) {
+        let s = datesByUser.get(log.user_id);
+        if (!s) {
+          s = new Set();
+          datesByUser.set(log.user_id, s);
+        }
+        s.add(log.activity_date);
+      }
+      const activeDaysByUserId = new Map<string, number>();
+      for (const [uid, dates] of datesByUser) activeDaysByUserId.set(uid, dates.size);
+
+      // Take top 200 active user IDs to bound the user query
+      const topUserIds = [...activeDaysByUserId.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 200)
+        .map(([uid]) => uid);
+
+      if (topUserIds.length === 0) {
+        return NextResponse.json(
+          { leaderboard: [], range: "week", mode: "active" },
+          { headers: { "Cache-Control": "public, s-maxage=60, stale-while-revalidate=120" } },
+        );
+      }
+
+      const { data: users } = await sb
         .from("users")
-        .select("id, username, avatar_url, vibe_score")
+        .select("id, username, avatar_url, vibe_score, streak")
+        .in("id", topUserIds)
+        .not("username", "is", null);
+
+      // Assign live ranks from a separate query (overall vibe_score ranking)
+      // For simplicity, rank within the active set by vibe_score for now —
+      // current_rank is informational ("rank #38") so set it relative to all users.
+      const { data: allRanked } = await sb
+        .from("users")
+        .select("id")
         .not("username", "is", null)
-        .gte("vibe_score", MIN_VIBE_FLOOR)
         .order("vibe_score", { ascending: false });
+      const rankByUserId = new Map<string, number>();
+      (allRanked ?? []).forEach((u: { id: string }, i: number) => rankByUserId.set(u.id, i + 1));
 
-      const ranked = (current ?? []).map(
-        (u: { id: string; username: string; avatar_url: string | null; vibe_score: number }, i: number) => ({
-          ...u,
-          rank: i + 1,
-        })
-      );
+      const enriched = (users ?? []).map((u: { id: string; username: string; avatar_url: string | null; vibe_score: number; streak: number }) => ({
+        id: u.id,
+        username: u.username,
+        avatar_url: u.avatar_url,
+        vibe_score: u.vibe_score,
+        streak: u.streak ?? 0,
+        rank: rankByUserId.get(u.id) ?? 9999,
+      }));
 
-      const climbers = computeClimbers(snapshots ?? [], ranked).slice(0, limit);
+      const builders = computeActiveBuilders(activeDaysByUserId, enriched).slice(0, limit);
 
       return NextResponse.json(
-        { leaderboard: climbers, range: "week", week_start: monday },
-        {
-          headers: {
-            "Cache-Control": "public, s-maxage=60, stale-while-revalidate=120",
-          },
-        }
+        { leaderboard: builders, range: "week", mode: "active" },
+        { headers: { "Cache-Control": "public, s-maxage=60, stale-while-revalidate=120" } },
       );
     }
 

--- a/src/app/api/og/receipt/[type]/[username]/route.tsx
+++ b/src/app/api/og/receipt/[type]/[username]/route.tsx
@@ -13,14 +13,15 @@ export async function GET(
 ) {
   const { type, username } = await ctx.params;
   const validType = (["weekly", "shipped", "custom"] as const).includes(type as ReceiptType) ? (type as ReceiptType) : "weekly";
+  // validType is currently computed for future per-type detail rows; keep it for parity.
+  void validType;
 
   const user = await fetchUserByUsernameCached(username);
   if (!user) {
     return new Response("Not Found", { status: 404 });
   }
 
-  const lines = buildLines(validType, user);
-  const headerSub = headerSubFor(validType);
+  const lines = buildLines(user);
 
   return new ImageResponse(
     (
@@ -32,9 +33,26 @@ export async function GET(
           background: "#fff", color: "#0F0F0F", padding: "36px 44px", width: "76%",
           boxShadow: "12px 12px 0 #FF3A00", position: "relative", display: "flex", flexDirection: "column",
         }}>
-          <div style={{ textAlign: "center", borderBottom: "3px dashed #0F0F0F", paddingBottom: 16, marginBottom: 18, display: "flex", flexDirection: "column" }}>
-            <div style={{ fontSize: 26, fontWeight: 900, letterSpacing: "0.18em", display: "flex", justifyContent: "center" }}>VIBETALENT · {validType.toUpperCase()}</div>
-            <div style={{ fontSize: 16, fontWeight: 700, color: "#3F3F46", letterSpacing: "0.08em", marginTop: 6, display: "flex", justifyContent: "center" }}>{headerSub}</div>
+          <div style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            borderBottom: "3px dashed #0F0F0F",
+            paddingBottom: 18,
+            marginBottom: 18,
+          }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+              <Avatar user={user} size={64} />
+              <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                <span style={{ display: "flex", fontSize: 32, fontWeight: 900, letterSpacing: "-0.02em" }}>
+                  @{user.username}
+                </span>
+                {user.github_username ? <VerifiedBadge size={24} /> : null}
+              </div>
+            </div>
+            <div style={{ display: "flex", fontSize: 14, fontWeight: 900, letterSpacing: "0.18em", color: "#0F0F0F" }}>
+              VIBE<span style={{ display: "flex", color: "#FF3A00" }}>TALENT</span>
+            </div>
           </div>
 
           {lines.map(({ label, value, highlight }) => (
@@ -69,18 +87,69 @@ export async function GET(
   );
 }
 
-function buildLines(_type: ReceiptType, user: { username: string; longest_streak?: number | null; streak?: number | null }): Array<{ label: string; value: string; highlight?: boolean }> {
-  // For v1, just username + streak + longest. Receipt detail (commits, rank delta) gets
-  // wired in Task 17 when we add /api/receipt/[username]/weekly.
+function buildLines(user: { longest_streak?: number | null; streak?: number | null }): Array<{ label: string; value: string; highlight?: boolean }> {
+  // For v1, just streak + longest. Receipt detail (commits, rank delta) gets
+  // wired in Task 17 when we add /api/receipt/[username]/weekly. Username is in the header.
   return [
-    { label: "USER", value: `@${user.username}` },
     { label: "STREAK", value: `${user.streak ?? 0} days` },
     { label: "LONGEST", value: `${user.longest_streak ?? 0} days` },
   ];
 }
 
-function headerSubFor(type: ReceiptType): string {
-  if (type === "weekly")  return "WEEKLY RECEIPT";
-  if (type === "shipped") return "PROJECT SHIPPED";
-  return "SHARED FROM PROFILE";
+function Avatar({ user, size }: { user: { username: string; avatar_url: string | null }; size: number }) {
+  const url = user.avatar_url;
+  const valid = typeof url === "string" && /^https?:\/\//.test(url);
+  if (valid) {
+    return (
+      <div style={{
+        display: "flex",
+        width: size, height: size,
+        borderRadius: "50%",
+        overflow: "hidden",
+        border: "2px solid #0F0F0F",
+        flexShrink: 0,
+      }}>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={url} width={size} height={size} alt="" style={{ display: "flex", objectFit: "cover", width: size, height: size }} />
+      </div>
+    );
+  }
+  return (
+    <div style={{
+      display: "flex",
+      width: size, height: size,
+      borderRadius: "50%",
+      border: "2px solid #0F0F0F",
+      background: "linear-gradient(135deg, #FF3A00, #FFA07A)",
+      color: "#fff",
+      fontWeight: 900,
+      fontSize: size * 0.42,
+      alignItems: "center",
+      justifyContent: "center",
+      flexShrink: 0,
+    }}>
+      {(user.username[0] ?? "?").toUpperCase()}
+    </div>
+  );
+}
+
+function VerifiedBadge({ size }: { size: number }) {
+  return (
+    <div style={{
+      display: "flex",
+      width: size, height: size,
+      borderRadius: "50%",
+      background: "#FF3A00",
+      border: "1.5px solid #0F0F0F",
+      alignItems: "center",
+      justifyContent: "center",
+      color: "#fff",
+      fontWeight: 900,
+      fontSize: size * 0.6,
+      lineHeight: 1,
+      flexShrink: 0,
+    }}>
+      ✓
+    </div>
+  );
 }

--- a/src/app/api/og/receipt/[type]/[username]/route.tsx
+++ b/src/app/api/og/receipt/[type]/[username]/route.tsx
@@ -1,0 +1,86 @@
+import { ImageResponse } from "next/og";
+import { fetchUserByUsernameCached } from "@/lib/supabase/server-queries";
+
+export const runtime = "edge";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+type ReceiptType = "weekly" | "shipped" | "custom";
+
+export async function GET(
+  _req: Request,
+  ctx: { params: Promise<{ type: string; username: string }> },
+) {
+  const { type, username } = await ctx.params;
+  const validType = (["weekly", "shipped", "custom"] as const).includes(type as ReceiptType) ? (type as ReceiptType) : "weekly";
+
+  const user = await fetchUserByUsernameCached(username);
+  if (!user) {
+    return new Response("Not Found", { status: 404 });
+  }
+
+  const lines = buildLines(validType, user);
+  const headerSub = headerSubFor(validType);
+
+  return new ImageResponse(
+    (
+      <div style={{
+        width: "100%", height: "100%", display: "flex", alignItems: "center", justifyContent: "center",
+        background: "#0F0F0F", padding: 50, fontFamily: "ui-monospace, Menlo, monospace",
+      }}>
+        <div style={{
+          background: "#fff", color: "#0F0F0F", padding: "36px 44px", width: "76%",
+          boxShadow: "12px 12px 0 #FF3A00", position: "relative", display: "flex", flexDirection: "column",
+        }}>
+          <div style={{ textAlign: "center", borderBottom: "3px dashed #0F0F0F", paddingBottom: 16, marginBottom: 18, display: "flex", flexDirection: "column" }}>
+            <div style={{ fontSize: 26, fontWeight: 900, letterSpacing: "0.18em", display: "flex", justifyContent: "center" }}>VIBETALENT · {validType.toUpperCase()}</div>
+            <div style={{ fontSize: 16, fontWeight: 700, color: "#3F3F46", letterSpacing: "0.08em", marginTop: 6, display: "flex", justifyContent: "center" }}>{headerSub}</div>
+          </div>
+
+          {lines.map(({ label, value, highlight }) => (
+            <div key={label} style={{ display: "flex", justifyContent: "space-between", fontSize: 22, padding: "4px 0", letterSpacing: "0.02em" }}>
+              <span style={{ display: "flex" }}>{label}</span>
+              <span style={{ fontWeight: 800, color: highlight ? "#FF3A00" : "#0F0F0F", display: "flex" }}>{value}</span>
+            </div>
+          ))}
+
+          <div style={{ marginTop: 12, paddingTop: 12, borderTop: "3px dashed #0F0F0F", display: "flex", justifyContent: "space-between", fontSize: 24, fontWeight: 800 }}>
+            <span style={{ display: "flex" }}>VIBE_SCORE</span>
+            <span style={{ color: "#FF3A00", fontSize: 28, display: "flex" }}>{user.vibe_score}</span>
+          </div>
+
+          <div style={{ display: "flex", gap: 2, justifyContent: "center", marginTop: 16 }}>
+            {Array.from({ length: 32 }).map((_, i) => (
+              <div key={i} style={{
+                width: i % 3 === 0 ? 4 : 2,
+                height: i % 2 === 0 ? 28 : 22,
+                background: "#0F0F0F",
+                display: "flex",
+              }} />
+            ))}
+          </div>
+          <div style={{ textAlign: "center", marginTop: 12, fontSize: 14, color: "#3F3F46", letterSpacing: "0.18em", fontWeight: 700, display: "flex", justifyContent: "center" }}>
+            — THANK YOU FOR SHIPPING —
+          </div>
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}
+
+function buildLines(_type: ReceiptType, user: { username: string; longest_streak?: number | null; streak?: number | null }): Array<{ label: string; value: string; highlight?: boolean }> {
+  // For v1, just username + streak + longest. Receipt detail (commits, rank delta) gets
+  // wired in Task 17 when we add /api/receipt/[username]/weekly.
+  return [
+    { label: "USER", value: `@${user.username}` },
+    { label: "STREAK", value: `${user.streak ?? 0} days` },
+    { label: "LONGEST", value: `${user.longest_streak ?? 0} days` },
+  ];
+}
+
+function headerSubFor(type: ReceiptType): string {
+  if (type === "weekly")  return "WEEKLY RECEIPT";
+  if (type === "shipped") return "PROJECT SHIPPED";
+  return "SHARED FROM PROFILE";
+}

--- a/src/app/api/og/receipt/[type]/[username]/route.tsx
+++ b/src/app/api/og/receipt/[type]/[username]/route.tsx
@@ -42,12 +42,12 @@ export async function GET(
             marginBottom: 18,
           }}>
             <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
-              <Avatar user={user} size={64} />
+              <Avatar user={user} size={100} />
               <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
                 <span style={{ display: "flex", fontSize: 32, fontWeight: 900, letterSpacing: "-0.02em" }}>
                   @{user.username}
                 </span>
-                {user.github_username ? <VerifiedBadge size={24} /> : null}
+                {user.github_username ? <VerifiedBadge size={32} /> : null}
               </div>
             </div>
             <div style={{ display: "flex", fontSize: 14, fontWeight: 900, letterSpacing: "0.18em", color: "#0F0F0F" }}>
@@ -106,11 +106,17 @@ function Avatar({ user, size }: { user: { username: string; avatar_url: string |
         width: size, height: size,
         borderRadius: "50%",
         overflow: "hidden",
-        border: "2px solid #0F0F0F",
+        border: "2.5px solid #0F0F0F",
         flexShrink: 0,
       }}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img src={url} width={size} height={size} alt="" style={{ display: "flex", objectFit: "cover", width: size, height: size }} />
+        <img
+          src={url}
+          width={size}
+          height={size}
+          alt=""
+          style={{ display: "flex", objectFit: "cover", width: size, height: size }}
+        />
       </div>
     );
   }
@@ -119,7 +125,7 @@ function Avatar({ user, size }: { user: { username: string; avatar_url: string |
       display: "flex",
       width: size, height: size,
       borderRadius: "50%",
-      border: "2px solid #0F0F0F",
+      border: "2.5px solid #0F0F0F",
       background: "linear-gradient(135deg, #FF3A00, #FFA07A)",
       color: "#fff",
       fontWeight: 900,
@@ -135,21 +141,22 @@ function Avatar({ user, size }: { user: { username: string; avatar_url: string |
 
 function VerifiedBadge({ size }: { size: number }) {
   return (
-    <div style={{
-      display: "flex",
-      width: size, height: size,
-      borderRadius: "50%",
-      background: "#FF3A00",
-      border: "1.5px solid #0F0F0F",
-      alignItems: "center",
-      justifyContent: "center",
-      color: "#fff",
-      fontWeight: 900,
-      fontSize: size * 0.6,
-      lineHeight: 1,
-      flexShrink: 0,
-    }}>
-      ✓
-    </div>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      style={{ display: "flex", flexShrink: 0 }}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx={12} cy={12} r={11} fill="#FF3A00" stroke="#0F0F0F" strokeWidth={1.5} />
+      <path
+        d="M7 12.5l3 3 7-7"
+        fill="none"
+        stroke="#fff"
+        strokeWidth={2.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
   );
 }

--- a/src/app/api/projects/verify/route.ts
+++ b/src/app/api/projects/verify/route.ts
@@ -60,9 +60,11 @@ export async function POST(request: Request) {
     // Resolve GitHub handle from users.github_username (authoritative; synced
     // from the GitHub identity on every OAuth callback). Fall back to OAuth
     // metadata only for the first-login edge case before the callback wrote.
+    // Also pull `username` here so the success response can return a
+    // shipped_receipt_url without a second round-trip.
     const { data: userRow } = await sb
       .from("users")
-      .select("github_username")
+      .select("github_username, username")
       .eq("id", user.id)
       .single();
 
@@ -71,6 +73,8 @@ export async function POST(request: Request) {
       user.user_metadata?.user_name ||
       user.user_metadata?.preferred_username ||
       null;
+
+    const profileUsername: string | null = userRow?.username ?? null;
 
     if (!githubUsername) {
       return NextResponse.json(
@@ -188,6 +192,13 @@ export async function POST(request: Request) {
       // visit instead of waiting up to 60s for unstable_cache to expire.
       await invalidateProfileCache(sb, user.id);
 
+      // Projects don't have a slug column today — id is the canonical handle
+      // used by /share/[username]/shipped/[slug] (slug is treated as a label).
+      const receiptSlug = project.id;
+      const shipped_receipt_url = profileUsername
+        ? `/share/${profileUsername}/shipped/${receiptSlug}`
+        : null;
+
       return NextResponse.json({
         verified: true,
         reason: "Repository owner matches your GitHub username.",
@@ -195,6 +206,7 @@ export async function POST(request: Request) {
         quality_score: qualityScore,
         quality_metrics: qualityMetrics,
         live_url_ok,
+        shipped_receipt_url,
       });
     }
 
@@ -280,6 +292,13 @@ export async function POST(request: Request) {
           // instead of waiting up to 60s for unstable_cache to expire.
           await invalidateProfileCache(sb, user.id);
 
+          // Projects don't have a slug column today — id is the canonical
+          // handle used by /share/[username]/shipped/[slug].
+          const receiptSlug = project.id;
+          const shipped_receipt_url = profileUsername
+            ? `/share/${profileUsername}/shipped/${receiptSlug}`
+            : null;
+
           return NextResponse.json({
             verified: true,
             reason:
@@ -288,6 +307,7 @@ export async function POST(request: Request) {
             quality_score: qualityScore,
             quality_metrics: qualityMetrics,
             live_url_ok,
+            shipped_receipt_url,
           });
         } else {
           return NextResponse.json({

--- a/src/app/api/receipt/[username]/weekly/route.ts
+++ b/src/app/api/receipt/[username]/weekly/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { mondayOf } from "@/lib/cron-jobs/weekly-snapshot";
+
+export async function GET(req: NextRequest, ctx: { params: Promise<{ username: string }> }) {
+  const { username } = await ctx.params;
+  const weekParam = req.nextUrl.searchParams.get("week");
+  // week format: YYYY-MM-DD (Monday) — defaults to current Monday
+  const weekStart = weekParam ?? mondayOf(new Date()).toISOString().slice(0, 10);
+
+  const sb = createAdminClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: user } = await (sb as any)
+    .from("users").select("id, username, vibe_score, streak, longest_streak").eq("username", username).single();
+
+  if (!user) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: thisWeek } = await (sb as any)
+    .from("vibe_score_weekly_snapshots").select("rank, vibe_score").eq("user_id", user.id).eq("week_start", weekStart).maybeSingle();
+
+  // Previous Monday for delta
+  const prevMonday = new Date(weekStart);
+  prevMonday.setUTCDate(prevMonday.getUTCDate() - 7);
+  const prevMondayStr = prevMonday.toISOString().slice(0, 10);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: prevWeek } = await (sb as any)
+    .from("vibe_score_weekly_snapshots").select("rank, vibe_score").eq("user_id", user.id).eq("week_start", prevMondayStr).maybeSingle();
+
+  return NextResponse.json({
+    username: user.username,
+    weekStart,
+    vibeScore: user.vibe_score,
+    scoreDelta: thisWeek && prevWeek ? thisWeek.vibe_score - prevWeek.vibe_score : null,
+    rank: thisWeek?.rank ?? null,
+    rankClimb: thisWeek && prevWeek ? prevWeek.rank - thisWeek.rank : null,
+    streak: user.streak,
+    ogImageUrl: `/api/og/receipt/weekly/${user.username}?w=${weekStart}`,
+    shareUrl: `/share/${user.username}/weekly/${weekStart}`,
+  }, { headers: { "Cache-Control": "public, s-maxage=300, stale-while-revalidate=600" } });
+}

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -4,6 +4,7 @@ import { calculateReviewTrust } from "@/lib/review-trust";
 import { createNotification } from "@/lib/notifications";
 import { sendReviewNotificationEmail } from "@/lib/email";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { validateName, validateEmail, validateUUID } from "@/lib/validation";
 
 export async function GET(req: NextRequest) {
@@ -119,6 +120,20 @@ export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
     const { builder_id, reviewer_name, reviewer_email, rating, comment, hire_request_id } = body;
+
+    // Detect the current authenticated user (if any) so we can link the review
+    // to a platform identity. Anonymous external reviewers (e.g. submitted from
+    // a hire-request email link) fall through with null — the existing flow is
+    // unchanged in that case. Wrapped in try/catch so a session-read hiccup
+    // never blocks a legitimate anonymous review.
+    let reviewerUserId: string | null = null;
+    try {
+      const supabase = await createServerSupabaseClient();
+      const { data: { user } } = await supabase.auth.getUser();
+      reviewerUserId = user?.id ?? null;
+    } catch {
+      reviewerUserId = null;
+    }
 
     // Validate required fields
     if (!builder_id || !reviewer_name || !reviewer_email || rating === undefined) {
@@ -277,6 +292,7 @@ export async function POST(req: NextRequest) {
         comment: commentClean,
         hire_request_id: hire_request_id || null,
         trust_score,
+        reviewer_user_id: reviewerUserId,
       })
       .select("id")
       .single();

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -21,9 +21,15 @@ export async function GET(req: NextRequest) {
     }
 
     const sb = createAdminClient();
-    const { data, error } = await sb
+    // Embed reviewer profile (username + reputation) via the reviewer_user_id FK.
+    // Anonymous reviews (reviewer_user_id IS NULL) come back with reviewer: null.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data, error } = await (sb as any)
       .from("reviews")
-      .select("id, builder_id, reviewer_name, reviewer_email, rating, comment, trust_score, created_at")
+      .select(`
+        id, builder_id, reviewer_name, reviewer_email, rating, comment, trust_score, created_at, reviewer_user_id,
+        reviewer:users!reviewer_user_id ( username, reviewer_calibration, reviewer_tier )
+      `)
       .eq("builder_id", builderId)
       .order("created_at", { ascending: false });
 

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,5 +1,5 @@
 import { fetchAllUsersCached } from "@/lib/supabase/server-queries";
-import { LeaderboardContent } from "@/components/leaderboard/leaderboard-content";
+import { LeaderboardTabs } from "@/components/leaderboard/leaderboard-tabs";
 import { siteUrl, buildBreadcrumbList } from "@/lib/seo";
 import { Trophy } from "lucide-react";
 import type { Metadata } from "next";
@@ -81,7 +81,7 @@ export default async function LeaderboardPage() {
         </p>
       </div>
 
-      <LeaderboardContent users={users} />
+      <LeaderboardTabs users={users} />
     </div>
   );
 }

--- a/src/app/profile/[username]/opengraph-image.tsx
+++ b/src/app/profile/[username]/opengraph-image.tsx
@@ -98,11 +98,12 @@ export default async function Image({
           <div
             style={{
               display: "flex",
-              gap: 10,
+              gap: 12,
               marginTop: 30,
               alignItems: "center",
             }}
           >
+            <Avatar user={user} size={56} />
             <span
               style={{
                 background: "#0F0F0F",
@@ -112,9 +113,12 @@ export default async function Image({
                 fontWeight: 800,
                 borderRadius: 4,
                 display: "flex",
+                alignItems: "center",
+                gap: 8,
               }}
             >
               @{user.username}
+              {user.github_username ? <VerifiedBadge size={20} /> : null}
             </span>
             <span
               style={{
@@ -210,5 +214,62 @@ export default async function Image({
       </div>
     ),
     { ...size }
+  );
+}
+
+function Avatar({ user, size }: { user: { username: string; avatar_url: string | null }; size: number }) {
+  const url = user.avatar_url;
+  const valid = typeof url === "string" && /^https?:\/\//.test(url);
+  if (valid) {
+    return (
+      <div style={{
+        display: "flex",
+        width: size, height: size,
+        borderRadius: "50%",
+        overflow: "hidden",
+        border: "2px solid #0F0F0F",
+        flexShrink: 0,
+      }}>
+        <img src={url} width={size} height={size} alt="" style={{ display: "flex", objectFit: "cover", width: size, height: size }} />
+      </div>
+    );
+  }
+  return (
+    <div style={{
+      display: "flex",
+      width: size, height: size,
+      borderRadius: "50%",
+      border: "2px solid #0F0F0F",
+      background: "linear-gradient(135deg, #FF3A00, #FFA07A)",
+      color: "#fff",
+      fontWeight: 900,
+      fontSize: size * 0.42,
+      alignItems: "center",
+      justifyContent: "center",
+      flexShrink: 0,
+    }}>
+      {(user.username[0] ?? "?").toUpperCase()}
+    </div>
+  );
+}
+
+function VerifiedBadge({ size }: { size: number }) {
+  return (
+    <div style={{
+      display: "flex",
+      width: size, height: size,
+      borderRadius: "50%",
+      background: "#FF3A00",
+      border: "1.5px solid #0F0F0F",
+      alignItems: "center",
+      justifyContent: "center",
+      color: "#fff",
+      fontWeight: 900,
+      fontSize: size * 0.6,
+      lineHeight: 1,
+      flexShrink: 0,
+    }}>
+      ✓
+    </div>
   );
 }

--- a/src/app/profile/[username]/opengraph-image.tsx
+++ b/src/app/profile/[username]/opengraph-image.tsx
@@ -103,7 +103,7 @@ export default async function Image({
               alignItems: "center",
             }}
           >
-            <Avatar user={user} size={56} />
+            <Avatar user={user} size={80} />
             <span
               style={{
                 background: "#0F0F0F",
@@ -118,7 +118,7 @@ export default async function Image({
               }}
             >
               @{user.username}
-              {user.github_username ? <VerifiedBadge size={20} /> : null}
+              {user.github_username ? <VerifiedBadge size={24} /> : null}
             </span>
             <span
               style={{
@@ -227,10 +227,16 @@ function Avatar({ user, size }: { user: { username: string; avatar_url: string |
         width: size, height: size,
         borderRadius: "50%",
         overflow: "hidden",
-        border: "2px solid #0F0F0F",
+        border: "2.5px solid #0F0F0F",
         flexShrink: 0,
       }}>
-        <img src={url} width={size} height={size} alt="" style={{ display: "flex", objectFit: "cover", width: size, height: size }} />
+        <img
+          src={url}
+          width={size}
+          height={size}
+          alt=""
+          style={{ display: "flex", objectFit: "cover", width: size, height: size }}
+        />
       </div>
     );
   }
@@ -239,7 +245,7 @@ function Avatar({ user, size }: { user: { username: string; avatar_url: string |
       display: "flex",
       width: size, height: size,
       borderRadius: "50%",
-      border: "2px solid #0F0F0F",
+      border: "2.5px solid #0F0F0F",
       background: "linear-gradient(135deg, #FF3A00, #FFA07A)",
       color: "#fff",
       fontWeight: 900,
@@ -255,21 +261,22 @@ function Avatar({ user, size }: { user: { username: string; avatar_url: string |
 
 function VerifiedBadge({ size }: { size: number }) {
   return (
-    <div style={{
-      display: "flex",
-      width: size, height: size,
-      borderRadius: "50%",
-      background: "#FF3A00",
-      border: "1.5px solid #0F0F0F",
-      alignItems: "center",
-      justifyContent: "center",
-      color: "#fff",
-      fontWeight: 900,
-      fontSize: size * 0.6,
-      lineHeight: 1,
-      flexShrink: 0,
-    }}>
-      ✓
-    </div>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      style={{ display: "flex", flexShrink: 0 }}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx={12} cy={12} r={11} fill="#FF3A00" stroke="#0F0F0F" strokeWidth={1.5} />
+      <path
+        d="M7 12.5l3 3 7-7"
+        fill="none"
+        stroke="#fff"
+        strokeWidth={2.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
   );
 }

--- a/src/app/profile/[username]/opengraph-image.tsx
+++ b/src/app/profile/[username]/opengraph-image.tsx
@@ -37,17 +37,6 @@ export default async function Image({
     );
   }
 
-  const badgeLabel =
-    user.badge_level === "diamond"
-      ? "DIAMOND"
-      : user.badge_level === "gold"
-        ? "GOLD"
-        : user.badge_level === "silver"
-          ? "SILVER"
-          : user.badge_level === "bronze"
-            ? "BRONZE"
-            : "";
-
   return new ImageResponse(
     (
       <div
@@ -55,230 +44,167 @@ export default async function Image({
           width: "100%",
           height: "100%",
           display: "flex",
-          flexDirection: "column",
+          flexDirection: "row",
+          alignItems: "center",
           backgroundColor: "#EAEBEA",
-          fontFamily: "sans-serif",
-          padding: 60,
+          backgroundImage:
+            "radial-gradient(rgba(0,0,0,0.06) 2px, transparent 2px)",
+          backgroundSize: "20px 20px",
+          padding: "60px 80px",
+          gap: "60px",
+          fontFamily: "system-ui, sans-serif",
         }}
       >
-        {/* Header */}
         <div
           style={{
+            position: "absolute",
+            top: "32px",
+            right: "60px",
+            fontSize: 14,
+            fontWeight: 900,
+            letterSpacing: "0.12em",
+            color: "#0F0F0F",
             display: "flex",
-            alignItems: "center",
-            gap: 12,
-            marginBottom: 16,
           }}
         >
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              width: 32,
-              height: 32,
-              backgroundColor: "#FF3A00",
-              border: "2px solid #0F0F0F",
-              color: "#FFFFFF",
-              fontSize: 16,
-              fontWeight: 800,
-            }}
-          >
-            V
-          </div>
-          <span style={{ fontSize: 24, fontWeight: 800, color: "#FF3A00" }}>
-            VibeTalent
-          </span>
+          VIBE<span style={{ color: "#FF3A00", display: "flex" }}>TALENT</span>
         </div>
 
-        {/* Main Card — no boxShadow (unsupported by Satori) */}
-        <div
-          style={{
-            display: "flex",
-            flex: 1,
-            backgroundColor: "#FFFFFF",
-            border: "4px solid #0F0F0F",
-            padding: 48,
-            gap: 48,
-          }}
-        >
-          {/* Avatar */}
+        <div style={{ display: "flex", flexDirection: "column", flex: 1 }}>
           <div
             style={{
-              width: 160,
-              height: 160,
-              backgroundColor: "#0F0F0F",
-              border: "4px solid #0F0F0F",
+              fontSize: 14,
+              fontWeight: 900,
+              letterSpacing: "0.2em",
+              color: "#0F0F0F",
               display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              fontSize: 56,
-              fontWeight: 800,
-              color: "#FFFFFF",
-              flexShrink: 0,
             }}
           >
-            {user.username.slice(0, 2).toUpperCase()}
+            VIBE SCORE
           </div>
-
-          {/* Info */}
+          <div
+            style={{
+              fontSize: 220,
+              fontWeight: 900,
+              letterSpacing: "-0.04em",
+              lineHeight: 0.9,
+              color: "#FF3A00",
+              textShadow: "4px 4px 0 #0F0F0F",
+              display: "flex",
+            }}
+          >
+            {user.vibe_score}
+          </div>
           <div
             style={{
               display: "flex",
-              flexDirection: "column",
-              justifyContent: "center",
-              flex: 1,
+              gap: 10,
+              marginTop: 30,
+              alignItems: "center",
             }}
           >
-            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-            <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
-              <span
-                style={{
-                  fontSize: 48,
-                  fontWeight: 800,
-                  color: "#0F0F0F",
-                  textTransform: "uppercase",
-                }}
-              >
-                {user.display_name || `@${user.username}`}
-              </span>
-              {user.github_username && (
-                <svg
-                  width="44"
-                  height="44"
-                  viewBox="0 0 24 24"
-                  fill="#1D9BF0"
-                  stroke="#FFFFFF"
-                  strokeWidth="2.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <path d="M3.85 8.62a4 4 0 0 1 4.78-4.77 4 4 0 0 1 6.74 0 4 4 0 0 1 4.78 4.78 4 4 0 0 1 0 6.74 4 4 0 0 1-4.77 4.78 4 4 0 0 1-6.75 0 4 4 0 0 1-4.78-4.77 4 4 0 0 1 0-6.76Z" />
-                  <path d="m9 12 2 2 4-4" stroke="#FFFFFF" />
-                </svg>
-              )}
-              {badgeLabel && (
-                <span
-                  style={{
-                    fontSize: 16,
-                    fontWeight: 800,
-                    color: "#CA8A04",
-                    backgroundColor: "#FFF7ED",
-                    border: "2px solid #0F0F0F",
-                    padding: "4px 12px",
-                    textTransform: "uppercase",
-                  }}
-                >
-                  {badgeLabel}
-                </span>
-              )}
-            </div>
-            {user.display_name && (
-              <span style={{ fontSize: 24, color: "#71717A", fontWeight: 500 }}>
-                @{user.username}
-              </span>
-            )}
-            </div>
-
-            {user.bio && (
-              <p
-                style={{
-                  fontSize: 22,
-                  color: "#52525B",
-                  marginTop: 8,
-                }}
-              >
-                {user.bio.slice(0, 100)}
-                {user.bio.length > 100 ? "..." : ""}
-              </p>
-            )}
-
-            {/* Stats */}
-            <div
+            <span
               style={{
+                background: "#0F0F0F",
+                color: "#fff",
+                padding: "8px 16px",
+                fontSize: 22,
+                fontWeight: 800,
+                borderRadius: 4,
                 display: "flex",
-                gap: 32,
-                marginTop: 32,
               }}
             >
-              <div
-                style={{
-                  display: "flex",
-                  flexDirection: "column",
-                  padding: "16px 24px",
-                  backgroundColor: "#FFF7ED",
-                  border: "3px solid #0F0F0F",
-                }}
-              >
-                <span
-                  style={{ fontSize: 36, fontWeight: 800, color: "#FF3A00" }}
-                >
-                  {user.streak}
-                </span>
-                <span
-                  style={{
-                    fontSize: 14,
-                    fontWeight: 700,
-                    color: "#71717A",
-                    textTransform: "uppercase",
-                  }}
-                >
-                  Day Streak
-                </span>
-              </div>
+              @{user.username}
+            </span>
+            <span
+              style={{
+                background: "#FF3A00",
+                color: "#fff",
+                padding: "6px 12px",
+                fontSize: 18,
+                fontWeight: 800,
+                border: "2px solid #0F0F0F",
+                borderRadius: 2,
+                display: "flex",
+              }}
+            >
+              🔥 streak {user.streak ?? 0}d
+            </span>
+          </div>
+        </div>
 
-              <div
-                style={{
-                  display: "flex",
-                  flexDirection: "column",
-                  padding: "16px 24px",
-                  backgroundColor: "#FFF7ED",
-                  border: "3px solid #0F0F0F",
-                }}
-              >
-                <span
-                  style={{ fontSize: 36, fontWeight: 800, color: "#FF3A00" }}
-                >
-                  {user.vibe_score}
-                </span>
-                <span
-                  style={{
-                    fontSize: 14,
-                    fontWeight: 700,
-                    color: "#71717A",
-                    textTransform: "uppercase",
-                  }}
-                >
-                  Vibe Score
-                </span>
-              </div>
-
-              <div
-                style={{
-                  display: "flex",
-                  flexDirection: "column",
-                  padding: "16px 24px",
-                  backgroundColor: "#F5F5F5",
-                  border: "3px solid #0F0F0F",
-                }}
-              >
-                <span
-                  style={{ fontSize: 36, fontWeight: 800, color: "#0F0F0F" }}
-                >
-                  {(user.projects ?? []).length}
-                </span>
-                <span
-                  style={{
-                    fontSize: 14,
-                    fontWeight: 700,
-                    color: "#71717A",
-                    textTransform: "uppercase",
-                  }}
-                >
-                  Projects
-                </span>
-              </div>
-            </div>
+        <div
+          style={{
+            background: "#fff",
+            border: "3px solid #0F0F0F",
+            boxShadow: "8px 8px 0 #0F0F0F",
+            padding: 24,
+            display: "flex",
+            flexDirection: "column",
+            gap: 10,
+            minWidth: 280,
+            borderRadius: 4,
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              fontSize: 18,
+              color: "#0F0F0F",
+            }}
+          >
+            <span
+              style={{
+                fontFamily: "ui-monospace, Menlo, monospace",
+                color: "#52525B",
+                display: "flex",
+              }}
+            >
+              badge
+            </span>
+            <span
+              style={{
+                fontFamily: "ui-monospace, Menlo, monospace",
+                fontWeight: 800,
+                color: "#FF3A00",
+                fontSize: 22,
+                display: "flex",
+              }}
+            >
+              {(user.badge_level ?? "none").toUpperCase()}
+            </span>
+          </div>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              fontSize: 18,
+              color: "#0F0F0F",
+            }}
+          >
+            <span
+              style={{
+                fontFamily: "ui-monospace, Menlo, monospace",
+                color: "#52525B",
+                display: "flex",
+              }}
+            >
+              longest streak
+            </span>
+            <span
+              style={{
+                fontFamily: "ui-monospace, Menlo, monospace",
+                fontWeight: 800,
+                color: "#FF3A00",
+                fontSize: 22,
+                display: "flex",
+              }}
+            >
+              {user.longest_streak ?? 0}d
+            </span>
           </div>
         </div>
       </div>

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -1,8 +1,11 @@
 import { fetchUserByUsernameCached, fetchStreakLogsCached } from "@/lib/supabase/server-queries";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
 import { ProfileSidebar } from "@/components/profile/profile-sidebar";
 import { StatsRibbon } from "@/components/profile/stats-ribbon";
 import { ProfileHeatmap } from "@/components/profile/profile-heatmap";
+import { ReviewerStats } from "@/components/profile/reviewer-stats";
+import type { ReviewerTier } from "@/lib/reviewer/tier";
 import { extractSocialHandle } from "@/lib/social-handles";
 import { ProfileProjectCard } from "@/components/profile/profile-project-card";
 import ReviewsSection from "@/components/profile/reviews-section";
@@ -92,6 +95,46 @@ export default async function ProfilePage({
 
   const heatmapData = await fetchStreakLogsCached(user.id);
 
+  // Fetch reviewer reputation data — kept outside the cached user fetch so we
+  // don't bust the per-username cache when only review counts change.
+  let reviewsGiven = 0;
+  let reviewsLast30d = 0;
+  let reviewerCalibration: number | null = null;
+  let reviewerTier: ReviewerTier | null = null;
+  try {
+    const adminSb = createAdminClient();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { count: givenCount } = await (adminSb as any)
+      .from("reviews")
+      .select("id", { count: "exact", head: true })
+      .eq("reviewer_user_id", user.id);
+    reviewsGiven = givenCount ?? 0;
+
+    const since = new Date();
+    since.setUTCDate(since.getUTCDate() - 30);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { count: last30Count } = await (adminSb as any)
+      .from("reviews")
+      .select("id", { count: "exact", head: true })
+      .eq("reviewer_user_id", user.id)
+      .gte("created_at", since.toISOString());
+    reviewsLast30d = last30Count ?? 0;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: rep } = await (adminSb as any)
+      .from("users")
+      .select("reviewer_calibration, reviewer_tier")
+      .eq("id", user.id)
+      .single();
+    reviewerCalibration = rep?.reviewer_calibration ?? null;
+    reviewerTier = (rep?.reviewer_tier ?? null) as ReviewerTier | null;
+  } catch (err) {
+    // Reviewer reputation is non-critical — fall through with zeros/nulls so
+    // the profile page still renders if Supabase is briefly unavailable.
+    console.error("Failed to fetch reviewer reputation:", err);
+  }
+
   const breadcrumbLd = {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
@@ -142,8 +185,16 @@ export default async function ProfilePage({
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
       <div className="w-full max-w-[1200px] grid grid-cols-1 lg:grid-cols-[320px_1fr] gap-6 items-start">
-        {/* Sidebar */}
-        <ProfileSidebar user={user} />
+        {/* Sidebar column — primary profile sidebar + reviewer reputation block */}
+        <div className="flex flex-col gap-6">
+          <ProfileSidebar user={user} />
+          <ReviewerStats
+            reviewsGiven={reviewsGiven}
+            reviewsLast30d={reviewsLast30d}
+            calibration={reviewerCalibration}
+            tier={reviewerTier}
+          />
+        </div>
 
         {/* Main Content */}
         <div className="flex flex-col gap-6">

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -206,6 +206,7 @@ export default async function ProfilePage({
             <ShareButton
               url={`/share/${user.username}/custom?range=30d`}
               text={`Check out @${user.username} on VibeTalent`}
+              imageUrl={`/api/og/receipt/custom/${user.username}?range=30d`}
             />
           </div>
 

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -7,6 +7,7 @@ import { extractSocialHandle } from "@/lib/social-handles";
 import { ProfileProjectCard } from "@/components/profile/profile-project-card";
 import ReviewsSection from "@/components/profile/reviews-section";
 import { ProfileViewTracker } from "@/components/profile/profile-view-tracker";
+import { ShareButton } from "@/components/share/share-button";
 import Link from "next/link";
 import type { Metadata } from "next";
 import { siteUrl } from "@/lib/seo";
@@ -146,6 +147,17 @@ export default async function ProfilePage({
 
         {/* Main Content */}
         <div className="flex flex-col gap-6">
+          {/* Share Receipt */}
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <h2 className="text-base font-extrabold uppercase text-[var(--foreground)]">
+              Share @{user.username}&apos;s receipt
+            </h2>
+            <ShareButton
+              url={`/share/${user.username}/custom?range=30d`}
+              text={`Check out @${user.username} on VibeTalent`}
+            />
+          </div>
+
           {/* Stats Ribbon */}
           <StatsRibbon
             streak={user.streak}

--- a/src/app/share/[username]/custom/page.tsx
+++ b/src/app/share/[username]/custom/page.tsx
@@ -1,0 +1,43 @@
+import Image from "next/image";
+import { ShareButton } from "@/components/share/share-button";
+import { siteUrl } from "@/lib/seo";
+import type { Metadata } from "next";
+
+type Range = "7d" | "30d" | "all";
+
+function normalizeRange(v: string | string[] | undefined): Range {
+  const s = Array.isArray(v) ? v[0] : v;
+  return s === "7d" || s === "all" ? s : "30d";
+}
+
+export async function generateMetadata({ params, searchParams }: { params: Promise<{ username: string }>; searchParams: Promise<{ range?: string }> }): Promise<Metadata> {
+  const { username } = await params;
+  const { range } = await searchParams;
+  const r = normalizeRange(range);
+  const og = `${siteUrl}/api/og/receipt/custom/${username}?range=${r}`;
+  return {
+    title: `@${username} on VibeTalent`,
+    openGraph: { images: [{ url: og, width: 1200, height: 630 }] },
+    twitter:   { card: "summary_large_image", images: [og] },
+  };
+}
+
+export default async function CustomReceiptPage({ params, searchParams }: { params: Promise<{ username: string }>; searchParams: Promise<{ range?: string }> }) {
+  const { username } = await params;
+  const { range } = await searchParams;
+  const r = normalizeRange(range);
+  const ogImage = `/api/og/receipt/custom/${username}?range=${r}`;
+  const shareText = `Check out @${username} on VibeTalent`;
+  const shareUrl = `/share/${username}/custom?range=${r}`;
+
+  return (
+    <main className="max-w-[840px] mx-auto p-6">
+      <h1 className="text-[28px] font-extrabold mb-1">@{username}</h1>
+      <p className="text-[14px] text-[var(--text-muted)] mb-4">Range: {r}</p>
+      <div className="border-2 border-[var(--border-hard)]" style={{ boxShadow: "var(--shadow-brutal)" }}>
+        <Image src={ogImage} alt="receipt" width={1200} height={630} className="w-full h-auto" />
+      </div>
+      <div className="mt-6"><ShareButton url={shareUrl} text={shareText} /></div>
+    </main>
+  );
+}

--- a/src/app/share/[username]/custom/page.tsx
+++ b/src/app/share/[username]/custom/page.tsx
@@ -37,7 +37,7 @@ export default async function CustomReceiptPage({ params, searchParams }: { para
       <div className="border-2 border-[var(--border-hard)]" style={{ boxShadow: "var(--shadow-brutal)" }}>
         <Image src={ogImage} alt="receipt" width={1200} height={630} className="w-full h-auto" />
       </div>
-      <div className="mt-6"><ShareButton url={shareUrl} text={shareText} /></div>
+      <div className="mt-6"><ShareButton url={shareUrl} text={shareText} imageUrl={ogImage} /></div>
     </main>
   );
 }

--- a/src/app/share/[username]/shipped/[slug]/page.tsx
+++ b/src/app/share/[username]/shipped/[slug]/page.tsx
@@ -26,7 +26,7 @@ export default async function ShippedReceiptPage({ params }: { params: Promise<{
       <div className="border-2 border-[var(--border-hard)]" style={{ boxShadow: "var(--shadow-brutal)" }}>
         <Image src={ogImage} alt="receipt" width={1200} height={630} className="w-full h-auto" />
       </div>
-      <div className="mt-6"><ShareButton url={shareUrl} text={shareText} /></div>
+      <div className="mt-6"><ShareButton url={shareUrl} text={shareText} imageUrl={ogImage} /></div>
     </main>
   );
 }

--- a/src/app/share/[username]/shipped/[slug]/page.tsx
+++ b/src/app/share/[username]/shipped/[slug]/page.tsx
@@ -1,0 +1,32 @@
+import Image from "next/image";
+import { ShareButton } from "@/components/share/share-button";
+import { siteUrl } from "@/lib/seo";
+import type { Metadata } from "next";
+
+export async function generateMetadata({ params }: { params: Promise<{ username: string; slug: string }> }): Promise<Metadata> {
+  const { username, slug } = await params;
+  const og = `${siteUrl}/api/og/receipt/shipped/${username}?slug=${slug}`;
+  return {
+    title: `@${username} shipped ${slug}`,
+    openGraph: { images: [{ url: og, width: 1200, height: 630 }] },
+    twitter:   { card: "summary_large_image", images: [og] },
+  };
+}
+
+export default async function ShippedReceiptPage({ params }: { params: Promise<{ username: string; slug: string }> }) {
+  const { username, slug } = await params;
+  const ogImage = `/api/og/receipt/shipped/${username}?slug=${slug}`;
+  const shareText = `Just shipped ${slug} on VibeTalent`;
+  const shareUrl = `/share/${username}/shipped/${slug}`;
+
+  return (
+    <main className="max-w-[840px] mx-auto p-6">
+      <h1 className="text-[28px] font-extrabold mb-1">@{username} shipped <span className="text-[var(--accent)]">{slug}</span></h1>
+      <p className="text-[14px] text-[var(--text-muted)] mb-4">Project shipped &amp; verified</p>
+      <div className="border-2 border-[var(--border-hard)]" style={{ boxShadow: "var(--shadow-brutal)" }}>
+        <Image src={ogImage} alt="receipt" width={1200} height={630} className="w-full h-auto" />
+      </div>
+      <div className="mt-6"><ShareButton url={shareUrl} text={shareText} /></div>
+    </main>
+  );
+}

--- a/src/app/share/[username]/weekly/[week]/page.tsx
+++ b/src/app/share/[username]/weekly/[week]/page.tsx
@@ -1,0 +1,34 @@
+import Image from "next/image";
+import { ShareButton } from "@/components/share/share-button";
+import { siteUrl } from "@/lib/seo";
+import type { Metadata } from "next";
+
+export async function generateMetadata({ params }: { params: Promise<{ username: string; week: string }> }): Promise<Metadata> {
+  const { username, week } = await params;
+  const og = `${siteUrl}/api/og/receipt/weekly/${username}?w=${week}`;
+  return {
+    title: `@${username}'s weekly receipt`,
+    openGraph: { images: [{ url: og, width: 1200, height: 630 }] },
+    twitter:   { card: "summary_large_image", images: [og] },
+  };
+}
+
+export default async function WeeklyReceiptPage({ params }: { params: Promise<{ username: string; week: string }> }) {
+  const { username, week } = await params;
+  const ogImage = `/api/og/receipt/weekly/${username}?w=${week}`;
+  const shareText = `My VibeTalent receipt for the week of ${week}`;
+  const shareUrl = `/share/${username}/weekly/${week}`;
+
+  return (
+    <main className="max-w-[840px] mx-auto p-6">
+      <h1 className="text-[28px] font-extrabold mb-1">@{username}&apos;s receipt</h1>
+      <p className="text-[14px] text-[var(--text-muted)] mb-4">Week of {week}</p>
+      <div className="border-2 border-[var(--border-hard)]" style={{ boxShadow: "var(--shadow-brutal)" }}>
+        <Image src={ogImage} alt="receipt" width={1200} height={630} className="w-full h-auto" />
+      </div>
+      <div className="mt-6">
+        <ShareButton url={shareUrl} text={shareText} />
+      </div>
+    </main>
+  );
+}

--- a/src/app/share/[username]/weekly/[week]/page.tsx
+++ b/src/app/share/[username]/weekly/[week]/page.tsx
@@ -27,7 +27,7 @@ export default async function WeeklyReceiptPage({ params }: { params: Promise<{ 
         <Image src={ogImage} alt="receipt" width={1200} height={630} className="w-full h-auto" />
       </div>
       <div className="mt-6">
-        <ShareButton url={shareUrl} text={shareText} />
+        <ShareButton url={shareUrl} text={shareText} imageUrl={ogImage} />
       </div>
     </main>
   );

--- a/src/components/leaderboard/active-builder-row.tsx
+++ b/src/components/leaderboard/active-builder-row.tsx
@@ -7,6 +7,7 @@ export interface ActiveBuilderRowProps {
   avatarUrl: string | null;
   currentRank: number;
   activeDays7d: number;
+  commits7d: number;
   streak: number;
   vibeScore: number;
   isCrown?: boolean;
@@ -16,8 +17,8 @@ export function ActiveBuilderRow(p: ActiveBuilderRowProps) {
   return (
     <Link
       href={`/profile/${p.username}`}
-      className={`grid items-center gap-5 px-5 py-4 border-b border-[var(--border-subtle)] last:border-b-0 hover:bg-[var(--bg-surface-light)] transition-colors ${p.isCrown ? "bg-[#FFF7ED] dark:bg-[var(--bg-surface-light)] border-b-[var(--border-hard)]" : ""}`}
-      style={{ gridTemplateColumns: "44px 48px 1fr auto auto auto" }}
+      className={`grid items-center gap-4 px-5 py-4 border-b border-[var(--border-subtle)] last:border-b-0 hover:bg-[var(--bg-surface-light)] transition-colors ${p.isCrown ? "bg-[#FFF7ED] dark:bg-[var(--bg-surface-light)] border-b-[var(--border-hard)]" : ""}`}
+      style={{ gridTemplateColumns: "44px 48px 1fr auto auto auto auto" }}
     >
       <span className="font-mono text-[15px] font-extrabold text-[var(--text-secondary)]">
         {String(p.position).padStart(2, "0")}
@@ -34,28 +35,28 @@ export function ActiveBuilderRow(p: ActiveBuilderRowProps) {
         </div>
       )}
 
-      <div>
-        <div className="font-bold text-[16px] text-[var(--foreground)] leading-tight">@{p.username}</div>
+      <div className="min-w-0">
+        <div className="font-bold text-[16px] text-[var(--foreground)] leading-tight truncate">@{p.username}</div>
         <div className="text-[13px] font-mono text-[var(--text-tertiary)] mt-1">
           rank #{p.currentRank} · {p.activeDays7d}/7 active
         </div>
       </div>
 
-      <div className="text-right min-w-[80px]">
+      <div className="text-right min-w-[70px]">
+        <div className="font-mono font-black text-[22px] leading-none text-[var(--foreground)]">
+          {p.commits7d}
+        </div>
+        <div className="text-[11px] font-extrabold uppercase tracking-widest text-[var(--text-secondary)] mt-1">
+          COMMITS
+        </div>
+      </div>
+
+      <div className="text-right min-w-[70px]">
         <div className="font-mono font-black text-[22px] leading-none text-[var(--foreground)] tracking-tight">
           {p.streak}
         </div>
         <div className="text-[11px] font-extrabold uppercase tracking-widest text-[var(--text-secondary)] mt-1">
-          {p.streak === 1 ? "DAY STREAK" : "DAY STREAK"}
-        </div>
-      </div>
-
-      <div className="text-right min-w-[60px]">
-        <div className="font-mono font-black text-[22px] leading-none text-[var(--foreground)]">
-          {p.activeDays7d}
-        </div>
-        <div className="text-[11px] font-extrabold uppercase tracking-widest text-[var(--text-secondary)] mt-1">
-          /7 ACTIVE
+          DAY STREAK
         </div>
       </div>
 

--- a/src/components/leaderboard/active-builder-row.tsx
+++ b/src/components/leaderboard/active-builder-row.tsx
@@ -61,7 +61,7 @@ export function ActiveBuilderRow(p: ActiveBuilderRowProps) {
 
       <div className="text-right min-w-[70px]">
         <div className="font-mono font-black text-[22px] leading-none text-[var(--accent)]">{p.vibeScore}</div>
-        <div className="text-[11px] font-extrabold uppercase tracking-widest text-[var(--text-secondary)] mt-1">VIBE</div>
+        <div className="text-[11px] font-extrabold uppercase tracking-widest text-[var(--text-secondary)] mt-1">VIBE SCORE</div>
       </div>
     </Link>
   );

--- a/src/components/leaderboard/active-builder-row.tsx
+++ b/src/components/leaderboard/active-builder-row.tsx
@@ -42,11 +42,11 @@ export function ActiveBuilderRow(p: ActiveBuilderRowProps) {
       </div>
 
       <div className="text-right min-w-[80px]">
-        <div className="font-mono font-black text-[22px] leading-none text-[var(--accent)] tracking-tight">
-          🔥 {p.streak}
+        <div className="font-mono font-black text-[22px] leading-none text-[var(--foreground)] tracking-tight">
+          {p.streak}
         </div>
         <div className="text-[11px] font-extrabold uppercase tracking-widest text-[var(--text-secondary)] mt-1">
-          {p.streak === 1 ? "DAY" : "DAYS"}
+          {p.streak === 1 ? "DAY STREAK" : "DAY STREAK"}
         </div>
       </div>
 
@@ -60,7 +60,7 @@ export function ActiveBuilderRow(p: ActiveBuilderRowProps) {
       </div>
 
       <div className="text-right min-w-[70px]">
-        <div className="font-mono font-extrabold text-[22px] leading-none text-[var(--foreground)]">{p.vibeScore}</div>
+        <div className="font-mono font-black text-[22px] leading-none text-[var(--accent)]">{p.vibeScore}</div>
         <div className="text-[11px] font-extrabold uppercase tracking-widest text-[var(--text-secondary)] mt-1">VIBE</div>
       </div>
     </Link>

--- a/src/components/leaderboard/active-builder-row.tsx
+++ b/src/components/leaderboard/active-builder-row.tsx
@@ -1,0 +1,68 @@
+import Link from "next/link";
+import Image from "next/image";
+
+export interface ActiveBuilderRowProps {
+  position: number;
+  username: string;
+  avatarUrl: string | null;
+  currentRank: number;
+  activeDays7d: number;
+  streak: number;
+  vibeScore: number;
+  isCrown?: boolean;
+}
+
+export function ActiveBuilderRow(p: ActiveBuilderRowProps) {
+  return (
+    <Link
+      href={`/profile/${p.username}`}
+      className={`grid items-center gap-5 px-5 py-4 border-b border-[var(--border-subtle)] last:border-b-0 hover:bg-[var(--bg-surface-light)] transition-colors ${p.isCrown ? "bg-[#FFF7ED] dark:bg-[var(--bg-surface-light)] border-b-[var(--border-hard)]" : ""}`}
+      style={{ gridTemplateColumns: "44px 48px 1fr auto auto auto" }}
+    >
+      <span className="font-mono text-[15px] font-extrabold text-[var(--text-secondary)]">
+        {String(p.position).padStart(2, "0")}
+      </span>
+
+      {p.avatarUrl ? (
+        <Image src={p.avatarUrl} alt={p.username} width={48} height={48} className="rounded-full border-2 border-[var(--border-hard)]" />
+      ) : (
+        <div
+          className="w-12 h-12 rounded-full border-2 border-[var(--border-hard)] flex items-center justify-center text-white font-extrabold text-[17px]"
+          style={{ background: "linear-gradient(135deg, var(--accent), #FFA07A)" }}
+        >
+          {p.username[0]?.toUpperCase()}
+        </div>
+      )}
+
+      <div>
+        <div className="font-bold text-[16px] text-[var(--foreground)] leading-tight">@{p.username}</div>
+        <div className="text-[13px] font-mono text-[var(--text-tertiary)] mt-1">
+          rank #{p.currentRank} · {p.activeDays7d}/7 active
+        </div>
+      </div>
+
+      <div className="text-right min-w-[80px]">
+        <div className="font-mono font-black text-[22px] leading-none text-[var(--accent)] tracking-tight">
+          🔥 {p.streak}
+        </div>
+        <div className="text-[11px] font-extrabold uppercase tracking-widest text-[var(--text-secondary)] mt-1">
+          {p.streak === 1 ? "DAY" : "DAYS"}
+        </div>
+      </div>
+
+      <div className="text-right min-w-[60px]">
+        <div className="font-mono font-black text-[22px] leading-none text-[var(--foreground)]">
+          {p.activeDays7d}
+        </div>
+        <div className="text-[11px] font-extrabold uppercase tracking-widest text-[var(--text-secondary)] mt-1">
+          /7 ACTIVE
+        </div>
+      </div>
+
+      <div className="text-right min-w-[70px]">
+        <div className="font-mono font-extrabold text-[22px] leading-none text-[var(--foreground)]">{p.vibeScore}</div>
+        <div className="text-[11px] font-extrabold uppercase tracking-widest text-[var(--text-secondary)] mt-1">VIBE</div>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/leaderboard/all-time-tab.tsx
+++ b/src/components/leaderboard/all-time-tab.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { LeaderboardContent } from "./leaderboard-content";
+import type { UserWithSocials } from "@/lib/types/database";
+
+export function AllTimeTab({ users }: { users: UserWithSocials[] }) {
+  return <LeaderboardContent users={users} />;
+}

--- a/src/components/leaderboard/leaderboard-tabs.tsx
+++ b/src/components/leaderboard/leaderboard-tabs.tsx
@@ -19,7 +19,7 @@ export function LeaderboardTabs({ users }: { users: UserWithSocials[] }) {
           onClick={() => setTab("week")}
           className={`flex-1 py-3 px-4 text-[14px] font-bold border-r-2 border-[var(--border-hard)] ${tab === "week" ? "bg-[var(--accent)] text-white" : "bg-[var(--bg-surface)] text-[var(--foreground)]"}`}
         >
-          This week ▲
+          Active this week 🔥
         </button>
         <button
           role="tab"

--- a/src/components/leaderboard/leaderboard-tabs.tsx
+++ b/src/components/leaderboard/leaderboard-tabs.tsx
@@ -19,7 +19,7 @@ export function LeaderboardTabs({ users }: { users: UserWithSocials[] }) {
           onClick={() => setTab("week")}
           className={`flex-1 py-3 px-4 text-[14px] font-bold border-r-2 border-[var(--border-hard)] ${tab === "week" ? "bg-[var(--accent)] text-white" : "bg-[var(--bg-surface)] text-[var(--foreground)]"}`}
         >
-          Active this week 🔥
+          This week
         </button>
         <button
           role="tab"

--- a/src/components/leaderboard/leaderboard-tabs.tsx
+++ b/src/components/leaderboard/leaderboard-tabs.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState } from "react";
+import { WeeklyTab } from "./weekly-tab";
+import { AllTimeTab } from "./all-time-tab";
+import type { UserWithSocials } from "@/lib/types/database";
+
+type Tab = "week" | "all";
+
+export function LeaderboardTabs({ users }: { users: UserWithSocials[] }) {
+  const [tab, setTab] = useState<Tab>("week");
+
+  return (
+    <div>
+      <div className="flex border-2 border-[var(--border-hard)] mb-4" role="tablist" aria-label="Leaderboard range">
+        <button
+          role="tab"
+          aria-selected={tab === "week"}
+          onClick={() => setTab("week")}
+          className={`flex-1 py-3 px-4 text-[14px] font-bold border-r-2 border-[var(--border-hard)] ${tab === "week" ? "bg-[var(--accent)] text-white" : "bg-[var(--bg-surface)] text-[var(--foreground)]"}`}
+        >
+          This week ▲
+        </button>
+        <button
+          role="tab"
+          aria-selected={tab === "all"}
+          onClick={() => setTab("all")}
+          className={`flex-1 py-3 px-4 text-[14px] font-bold ${tab === "all" ? "bg-[var(--accent)] text-white" : "bg-[var(--bg-surface)] text-[var(--foreground)]"}`}
+        >
+          All-time
+        </button>
+      </div>
+
+      {tab === "week" ? <WeeklyTab /> : <AllTimeTab users={users} />}
+    </div>
+  );
+}

--- a/src/components/leaderboard/row.tsx
+++ b/src/components/leaderboard/row.tsx
@@ -1,0 +1,71 @@
+import Link from "next/link";
+import Image from "next/image";
+
+export interface LeaderboardRowProps {
+  position: number;             // visual 1-indexed position
+  username: string;
+  avatarUrl: string | null;
+  currentRank: number;
+  previousRank: number | null;
+  rankClimb: number | null;     // null = no prior data
+  currentScore: number;
+  scoreDelta: number | null;
+  isCrown?: boolean;
+}
+
+export function LeaderboardRow(p: LeaderboardRowProps) {
+  return (
+    <Link
+      href={`/profile/${p.username}`}
+      className={`grid items-center gap-5 px-5 py-4 border-b border-[var(--border-subtle)] last:border-b-0 hover:bg-[var(--bg-surface-light)] transition-colors ${p.isCrown ? "bg-[#FFF7ED] dark:bg-[var(--bg-surface-light)] border-b-[var(--border-hard)]" : ""}`}
+      style={{ gridTemplateColumns: "44px 48px 1fr auto auto" }}
+    >
+      <span className="font-mono text-[15px] font-extrabold text-[var(--text-secondary)]">
+        {String(p.position).padStart(2, "0")}
+      </span>
+
+      {p.avatarUrl ? (
+        <Image src={p.avatarUrl} alt={p.username} width={48} height={48} className="rounded-full border-2 border-[var(--border-hard)]" />
+      ) : (
+        <div
+          className="w-12 h-12 rounded-full border-2 border-[var(--border-hard)] flex items-center justify-center text-white font-extrabold text-[17px]"
+          style={{ background: "linear-gradient(135deg, var(--accent), #FFA07A)" }}
+        >
+          {p.username[0]?.toUpperCase()}
+        </div>
+      )}
+
+      <div>
+        <div className="font-bold text-[16px] text-[var(--foreground)] leading-tight">@{p.username}</div>
+        <div className="text-[13px] font-mono text-[var(--text-tertiary)] mt-1">
+          rank #{p.currentRank}
+          {p.previousRank != null && ` · was #${p.previousRank}`}
+        </div>
+      </div>
+
+      <div className="text-right min-w-[70px]">
+        {p.rankClimb != null ? (
+          <>
+            <div className="font-mono font-black text-[22px] leading-none text-[var(--accent)] tracking-tight">
+              {p.rankClimb > 0 ? `▲${p.rankClimb}` : p.rankClimb === 0 ? "·" : `▼${-p.rankClimb}`}
+            </div>
+            <div className="text-[11px] font-extrabold uppercase tracking-widest text-[var(--text-secondary)] mt-1">
+              {Math.abs(p.rankClimb) === 1 ? "SPOT" : "SPOTS"}
+            </div>
+          </>
+        ) : (
+          <div className="text-[13px] font-mono text-[var(--text-muted)]">—</div>
+        )}
+      </div>
+
+      <div className="text-right min-w-[70px]">
+        <div className="font-mono font-extrabold text-[22px] leading-none text-[var(--foreground)]">{p.currentScore}</div>
+        {p.scoreDelta != null && (
+          <div className="text-[13px] font-extrabold font-mono text-[var(--accent)] mt-1">
+            {p.scoreDelta >= 0 ? `+${p.scoreDelta}` : `${p.scoreDelta}`}
+          </div>
+        )}
+      </div>
+    </Link>
+  );
+}

--- a/src/components/leaderboard/weekly-tab.tsx
+++ b/src/components/leaderboard/weekly-tab.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { LeaderboardRow, type LeaderboardRowProps } from "./row";
+import { ActiveBuilderRow, type ActiveBuilderRowProps } from "./active-builder-row";
 
 export function WeeklyTab() {
-  const [rows, setRows] = useState<LeaderboardRowProps[] | null>(null);
+  const [rows, setRows] = useState<ActiveBuilderRowProps[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -15,24 +15,22 @@ export function WeeklyTab() {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const json = await res.json();
         if (cancelled) return;
-        const props: LeaderboardRowProps[] = (json.leaderboard ?? []).map(
+        const props: ActiveBuilderRowProps[] = (json.leaderboard ?? []).map(
           (r: {
             username: string;
             avatar_url: string | null;
             currentRank: number;
-            previousRank: number | null;
-            rankClimb: number | null;
-            currentScore: number;
-            scoreDelta: number | null;
+            activeDays7d: number;
+            streak: number;
+            vibeScore: number;
           }, idx: number) => ({
             position: idx + 1,
             username: r.username,
             avatarUrl: r.avatar_url,
             currentRank: r.currentRank,
-            previousRank: r.previousRank,
-            rankClimb: r.rankClimb,
-            currentScore: r.currentScore,
-            scoreDelta: r.scoreDelta,
+            activeDays7d: r.activeDays7d,
+            streak: r.streak,
+            vibeScore: r.vibeScore,
             isCrown: idx === 0,
           }),
         );
@@ -47,7 +45,7 @@ export function WeeklyTab() {
   if (error) {
     return (
       <div className="text-[13px] text-[var(--status-error-text)] bg-[var(--status-error-bg)] border border-[var(--status-error-border)] p-4 rounded">
-        Couldn&apos;t load weekly leaderboard ({error}).
+        Couldn&apos;t load active builders ({error}).
       </div>
     );
   }
@@ -55,17 +53,17 @@ export function WeeklyTab() {
     return <div className="text-[13px] text-[var(--text-muted)] p-4">Loading…</div>;
   }
   if (rows.length === 0) {
-    return <div className="text-[13px] text-[var(--text-muted)] p-4">No climbers this week yet. Check back Monday.</div>;
+    return <div className="text-[13px] text-[var(--text-muted)] p-4">No active builders in the last 7 days yet.</div>;
   }
 
   return (
     <div className="bg-[var(--bg-surface)] border-2 border-[var(--border-hard)] rounded overflow-hidden" style={{ boxShadow: "var(--shadow-brutal)" }}>
       <header className="bg-[var(--bg-inverted)] text-[var(--text-on-inverted)] px-5 py-4 flex justify-between items-center">
-        <h3 className="text-[15px] font-extrabold tracking-wider">LEADERBOARD</h3>
-        <span className="bg-[var(--accent)] text-white px-3 py-1 text-[12px] font-extrabold rounded-sm">THIS WEEK ▲</span>
+        <h3 className="text-[15px] font-extrabold tracking-wider">ACTIVE BUILDERS</h3>
+        <span className="bg-[var(--accent)] text-white px-3 py-1 text-[12px] font-extrabold rounded-sm">LAST 7 DAYS 🔥</span>
       </header>
       <div>
-        {rows.map((r) => <LeaderboardRow key={r.username} {...r} />)}
+        {rows.map((r) => <ActiveBuilderRow key={r.username} {...r} />)}
       </div>
     </div>
   );

--- a/src/components/leaderboard/weekly-tab.tsx
+++ b/src/components/leaderboard/weekly-tab.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { LeaderboardRow, type LeaderboardRowProps } from "./row";
+
+export function WeeklyTab() {
+  const [rows, setRows] = useState<LeaderboardRowProps[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/leaderboard?range=week&limit=50");
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const json = await res.json();
+        if (cancelled) return;
+        const props: LeaderboardRowProps[] = (json.leaderboard ?? []).map(
+          (r: {
+            username: string;
+            avatar_url: string | null;
+            currentRank: number;
+            previousRank: number | null;
+            rankClimb: number | null;
+            currentScore: number;
+            scoreDelta: number | null;
+          }, idx: number) => ({
+            position: idx + 1,
+            username: r.username,
+            avatarUrl: r.avatar_url,
+            currentRank: r.currentRank,
+            previousRank: r.previousRank,
+            rankClimb: r.rankClimb,
+            currentScore: r.currentScore,
+            scoreDelta: r.scoreDelta,
+            isCrown: idx === 0,
+          }),
+        );
+        setRows(props);
+      } catch (e) {
+        if (!cancelled) setError((e as Error).message);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  if (error) {
+    return (
+      <div className="text-[13px] text-[var(--status-error-text)] bg-[var(--status-error-bg)] border border-[var(--status-error-border)] p-4 rounded">
+        Couldn&apos;t load weekly leaderboard ({error}).
+      </div>
+    );
+  }
+  if (rows == null) {
+    return <div className="text-[13px] text-[var(--text-muted)] p-4">Loading…</div>;
+  }
+  if (rows.length === 0) {
+    return <div className="text-[13px] text-[var(--text-muted)] p-4">No climbers this week yet. Check back Monday.</div>;
+  }
+
+  return (
+    <div className="bg-[var(--bg-surface)] border-2 border-[var(--border-hard)] rounded overflow-hidden" style={{ boxShadow: "var(--shadow-brutal)" }}>
+      <header className="bg-[var(--bg-inverted)] text-[var(--text-on-inverted)] px-5 py-4 flex justify-between items-center">
+        <h3 className="text-[15px] font-extrabold tracking-wider">LEADERBOARD</h3>
+        <span className="bg-[var(--accent)] text-white px-3 py-1 text-[12px] font-extrabold rounded-sm">THIS WEEK ▲</span>
+      </header>
+      <div>
+        {rows.map((r) => <LeaderboardRow key={r.username} {...r} />)}
+      </div>
+    </div>
+  );
+}

--- a/src/components/leaderboard/weekly-tab.tsx
+++ b/src/components/leaderboard/weekly-tab.tsx
@@ -60,7 +60,7 @@ export function WeeklyTab() {
     <div className="bg-[var(--bg-surface)] border-2 border-[var(--border-hard)] rounded overflow-hidden" style={{ boxShadow: "var(--shadow-brutal)" }}>
       <header className="bg-[var(--bg-inverted)] text-[var(--text-on-inverted)] px-5 py-4 flex justify-between items-center">
         <h3 className="text-[15px] font-extrabold tracking-wider">ACTIVE BUILDERS</h3>
-        <span className="bg-[var(--accent)] text-white px-3 py-1 text-[12px] font-extrabold rounded-sm">LAST 7 DAYS 🔥</span>
+        <span className="bg-[var(--accent)] text-white px-3 py-1 text-[12px] font-extrabold rounded-sm">LAST 7 DAYS</span>
       </header>
       <div>
         {rows.map((r) => <ActiveBuilderRow key={r.username} {...r} />)}

--- a/src/components/leaderboard/weekly-tab.tsx
+++ b/src/components/leaderboard/weekly-tab.tsx
@@ -21,6 +21,7 @@ export function WeeklyTab() {
             avatar_url: string | null;
             currentRank: number;
             activeDays7d: number;
+            commits7d: number;
             streak: number;
             vibeScore: number;
           }, idx: number) => ({
@@ -29,6 +30,7 @@ export function WeeklyTab() {
             avatarUrl: r.avatar_url,
             currentRank: r.currentRank,
             activeDays7d: r.activeDays7d,
+            commits7d: r.commits7d,
             streak: r.streak,
             vibeScore: r.vibeScore,
             isCrown: idx === 0,

--- a/src/components/profile/profile-project-card.tsx
+++ b/src/components/profile/profile-project-card.tsx
@@ -7,6 +7,7 @@ import Image from "next/image";
 import type { Project } from "@/lib/types/database";
 import { QualityScoreBadge } from "@/components/ui/quality-score-badge";
 import { EndorseButton } from "@/components/ui/endorse-button";
+import { GithubSignal } from "@/components/projects/github-signal";
 import { createClient } from "@/lib/supabase/client";
 import { parseImageCrop } from "@/lib/image-crop";
 import { normalizeExternalUrl, normalizeRepoUrl } from "@/lib/url-normalize";
@@ -275,6 +276,13 @@ export function ProfileProjectCard({ project, verified = false, isOwner = false 
           </span>
         ))}
       </div>
+
+      <GithubSignal
+        commits7d={null}
+        values7d={null}
+        lastCommitAgo={null}
+        githubUrl={project.github_url ?? null}
+      />
 
       {isOwner && !verified && project.github_url && (
         <div className="mt-2 flex flex-col gap-1.5">

--- a/src/components/profile/reviewer-stats.tsx
+++ b/src/components/profile/reviewer-stats.tsx
@@ -1,0 +1,59 @@
+import { TIER_THRESHOLDS, type ReviewerTier } from "@/lib/reviewer/tier";
+
+interface ReviewerStatsProps {
+  reviewsGiven: number;          // count of reviews where reviewer_user_id = this user
+  reviewsLast30d: number;        // subset
+  calibration: number | null;    // 0-100 or null
+  tier: ReviewerTier | null;
+}
+
+const TIER_STYLES: Record<ReviewerTier, { bg: string; label: string }> = {
+  bronze: { bg: "bg-[#D97706]", label: "BRONZE" },
+  silver: { bg: "bg-[#71717A]", label: "SILVER" },
+  gold:   { bg: "bg-[#CA8A04]", label: "GOLD" },
+};
+
+export function ReviewerStats({ reviewsGiven, reviewsLast30d, calibration, tier }: ReviewerStatsProps) {
+  // Hide block entirely if user has never reviewed anyone — keeps non-reviewer profiles clean.
+  if (reviewsGiven === 0) return null;
+
+  return (
+    <section
+      className="bg-[var(--bg-surface)] border-2 border-[var(--border-hard)] p-4 sm:p-5 rounded"
+      style={{ boxShadow: "var(--shadow-brutal-sm)" }}
+      aria-labelledby="reviewer-stats-heading"
+    >
+      <header className="flex items-center justify-between pb-3 mb-4 border-b-2 border-dashed border-[var(--border-subtle)]">
+        <h3 id="reviewer-stats-heading" className="text-[15px] font-extrabold uppercase tracking-wider text-[var(--text-secondary)]">
+          Reviewer
+        </h3>
+        {tier && (
+          <span
+            className={`${TIER_STYLES[tier].bg} text-white px-3 py-1 text-[11px] font-extrabold tracking-wide rounded-full border-2 border-[var(--border-hard)]`}
+          >
+            {TIER_STYLES[tier].label}
+          </span>
+        )}
+      </header>
+
+      <div className="grid grid-cols-2 gap-3">
+        <Stat number={reviewsGiven.toString()} label="REVIEWS GIVEN" tooltip={`${reviewsLast30d} in last 30d`} />
+        <Stat
+          number={calibration != null ? `${Math.round(calibration)}%` : "—"}
+          label="CALIBRATION"
+          tooltip={calibration != null ? "stars vs builder rank" : `need ${TIER_THRESHOLDS.bronze.minReviews - reviewsGiven} more reviews`}
+        />
+      </div>
+    </section>
+  );
+}
+
+function Stat({ number, label, tooltip }: { number: string; label: string; tooltip: string }) {
+  return (
+    <div className="bg-[var(--background)] border-2 border-[var(--border-hard)] p-3 rounded">
+      <div className="font-mono font-black text-[22px] leading-none text-[var(--accent)]">{number}</div>
+      <div className="text-[11px] font-extrabold tracking-widest text-[var(--text-secondary)] mt-1">{label}</div>
+      <div className="text-[10px] font-mono text-[var(--text-muted)] mt-1">{tooltip}</div>
+    </div>
+  );
+}

--- a/src/components/profile/reviews-section.tsx
+++ b/src/components/profile/reviews-section.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { Star, MessageSquare, Send, Trash2 } from "lucide-react";
 import { createClient } from "@/lib/supabase/client";
 import type { Review } from "@/lib/types/database";
+import { ReviewerByline } from "@/components/reviews/reviewer-byline";
 
 interface ReviewsSectionProps {
   builderId: string;
@@ -408,14 +409,18 @@ export default function ReviewsSection({ builderId, isOwner = false }: ReviewsSe
               className="border-2 p-4"
               style={{ borderColor: "var(--border-subtle)" }}
             >
-              <div className="flex items-center justify-between mb-2">
-                <div className="flex items-center gap-3">
-                  <span className="font-bold text-[var(--foreground)] text-sm">
-                    {review.reviewer_name}
-                  </span>
+              <div className="flex items-start justify-between gap-3 mb-2">
+                <div className="flex flex-col gap-1.5 min-w-0">
+                  <ReviewerByline
+                    reviewerName={review.reviewer_name}
+                    reviewerUsername={review.reviewer?.username ?? null}
+                    reviewsGiven={null}
+                    calibration={review.reviewer?.reviewer_calibration ?? null}
+                    tier={review.reviewer?.reviewer_tier ?? null}
+                  />
                   <StarRating rating={review.rating} size={14} />
                 </div>
-                <div className="flex items-center gap-2">
+                <div className="flex items-center gap-2 shrink-0">
                   <span className="text-[var(--text-muted-soft)] text-xs font-mono">
                     {timeAgo(review.created_at)}
                   </span>

--- a/src/components/projects/github-signal-expanded.tsx
+++ b/src/components/projects/github-signal-expanded.tsx
@@ -1,0 +1,34 @@
+import { GithubSparkline } from "./github-sparkline";
+
+interface Props {
+  commits7d: number | null;
+  values7d: number[] | null;
+  lastCommitHash: string | null;
+  lastCommitMessage: string | null;
+  lastCommitAgo: string | null;
+  githubUrl: string | null;
+}
+
+export function GithubSignalExpanded({ commits7d, values7d, lastCommitHash, lastCommitMessage, lastCommitAgo, githubUrl }: Props) {
+  if (!githubUrl) return null;
+  const showMessage = lastCommitMessage && lastCommitMessage.trim().length >= 5;
+
+  return (
+    <div className="mt-3 bg-[var(--bg-inverted)] text-[var(--text-on-inverted)] rounded font-mono overflow-hidden">
+      <div className="grid items-center gap-3 px-3 py-2.5 border-b border-[#2a2a2a]" style={{ gridTemplateColumns: "1fr auto" }}>
+        <div>
+          <div className="text-[11px] text-[var(--text-muted)] tracking-wider font-extrabold">COMMITS / 7d</div>
+          <div className="text-[16px] font-extrabold text-[var(--accent)] leading-none mt-1">{commits7d ?? 0}</div>
+        </div>
+        <GithubSparkline values={values7d ?? []} />
+      </div>
+      {showMessage && lastCommitHash && (
+        <div className="px-3 py-2 flex gap-2 items-center text-[12px]">
+          <span className="bg-[var(--accent)] text-[var(--bg-inverted)] px-1.5 font-extrabold rounded-sm">{lastCommitHash.slice(0, 6)}</span>
+          <span className="flex-1 truncate">{lastCommitMessage}</span>
+          {lastCommitAgo && <span className="text-[10px] text-[var(--text-muted)]">{lastCommitAgo}</span>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/projects/github-signal.tsx
+++ b/src/components/projects/github-signal.tsx
@@ -1,0 +1,31 @@
+import { GithubSparkline } from "./github-sparkline";
+
+interface Props {
+  commits7d: number | null;
+  values7d: number[] | null;
+  lastCommitAgo: string | null;
+  githubUrl: string | null;
+}
+
+export function GithubSignal({ commits7d, values7d, lastCommitAgo, githubUrl }: Props) {
+  if (!githubUrl) {
+    return (
+      <div className="text-[11px] font-extrabold tracking-wider text-[var(--text-muted)] uppercase mt-2 px-3 py-2 bg-[var(--bg-surface-light)] rounded">
+        no github linked
+      </div>
+    );
+  }
+  return (
+    <div className="mt-3 px-3 py-2.5 bg-[var(--bg-inverted)] text-[var(--text-on-inverted)] rounded grid items-center gap-3 font-mono" style={{ gridTemplateColumns: "1fr auto auto" }}>
+      <div>
+        <div className="text-[11px] text-[var(--text-muted)] tracking-wider font-extrabold">COMMITS / 7d</div>
+        <div className="text-[16px] font-extrabold text-[var(--accent)] leading-none mt-1">{commits7d ?? 0}</div>
+      </div>
+      <GithubSparkline values={values7d ?? []} />
+      <div className="text-right text-[12px]">
+        {lastCommitAgo ?? "—"}
+        <div className="text-[10px] text-[var(--text-muted)]">last commit</div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/projects/github-signal.tsx
+++ b/src/components/projects/github-signal.tsx
@@ -15,6 +15,12 @@ export function GithubSignal({ commits7d, values7d, lastCommitAgo, githubUrl }: 
       </div>
     );
   }
+  // No data yet — silently hide rather than showing misleading zeros.
+  // (The github-sync cron doesn't store per-project commit aggregates as of v1;
+  // when that lands, this guard becomes a no-op.)
+  if (commits7d == null && values7d == null) {
+    return null;
+  }
   return (
     <div className="mt-3 px-3 py-2.5 bg-[var(--bg-inverted)] text-[var(--text-on-inverted)] rounded grid items-center gap-3 font-mono" style={{ gridTemplateColumns: "1fr auto auto" }}>
       <div>

--- a/src/components/projects/github-sparkline.tsx
+++ b/src/components/projects/github-sparkline.tsx
@@ -1,0 +1,26 @@
+export function GithubSparkline({ values }: { values: number[] }) {
+  // Always render 7 bars. Missing days padded with 0.
+  const data = values.length === 7 ? values : [...values, ...Array(7 - values.length).fill(0)];
+  const max = Math.max(...data, 1);
+  const barWidth = 5;
+  const gap = 2;
+  const height = 24;
+  return (
+    <svg width={7 * barWidth + 6 * gap} height={height} aria-label={`commits last 7 days: ${data.join(", ")}`} role="img">
+      {data.map((v, i) => {
+        const h = Math.max(2, (v / max) * height);
+        return (
+          <rect
+            key={i}
+            x={i * (barWidth + gap)}
+            y={height - h}
+            width={barWidth}
+            height={h}
+            fill="#FF3A00"
+            rx={1}
+          />
+        );
+      })}
+    </svg>
+  );
+}

--- a/src/components/reviews/reviewer-byline.tsx
+++ b/src/components/reviews/reviewer-byline.tsx
@@ -1,0 +1,47 @@
+import type { ReviewerTier } from "@/lib/reviewer/tier";
+
+interface ReviewerBylineProps {
+  reviewerName: string;
+  reviewerUsername?: string | null;   // present when reviewer_user_id is set
+  reviewsGiven?: number | null;
+  calibration?: number | null;
+  tier?: ReviewerTier | null;
+}
+
+const TIER_STYLES: Record<ReviewerTier, string> = {
+  bronze: "bg-[#D97706]",
+  silver: "bg-[#71717A]",
+  gold:   "bg-[#CA8A04]",
+};
+
+export function ReviewerByline({
+  reviewerName,
+  reviewerUsername,
+  reviewsGiven,
+  calibration,
+  tier,
+}: ReviewerBylineProps) {
+  // Anonymous reviewer — no reputation data to show.
+  if (!reviewerUsername || reviewsGiven == null || reviewsGiven === 0) {
+    return (
+      <div className="text-[13px] text-[var(--text-secondary)]">
+        reviewed by <b className="text-[var(--foreground)]">{reviewerName}</b>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap text-[13px] text-[var(--text-secondary)]">
+      <span>reviewed by <b className="text-[var(--foreground)]">@{reviewerUsername}</b></span>
+      <span className="font-mono">
+        · {reviewsGiven} reviews
+        {calibration != null && ` · ${Math.round(calibration)}% cal`}
+      </span>
+      {tier && (
+        <span className={`${TIER_STYLES[tier]} text-white text-[9px] font-extrabold px-1.5 py-0.5 rounded-sm tracking-wider`}>
+          {tier.toUpperCase()}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/reviews/reviewer-byline.tsx
+++ b/src/components/reviews/reviewer-byline.tsx
@@ -21,8 +21,8 @@ export function ReviewerByline({
   calibration,
   tier,
 }: ReviewerBylineProps) {
-  // Anonymous reviewer — no reputation data to show.
-  if (!reviewerUsername || reviewsGiven == null || reviewsGiven === 0) {
+  // Anonymous reviewer (no linked user) — fall back to plain name.
+  if (!reviewerUsername) {
     return (
       <div className="text-[13px] text-[var(--text-secondary)]">
         reviewed by <b className="text-[var(--foreground)]">{reviewerName}</b>
@@ -30,13 +30,17 @@ export function ReviewerByline({
     );
   }
 
+  const hasMeta = (reviewsGiven != null && reviewsGiven > 0) || calibration != null;
+
   return (
     <div className="flex items-center gap-2 flex-wrap text-[13px] text-[var(--text-secondary)]">
       <span>reviewed by <b className="text-[var(--foreground)]">@{reviewerUsername}</b></span>
-      <span className="font-mono">
-        · {reviewsGiven} reviews
-        {calibration != null && ` · ${Math.round(calibration)}% cal`}
-      </span>
+      {hasMeta && (
+        <span className="font-mono">
+          {reviewsGiven != null && reviewsGiven > 0 && `· ${reviewsGiven} reviews`}
+          {calibration != null && ` · ${Math.round(calibration)}% cal`}
+        </span>
+      )}
       {tier && (
         <span className={`${TIER_STYLES[tier]} text-white text-[9px] font-extrabold px-1.5 py-0.5 rounded-sm tracking-wider`}>
           {tier.toUpperCase()}

--- a/src/components/share/share-button.tsx
+++ b/src/components/share/share-button.tsx
@@ -2,30 +2,82 @@
 
 import { useState } from "react";
 
-export function ShareButton({ url, text }: { url: string; text: string }) {
-  const [copied, setCopied] = useState(false);
+interface ShareButtonProps {
+  url: string;
+  text: string;
+  /** Optional. When provided, renders a "Copy image" button that copies this image to clipboard. */
+  imageUrl?: string;
+}
+
+type Status = "idle" | "copying" | "copied-link" | "copied-image" | "image-error";
+
+export function ShareButton({ url, text, imageUrl }: ShareButtonProps) {
+  const [status, setStatus] = useState<Status>("idle");
   const absUrl = typeof window !== "undefined" ? new URL(url, window.location.origin).toString() : url;
+  const absImageUrl = imageUrl && typeof window !== "undefined" ? new URL(imageUrl, window.location.origin).toString() : imageUrl;
+
+  async function copyLink() {
+    try {
+      await navigator.clipboard.writeText(absUrl);
+      setStatus("copied-link");
+      setTimeout(() => setStatus("idle"), 1500);
+    } catch {
+      // Best-effort fallback: select text via prompt — rare on modern browsers
+      setStatus("idle");
+    }
+  }
+
+  async function copyImage() {
+    if (!absImageUrl) return;
+    setStatus("copying");
+    try {
+      const res = await fetch(absImageUrl);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const blob = await res.blob();
+      // Clipboard API in some browsers requires a PNG specifically.
+      // ImageResponse from next/og emits image/png.
+      await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })]);
+      setStatus("copied-image");
+      setTimeout(() => setStatus("idle"), 1500);
+    } catch (e) {
+      console.error("copy image failed:", e);
+      setStatus("image-error");
+      setTimeout(() => setStatus("idle"), 2000);
+    }
+  }
 
   return (
     <div className="flex gap-2 flex-wrap">
       <a
         href={`https://x.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(absUrl)}`}
-        target="_blank" rel="noopener noreferrer"
+        target="_blank"
+        rel="noopener noreferrer"
         className="bg-[var(--bg-inverted)] text-white px-4 py-2 text-[13px] font-extrabold rounded-sm hover:opacity-90"
-      >Share on X →</a>
-      <a
-        href={`https://warpcast.com/~/compose?text=${encodeURIComponent(text)}&embeds[]=${encodeURIComponent(absUrl)}`}
-        target="_blank" rel="noopener noreferrer"
-        className="bg-[var(--bg-inverted)] text-white px-4 py-2 text-[13px] font-extrabold rounded-sm hover:opacity-90"
-      >Cast on Farcaster →</a>
+      >
+        Share on X →
+      </a>
+
+      {absImageUrl && (
+        <button
+          onClick={copyImage}
+          disabled={status === "copying"}
+          className="bg-[var(--accent)] text-white px-4 py-2 text-[13px] font-extrabold rounded-sm hover:opacity-90 disabled:opacity-60"
+          aria-label="Copy receipt image to clipboard"
+        >
+          {status === "copying" ? "Copying…"
+            : status === "copied-image" ? "Image copied ✓"
+            : status === "image-error" ? "Couldn’t copy"
+            : "Copy image"}
+        </button>
+      )}
+
       <button
-        onClick={async () => {
-          await navigator.clipboard.writeText(absUrl);
-          setCopied(true);
-          setTimeout(() => setCopied(false), 1500);
-        }}
-        className="bg-[var(--accent)] text-white px-4 py-2 text-[13px] font-extrabold rounded-sm hover:opacity-90"
-      >{copied ? "Copied ✓" : "Copy link"}</button>
+        onClick={copyLink}
+        className="bg-[var(--bg-surface)] text-[var(--foreground)] border-2 border-[var(--border-hard)] px-4 py-2 text-[13px] font-extrabold rounded-sm hover:bg-[var(--bg-surface-light)]"
+        aria-label="Copy share link"
+      >
+        {status === "copied-link" ? "Link copied ✓" : "Copy link"}
+      </button>
     </div>
   );
 }

--- a/src/components/share/share-button.tsx
+++ b/src/components/share/share-button.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useState } from "react";
+
+export function ShareButton({ url, text }: { url: string; text: string }) {
+  const [copied, setCopied] = useState(false);
+  const absUrl = typeof window !== "undefined" ? new URL(url, window.location.origin).toString() : url;
+
+  return (
+    <div className="flex gap-2 flex-wrap">
+      <a
+        href={`https://x.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(absUrl)}`}
+        target="_blank" rel="noopener noreferrer"
+        className="bg-[var(--bg-inverted)] text-white px-4 py-2 text-[13px] font-extrabold rounded-sm hover:opacity-90"
+      >Share on X →</a>
+      <a
+        href={`https://warpcast.com/~/compose?text=${encodeURIComponent(text)}&embeds[]=${encodeURIComponent(absUrl)}`}
+        target="_blank" rel="noopener noreferrer"
+        className="bg-[var(--bg-inverted)] text-white px-4 py-2 text-[13px] font-extrabold rounded-sm hover:opacity-90"
+      >Cast on Farcaster →</a>
+      <button
+        onClick={async () => {
+          await navigator.clipboard.writeText(absUrl);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        }}
+        className="bg-[var(--accent)] text-white px-4 py-2 text-[13px] font-extrabold rounded-sm hover:opacity-90"
+      >{copied ? "Copied ✓" : "Copy link"}</button>
+    </div>
+  );
+}

--- a/src/components/ui/project-card.tsx
+++ b/src/components/ui/project-card.tsx
@@ -7,6 +7,7 @@ import Image from "next/image";
 import type { Project } from "@/lib/types/database";
 import { QualityScoreBadge } from "@/components/ui/quality-score-badge";
 import { EndorseButton } from "@/components/ui/endorse-button";
+import { GithubSignal } from "@/components/projects/github-signal";
 import { createClient } from "@/lib/supabase/client";
 import { parseImageCrop } from "@/lib/image-crop";
 import { normalizeExternalUrl, normalizeRepoUrl } from "@/lib/url-normalize";
@@ -278,6 +279,13 @@ export function ProjectCard({ project, authorUsername, onEdit, showReport = true
         ))}
       </div>
       )}
+
+      <GithubSignal
+        commits7d={null}
+        values7d={null}
+        lastCommitAgo={null}
+        githubUrl={project.github_url ?? null}
+      />
 
       <div className="mt-2 flex items-center gap-3 text-[10px] font-bold text-[var(--text-muted)] uppercase">
         <EndorseButton projectId={project.id} initialCount={project.endorsement_count} />

--- a/src/lib/cron-jobs/__tests__/weekly-snapshot.test.ts
+++ b/src/lib/cron-jobs/__tests__/weekly-snapshot.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { mondayOf } from "../weekly-snapshot";
+
+describe("mondayOf", () => {
+  it("returns the same day when given a Monday", () => {
+    const mon = new Date("2026-05-11T15:00:00Z");      // a Monday
+    expect(mondayOf(mon).toISOString().slice(0, 10)).toBe("2026-05-11");
+  });
+  it("returns the previous Monday when given a Sunday", () => {
+    const sun = new Date("2026-05-10T15:00:00Z");
+    expect(mondayOf(sun).toISOString().slice(0, 10)).toBe("2026-05-04");
+  });
+  it("returns the previous Monday when given a Wednesday", () => {
+    const wed = new Date("2026-05-13T15:00:00Z");
+    expect(mondayOf(wed).toISOString().slice(0, 10)).toBe("2026-05-11");
+  });
+});

--- a/src/lib/cron-jobs/reviewer-calibration.ts
+++ b/src/lib/cron-jobs/reviewer-calibration.ts
@@ -1,0 +1,80 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import { computeCalibration, MIN_REVIEWS_FOR_CALIBRATION } from "@/lib/reviewer/calibration";
+import { classifyTier } from "@/lib/reviewer/tier";
+
+/**
+ * Nightly: recompute reviewer_calibration + reviewer_tier for every user
+ * who has authored >= MIN_REVIEWS_FOR_CALIBRATION reviews with reviewer_user_id set.
+ *
+ * Anonymous reviews (reviewer_user_id IS NULL) are skipped.
+ */
+export async function runReviewerCalibration(): Promise<{ updated: number; skipped: number }> {
+  const sb = createAdminClient();
+
+  // 1. Pull all reviews with a logged-in reviewer + the builder's vibe_score.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: rows, error } = await (sb as any)
+    .from("reviews")
+    .select("reviewer_user_id, rating, builder:users!builder_id ( vibe_score )")
+    .not("reviewer_user_id", "is", null);
+
+  if (error) {
+    console.error("reviewer-calibration: fetch failed", error);
+    return { updated: 0, skipped: 0 };
+  }
+
+  // 2. Pull the global vibe_score distribution to compute percentile.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: allScores } = await (sb as any)
+    .from("users")
+    .select("vibe_score")
+    .gt("vibe_score", 0)
+    .order("vibe_score", { ascending: true });
+
+  const scores: number[] = (allScores || []).map((u: { vibe_score: number }) => u.vibe_score);
+  const total = scores.length || 1;
+
+  // Percentile: fraction of users with score STRICTLY LESS than this one.
+  function percentileFor(score: number): number {
+    let count = 0;
+    for (const s of scores) {
+      if (s < score) count++;
+      else break;
+    }
+    return count / total;
+  }
+
+  // 3. Group reviews by reviewer.
+  const grouped = new Map<string, Array<{ rating: number; builderPercentile: number }>>();
+  for (const r of rows || []) {
+    const uid = r.reviewer_user_id as string;
+    const builderScore = (r.builder as { vibe_score: number } | null)?.vibe_score ?? 0;
+    const list = grouped.get(uid) || [];
+    list.push({ rating: r.rating, builderPercentile: percentileFor(builderScore) });
+    grouped.set(uid, list);
+  }
+
+  // 4. Compute + upsert per reviewer.
+  let updated = 0;
+  let skipped = 0;
+
+  for (const [reviewerUserId, reviews] of grouped) {
+    if (reviews.length < MIN_REVIEWS_FOR_CALIBRATION) { skipped++; continue; }
+    const cal = computeCalibration(reviews);
+    const tier = classifyTier(cal, reviews.length);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { error: updErr } = await (sb as any)
+      .from("users")
+      .update({ reviewer_calibration: cal, reviewer_tier: tier })
+      .eq("id", reviewerUserId);
+
+    if (updErr) {
+      console.error("reviewer-calibration: update failed", reviewerUserId, updErr);
+      continue;
+    }
+    updated++;
+  }
+
+  return { updated, skipped };
+}

--- a/src/lib/cron-jobs/weekly-snapshot.ts
+++ b/src/lib/cron-jobs/weekly-snapshot.ts
@@ -1,0 +1,57 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+
+/**
+ * Writes one snapshot row per active user for this Monday's week_start.
+ * Idempotent: PRIMARY KEY (user_id, week_start) means re-running the same day overwrites
+ * via ON CONFLICT.
+ */
+export async function runWeeklySnapshot(now: Date = new Date()): Promise<{ inserted: number }> {
+  const sb = createAdminClient();
+
+  const weekStart = mondayOf(now);
+  const weekStartStr = weekStart.toISOString().slice(0, 10);
+
+  // Pull all users with score > 0, ranked.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: users, error } = await (sb as any)
+    .from("users")
+    .select("id, vibe_score")
+    .gt("vibe_score", 0)
+    .order("vibe_score", { ascending: false });
+
+  if (error || !users) {
+    console.error("weekly-snapshot: fetch failed", error);
+    return { inserted: 0 };
+  }
+
+  const rows = users.map((u: { id: string; vibe_score: number }, idx: number) => ({
+    user_id: u.id,
+    week_start: weekStartStr,
+    vibe_score: u.vibe_score,
+    rank: idx + 1,
+    // commits_7d: intentionally left at 0 for v1. Spec §13 defers per-snapshot commit
+    // aggregation to post-hackathon. The cards already surface commits_7d from the
+    // projects table (Task 24), so the leaderboard receipt doesn't need it yet.
+    commits_7d: 0,
+  }));
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error: insErr, count } = await (sb as any)
+    .from("vibe_score_weekly_snapshots")
+    .upsert(rows, { onConflict: "user_id,week_start", count: "exact" });
+
+  if (insErr) {
+    console.error("weekly-snapshot: upsert failed", insErr);
+    return { inserted: 0 };
+  }
+  return { inserted: count ?? rows.length };
+}
+
+/** Returns the Monday on or before `d` at UTC midnight. */
+export function mondayOf(d: Date): Date {
+  const x = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  const day = x.getUTCDay();              // 0=Sun..6=Sat
+  const diff = day === 0 ? 6 : day - 1;
+  x.setUTCDate(x.getUTCDate() - diff);
+  return x;
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,5 +1,6 @@
 import { Resend } from "resend";
 import { getSiteUrl } from "@/lib/seo";
+import { mondayOf } from "@/lib/cron-jobs/weekly-snapshot";
 
 let resend: Resend | null = null;
 
@@ -210,6 +211,33 @@ ${statCell({ value: stats.vibeScore, label: "Vibe score", side: "left", borderRi
 ${statCell({ value: stats.hireRequests, label: "Hire requests", side: "right" })}
 </tr>
 </table>`;
+}
+
+/**
+ * Renders the weekly receipt card (OG image + share CTA) appended to the
+ * weekly digest. `username` is URL-encoded and `monday` is a YYYY-MM-DD string;
+ * both are interpolated into URLs and rendered as image src / hrefs only,
+ * so no HTML escaping is needed beyond the encodeURIComponent on username.
+ */
+export function renderWeeklyReceiptSection(opts: {
+  username: string;
+  monday: string;
+}): string {
+  const siteUrl = getSiteUrl();
+  const safeUser = encodeURIComponent(opts.username);
+  const receiptOg = `${siteUrl}/api/og/receipt/weekly/${safeUser}?w=${opts.monday}`;
+  const receiptLink = `${siteUrl}/share/${safeUser}/weekly/${opts.monday}`;
+  return `<div style="margin-top:8px;padding-top:28px;border-top:1px solid ${BRAND.hairline};">
+<p style="margin:0 0 14px;font-family:${BRAND.fontMono};font-size:11px;font-weight:500;letter-spacing:0.14em;text-transform:uppercase;color:${BRAND.textMuted};">Your weekly receipt</p>
+<a href="${receiptLink}" style="text-decoration:none;display:block;line-height:0;"><img src="${receiptOg}" alt="weekly receipt" width="560" style="display:block;width:100%;max-width:560px;height:auto;border:0;outline:none;" /></a>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:18px 0 0;">
+<tr><td bgcolor="${BRAND.accent}" style="background:${BRAND.accent};">
+<a href="${receiptLink}" style="display:inline-block;background:${BRAND.accent};color:${BRAND.accentText};padding:14px 26px;text-decoration:none;font-family:${BRAND.fontSans};font-size:14px;font-weight:600;letter-spacing:-0.005em;mso-padding-alt:0;">
+Share your receipt<span style="margin-left:8px;">→</span>
+</a>
+</td></tr>
+</table>
+</div>`;
 }
 
 interface HireNotificationParams {
@@ -519,6 +547,8 @@ export async function sendWeeklyDigestEmail({
   if (!client) return;
 
   const siteUrl = getSiteUrl();
+  const monday = mondayOf(new Date()).toISOString().slice(0, 10);
+  const receiptShareUrl = `${siteUrl}/share/${encodeURIComponent(username)}/weekly/${monday}`;
 
   const body = `
 ${eyebrow("Weekly recap")}
@@ -531,13 +561,14 @@ ${renderStatsGrid({
   hireRequests: stats.hireRequests,
 })}
 ${cta(`${siteUrl}/dashboard`, "View dashboard")}
+${renderWeeklyReceiptSection({ username, monday })}
 `;
 
   try {
     await sendEmail(client, {
       to: email,
       subject: `Your week on VibeTalent`,
-      text: `Hey @${username}, here's how your week went:\n\nProfile views: ${stats.profileViews}\nDay streak: ${stats.streakDays}\nVibe score: ${stats.vibeScore}\nHire requests: ${stats.hireRequests}\n\nView dashboard: ${siteUrl}/dashboard\n\nUnsubscribe: ${unsubUrl(email)}`,
+      text: `Hey @${username}, here's how your week went:\n\nProfile views: ${stats.profileViews}\nDay streak: ${stats.streakDays}\nVibe score: ${stats.vibeScore}\nHire requests: ${stats.hireRequests}\n\nView dashboard: ${siteUrl}/dashboard\n\nYour weekly receipt: ${receiptShareUrl}\n\nUnsubscribe: ${unsubUrl(email)}`,
       html: renderEmail({
         preheader: `${stats.profileViews} profile views · ${stats.streakDays}-day streak · ${stats.vibeScore} vibe score`,
         body,
@@ -858,12 +889,14 @@ ${cta(`${siteUrl}/dashboard`, "View dashboard")}
 
   {
     const stats = { profileViews: 47, streakDays: 12, vibeScore: 84, hireRequests: 3 };
+    const previewMonday = mondayOf(new Date()).toISOString().slice(0, 10);
     const body = `
 ${eyebrow("Weekly recap")}
 ${headline("Your week on VibeTalent")}
 ${paragraph(`Hey <strong>@${safeUser}</strong>, here's how the past 7 days went.`)}
 ${renderStatsGrid(stats)}
 ${cta(`${siteUrl}/dashboard`, "View dashboard")}
+${renderWeeklyReceiptSection({ username, monday: previewMonday })}
 `;
     samples.push({
       key: "weekly-digest",

--- a/src/lib/leaderboard/__tests__/weekly.test.ts
+++ b/src/lib/leaderboard/__tests__/weekly.test.ts
@@ -46,23 +46,56 @@ describe("computeClimbers", () => {
 describe("computeActiveBuilders", () => {
   it("filters out users with 0 active days", () => {
     const active = new Map<string, number>([["a", 5]]);
+    const commits = new Map<string, number>([["a", 20], ["b", 0]]);
     const current = [
       { id: "a", username: "alpha", vibe_score: 200, streak: 5, avatar_url: null, rank: 10 },
       { id: "b", username: "beta",  vibe_score: 500, streak: 0, avatar_url: null, rank: 5 },
     ];
-    const result = computeActiveBuilders(active, current);
+    const result = computeActiveBuilders(active, commits, current);
     expect(result.map(r => r.username)).toEqual(["alpha"]);
   });
 
-  it("sorts by active days desc, then streak desc, then vibe_score desc", () => {
-    const active = new Map<string, number>([["a", 5], ["b", 5], ["c", 7]]);
+  it("sorts by commits desc as primary", () => {
+    const active = new Map<string, number>([["a", 7], ["b", 7], ["c", 7]]);
+    const commits = new Map<string, number>([["a", 12], ["b", 47], ["c", 5]]);
     const current = [
-      { id: "a", username: "alpha", vibe_score: 200, streak: 3, avatar_url: null, rank: 10 },
-      { id: "b", username: "beta",  vibe_score: 100, streak: 10, avatar_url: null, rank: 30 },
-      { id: "c", username: "cara",  vibe_score: 500, streak: 1, avatar_url: null, rank: 5 },
+      { id: "a", username: "alpha", vibe_score: 200, streak: 30, avatar_url: null, rank: 1 },
+      { id: "b", username: "beta",  vibe_score: 100, streak: 5,  avatar_url: null, rank: 30 },
+      { id: "c", username: "cara",  vibe_score: 500, streak: 10, avatar_url: null, rank: 5 },
     ];
-    const result = computeActiveBuilders(active, current);
-    // cara first (7 days), then beta (5 days + higher streak), then alpha (5 days + lower streak)
-    expect(result.map(r => r.username)).toEqual(["cara", "beta", "alpha"]);
+    const result = computeActiveBuilders(active, commits, current);
+    expect(result.map(r => r.username)).toEqual(["beta", "alpha", "cara"]);
+  });
+
+  it("falls back to active days desc when commits tie", () => {
+    const active = new Map<string, number>([["a", 4], ["b", 7]]);
+    const commits = new Map<string, number>([["a", 10], ["b", 10]]);
+    const current = [
+      { id: "a", username: "alpha", vibe_score: 100, streak: 5, avatar_url: null, rank: 10 },
+      { id: "b", username: "beta",  vibe_score: 100, streak: 5, avatar_url: null, rank: 30 },
+    ];
+    const result = computeActiveBuilders(active, commits, current);
+    expect(result.map(r => r.username)).toEqual(["beta", "alpha"]);
+  });
+
+  it("falls back to streak desc when commits and active days tie", () => {
+    const active = new Map<string, number>([["a", 5], ["b", 5]]);
+    const commits = new Map<string, number>([["a", 10], ["b", 10]]);
+    const current = [
+      { id: "a", username: "alpha", vibe_score: 100, streak: 30, avatar_url: null, rank: 10 },
+      { id: "b", username: "beta",  vibe_score: 100, streak: 5,  avatar_url: null, rank: 30 },
+    ];
+    const result = computeActiveBuilders(active, commits, current);
+    expect(result.map(r => r.username)).toEqual(["alpha", "beta"]);
+  });
+
+  it("populates commits7d correctly", () => {
+    const active = new Map<string, number>([["a", 5]]);
+    const commits = new Map<string, number>([["a", 47]]);
+    const current = [
+      { id: "a", username: "alpha", vibe_score: 200, streak: 5, avatar_url: null, rank: 10 },
+    ];
+    const result = computeActiveBuilders(active, commits, current);
+    expect(result[0].commits7d).toBe(47);
   });
 });

--- a/src/lib/leaderboard/__tests__/weekly.test.ts
+++ b/src/lib/leaderboard/__tests__/weekly.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { computeClimbers, MIN_VIBE_FLOOR } from "../weekly";
+
+describe("computeClimbers", () => {
+  it("sorts by rank-position climb desc", () => {
+    const snapshots = [
+      { user_id: "a", rank: 80, vibe_score: 200 },
+      { user_id: "b", rank: 50, vibe_score: 775 },
+      { user_id: "c", rank: 15, vibe_score: 750 },
+    ];
+    const current = [
+      { id: "a", username: "maya", vibe_score: 280, rank: 38, avatar_url: null },
+      { id: "b", username: "abhi", vibe_score: 847, rank: 38, avatar_url: null },
+      { id: "c", username: "kai",  vibe_score: 850, rank: 8,  avatar_url: null },
+    ];
+    const result = computeClimbers(snapshots, current);
+    expect(result.map((r) => r.username)).toEqual(["maya", "abhi", "kai"]);
+    // maya: ▲42, abhi: ▲12, kai: ▲7
+    expect(result[0].rankClimb).toBe(42);
+    expect(result[0].scoreDelta).toBe(80);
+  });
+
+  it("filters out users below the vibe_score floor", () => {
+    const snapshots = [
+      { user_id: "n", rank: 999, vibe_score: 5 },
+    ];
+    const current = [
+      { id: "n", username: "newbie", vibe_score: 50, rank: 200, avatar_url: null },
+    ];
+    expect(computeClimbers(snapshots, current)).toEqual([]);
+    expect(MIN_VIBE_FLOOR).toBe(100);
+  });
+
+  it("includes users with no prior snapshot but marks rankClimb as null", () => {
+    const snapshots: Array<{ user_id: string; rank: number; vibe_score: number }> = [];
+    const current = [
+      { id: "x", username: "fresh", vibe_score: 150, rank: 60, avatar_url: null },
+    ];
+    const result = computeClimbers(snapshots, current);
+    expect(result).toHaveLength(1);
+    expect(result[0].rankClimb).toBeNull();
+    expect(result[0].scoreDelta).toBeNull();
+  });
+});

--- a/src/lib/leaderboard/__tests__/weekly.test.ts
+++ b/src/lib/leaderboard/__tests__/weekly.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computeClimbers, MIN_VIBE_FLOOR } from "../weekly";
+import { computeActiveBuilders, computeClimbers, MIN_VIBE_FLOOR } from "../weekly";
 
 describe("computeClimbers", () => {
   it("sorts by rank-position climb desc", () => {
@@ -40,5 +40,29 @@ describe("computeClimbers", () => {
     expect(result).toHaveLength(1);
     expect(result[0].rankClimb).toBeNull();
     expect(result[0].scoreDelta).toBeNull();
+  });
+});
+
+describe("computeActiveBuilders", () => {
+  it("filters out users with 0 active days", () => {
+    const active = new Map<string, number>([["a", 5]]);
+    const current = [
+      { id: "a", username: "alpha", vibe_score: 200, streak: 5, avatar_url: null, rank: 10 },
+      { id: "b", username: "beta",  vibe_score: 500, streak: 0, avatar_url: null, rank: 5 },
+    ];
+    const result = computeActiveBuilders(active, current);
+    expect(result.map(r => r.username)).toEqual(["alpha"]);
+  });
+
+  it("sorts by active days desc, then streak desc, then vibe_score desc", () => {
+    const active = new Map<string, number>([["a", 5], ["b", 5], ["c", 7]]);
+    const current = [
+      { id: "a", username: "alpha", vibe_score: 200, streak: 3, avatar_url: null, rank: 10 },
+      { id: "b", username: "beta",  vibe_score: 100, streak: 10, avatar_url: null, rank: 30 },
+      { id: "c", username: "cara",  vibe_score: 500, streak: 1, avatar_url: null, rank: 5 },
+    ];
+    const result = computeActiveBuilders(active, current);
+    // cara first (7 days), then beta (5 days + higher streak), then alpha (5 days + lower streak)
+    expect(result.map(r => r.username)).toEqual(["cara", "beta", "alpha"]);
   });
 });

--- a/src/lib/leaderboard/weekly.ts
+++ b/src/lib/leaderboard/weekly.ts
@@ -58,3 +58,51 @@ export function computeClimbers(snapshots: Snapshot[], current: CurrentUser[]): 
 
   return rows;
 }
+
+export interface ActiveBuilderRow {
+  username: string;
+  avatar_url: string | null;
+  currentRank: number;
+  activeDays7d: number;     // 0-7
+  streak: number;           // current streak
+  vibeScore: number;
+}
+
+interface CurrentUserForActive {
+  id: string;
+  username: string;
+  vibe_score: number;
+  streak: number;
+  avatar_url: string | null;
+  rank: number;
+}
+
+/**
+ * Joins active-days counts with current users.
+ * Filters: must have at least 1 active day in last 7d (i.e., be in activeDaysByUserId).
+ * Sort: activeDays7d desc, streak desc, vibeScore desc.
+ */
+export function computeActiveBuilders(
+  activeDaysByUserId: Map<string, number>,
+  current: CurrentUserForActive[],
+): ActiveBuilderRow[] {
+  const rows: ActiveBuilderRow[] = [];
+  for (const u of current) {
+    const days = activeDaysByUserId.get(u.id) ?? 0;
+    if (days <= 0) continue;
+    rows.push({
+      username: u.username,
+      avatar_url: u.avatar_url,
+      currentRank: u.rank,
+      activeDays7d: days,
+      streak: u.streak,
+      vibeScore: u.vibe_score,
+    });
+  }
+  rows.sort((a, b) => {
+    if (b.activeDays7d !== a.activeDays7d) return b.activeDays7d - a.activeDays7d;
+    if (b.streak !== a.streak) return b.streak - a.streak;
+    return b.vibeScore - a.vibeScore;
+  });
+  return rows;
+}

--- a/src/lib/leaderboard/weekly.ts
+++ b/src/lib/leaderboard/weekly.ts
@@ -1,0 +1,60 @@
+export const MIN_VIBE_FLOOR = 100;
+
+interface Snapshot {
+  user_id: string;
+  rank: number;
+  vibe_score: number;
+}
+
+interface CurrentUser {
+  id: string;
+  username: string;
+  vibe_score: number;
+  rank: number;
+  avatar_url: string | null;
+}
+
+export interface ClimberRow {
+  username: string;
+  avatar_url: string | null;
+  currentRank: number;
+  previousRank: number | null;
+  rankClimb: number | null;     // null if no snapshot
+  currentScore: number;
+  scoreDelta: number | null;    // null if no snapshot
+}
+
+/**
+ * Joins snapshots with current users, computes deltas, applies the floor, and sorts.
+ * Sort key: rankClimb desc, scoreDelta desc, currentRank asc.
+ * Users without a snapshot appear at the bottom (rankClimb = null sorts last).
+ */
+export function computeClimbers(snapshots: Snapshot[], current: CurrentUser[]): ClimberRow[] {
+  const snapByUser = new Map(snapshots.map((s) => [s.user_id, s]));
+
+  const rows: ClimberRow[] = current
+    .filter((u) => u.vibe_score >= MIN_VIBE_FLOOR)
+    .map((u) => {
+      const snap = snapByUser.get(u.id);
+      return {
+        username: u.username,
+        avatar_url: u.avatar_url,
+        currentRank: u.rank,
+        previousRank: snap?.rank ?? null,
+        rankClimb: snap ? snap.rank - u.rank : null,
+        currentScore: u.vibe_score,
+        scoreDelta: snap ? u.vibe_score - snap.vibe_score : null,
+      };
+    });
+
+  rows.sort((a, b) => {
+    // Null climb sorts last
+    if (a.rankClimb == null && b.rankClimb == null) return a.currentRank - b.currentRank;
+    if (a.rankClimb == null) return 1;
+    if (b.rankClimb == null) return -1;
+    if (b.rankClimb !== a.rankClimb) return b.rankClimb - a.rankClimb;
+    return (b.scoreDelta ?? 0) - (a.scoreDelta ?? 0);
+  });
+
+  return rows;
+}

--- a/src/lib/leaderboard/weekly.ts
+++ b/src/lib/leaderboard/weekly.ts
@@ -64,7 +64,8 @@ export interface ActiveBuilderRow {
   avatar_url: string | null;
   currentRank: number;
   activeDays7d: number;     // 0-7
-  streak: number;           // current streak
+  commits7d: number;        // sum of streak_logs.commit_count in last 7d
+  streak: number;
   vibeScore: number;
 }
 
@@ -78,12 +79,13 @@ interface CurrentUserForActive {
 }
 
 /**
- * Joins active-days counts with current users.
- * Filters: must have at least 1 active day in last 7d (i.e., be in activeDaysByUserId).
- * Sort: activeDays7d desc, streak desc, vibeScore desc.
+ * Joins active-days + commit counts with current users.
+ * Filters: must have at least 1 active day in last 7d.
+ * Sort: commits7d desc, activeDays7d desc, streak desc, vibeScore desc.
  */
 export function computeActiveBuilders(
   activeDaysByUserId: Map<string, number>,
+  commitsByUserId: Map<string, number>,
   current: CurrentUserForActive[],
 ): ActiveBuilderRow[] {
   const rows: ActiveBuilderRow[] = [];
@@ -95,11 +97,13 @@ export function computeActiveBuilders(
       avatar_url: u.avatar_url,
       currentRank: u.rank,
       activeDays7d: days,
+      commits7d: commitsByUserId.get(u.id) ?? 0,
       streak: u.streak,
       vibeScore: u.vibe_score,
     });
   }
   rows.sort((a, b) => {
+    if (b.commits7d !== a.commits7d) return b.commits7d - a.commits7d;
     if (b.activeDays7d !== a.activeDays7d) return b.activeDays7d - a.activeDays7d;
     if (b.streak !== a.streak) return b.streak - a.streak;
     return b.vibeScore - a.vibeScore;

--- a/src/lib/reviewer/__tests__/calibration.test.ts
+++ b/src/lib/reviewer/__tests__/calibration.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { computeCalibration } from "../calibration";
+
+describe("computeCalibration", () => {
+  it("returns null when reviewer has < 5 reviews", () => {
+    const reviews = [
+      { rating: 5, builderPercentile: 0.9 },
+      { rating: 4, builderPercentile: 0.8 },
+    ];
+    expect(computeCalibration(reviews)).toBeNull();
+  });
+
+  it("returns 100 when every review perfectly matches the builder's percentile", () => {
+    // rating 5 → normalized 1.0; builder in 100th percentile → 1.0 → error 0
+    const reviews = [
+      { rating: 5, builderPercentile: 1.0 },
+      { rating: 5, builderPercentile: 1.0 },
+      { rating: 5, builderPercentile: 1.0 },
+      { rating: 5, builderPercentile: 1.0 },
+      { rating: 5, builderPercentile: 1.0 },
+    ];
+    expect(computeCalibration(reviews)).toBe(100);
+  });
+
+  it("returns 0 when every review is maximally wrong", () => {
+    // rating 5 → 1.0; builder bottom percentile → 0.0 → error 1.0
+    const reviews = Array(5).fill({ rating: 5, builderPercentile: 0.0 });
+    expect(computeCalibration(reviews)).toBe(0);
+  });
+
+  it("computes a partial calibration correctly", () => {
+    // rating 4 → 0.8; builder 0.7 → error 0.1; five copies → mean error 0.1
+    // calibration = 100 - 0.1 * 100 = 90
+    const reviews = Array(5).fill({ rating: 4, builderPercentile: 0.7 });
+    expect(computeCalibration(reviews)).toBe(90);
+  });
+
+  it("rounds to 2 decimals", () => {
+    const reviews = [
+      { rating: 5, builderPercentile: 0.95 }, // error 0.05
+      { rating: 4, builderPercentile: 0.75 }, // error 0.05
+      { rating: 3, builderPercentile: 0.55 }, // error 0.05
+      { rating: 2, builderPercentile: 0.35 }, // error 0.05
+      { rating: 1, builderPercentile: 0.15 }, // error 0.05
+    ];
+    // mean error = 0.05, calibration = 100 - 5 = 95
+    expect(computeCalibration(reviews)).toBe(95);
+  });
+});

--- a/src/lib/reviewer/__tests__/tier.test.ts
+++ b/src/lib/reviewer/__tests__/tier.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { classifyTier } from "../tier";
+
+describe("classifyTier", () => {
+  it("returns null when calibration is null", () => {
+    expect(classifyTier(null, 50)).toBeNull();
+  });
+
+  it("returns null below bronze thresholds", () => {
+    expect(classifyTier(60, 100)).toBeNull();   // 60% cal fails bronze 70% min
+    expect(classifyTier(75, 5)).toBeNull();     // 5 reviews fails bronze 10 min
+  });
+
+  it("returns bronze when both bronze minimums met", () => {
+    expect(classifyTier(70, 10)).toBe("bronze");
+    expect(classifyTier(79, 29)).toBe("bronze");
+  });
+
+  it("returns silver when both silver minimums met", () => {
+    expect(classifyTier(80, 30)).toBe("silver");
+    expect(classifyTier(84, 74)).toBe("silver");
+  });
+
+  it("returns gold when both gold minimums met", () => {
+    expect(classifyTier(85, 75)).toBe("gold");
+    expect(classifyTier(100, 1000)).toBe("gold");
+  });
+
+  it("uses the lower tier when one threshold is met but not both", () => {
+    expect(classifyTier(85, 30)).toBe("silver");  // high cal, silver review count
+    expect(classifyTier(72, 75)).toBe("bronze");  // many reviews, bronze cal
+  });
+});

--- a/src/lib/reviewer/calibration.ts
+++ b/src/lib/reviewer/calibration.ts
@@ -1,0 +1,23 @@
+export const MIN_REVIEWS_FOR_CALIBRATION = 5;
+
+export interface ReviewForCalibration {
+  rating: number;          // 1-5
+  builderPercentile: number; // 0.0-1.0
+}
+
+/**
+ * Calibration score = 100 - (mean absolute error between normalized rating and builder percentile) * 100.
+ * Returns null when reviewer has fewer than MIN_REVIEWS_FOR_CALIBRATION reviews.
+ *
+ * Normalized rating: rating / 5 (so 5★ = 1.0, 1★ = 0.2).
+ * builderPercentile: the reviewed builder's rank percentile across all users (0.0 worst, 1.0 best).
+ */
+export function computeCalibration(reviews: ReviewForCalibration[]): number | null {
+  if (reviews.length < MIN_REVIEWS_FOR_CALIBRATION) return null;
+
+  const errors = reviews.map((r) => Math.abs(r.rating / 5 - r.builderPercentile));
+  const meanError = errors.reduce((s, e) => s + e, 0) / errors.length;
+  const calibration = 100 - meanError * 100;
+
+  return Math.round(calibration * 100) / 100;
+}

--- a/src/lib/reviewer/tier.ts
+++ b/src/lib/reviewer/tier.ts
@@ -1,0 +1,35 @@
+export type ReviewerTier = "bronze" | "silver" | "gold";
+
+export const TIER_THRESHOLDS = {
+  bronze: { minReviews: 10, minCalibration: 70 },
+  silver: { minReviews: 30, minCalibration: 80 },
+  gold:   { minReviews: 75, minCalibration: 85 },
+} as const;
+
+/**
+ * Returns the highest tier whose BOTH thresholds (minReviews and minCalibration)
+ * are met by the reviewer. Returns null below bronze.
+ */
+export function classifyTier(
+  calibration: number | null,
+  reviewCount: number,
+): ReviewerTier | null {
+  if (calibration == null) return null;
+
+  if (
+    reviewCount >= TIER_THRESHOLDS.gold.minReviews &&
+    calibration >= TIER_THRESHOLDS.gold.minCalibration
+  ) return "gold";
+
+  if (
+    reviewCount >= TIER_THRESHOLDS.silver.minReviews &&
+    calibration >= TIER_THRESHOLDS.silver.minCalibration
+  ) return "silver";
+
+  if (
+    reviewCount >= TIER_THRESHOLDS.bronze.minReviews &&
+    calibration >= TIER_THRESHOLDS.bronze.minCalibration
+  ) return "bronze";
+
+  return null;
+}

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -106,6 +106,14 @@ export interface Review {
   comment: string | null;
   trust_score: number;
   created_at: string;
+  reviewer_user_id?: string | null;
+  // Optional embedded reviewer profile when reviewer_user_id is set.
+  // Populated by API joins; null for anonymous reviews.
+  reviewer?: {
+    username: string;
+    reviewer_calibration: number | null;
+    reviewer_tier: "bronze" | "silver" | "gold" | null;
+  } | null;
 }
 
 export interface ProjectEndorsement {

--- a/supabase/migrations/20260512_social_visibility_pack.sql
+++ b/supabase/migrations/20260512_social_visibility_pack.sql
@@ -1,0 +1,42 @@
+-- Migration: Social Visibility Pack
+-- Adds weekly score snapshots, reviewer reputation columns, and reviewer→user link.
+-- All changes are additive and nullable; safe to roll forward without backfill.
+
+-- 1. Weekly snapshots (Monday rows only) for "climbed +N spots this week" math.
+create table public.vibe_score_weekly_snapshots (
+  user_id uuid not null references public.users(id) on delete cascade,
+  week_start date not null,
+  vibe_score integer not null,
+  rank integer not null,
+  commits_7d integer not null default 0,
+  created_at timestamptz not null default now(),
+  primary key (user_id, week_start)
+);
+
+create index vibe_score_weekly_snapshots_week_rank_idx
+  on public.vibe_score_weekly_snapshots (week_start, rank);
+
+alter table public.vibe_score_weekly_snapshots enable row level security;
+
+create policy "weekly_snapshots_public_read"
+  on public.vibe_score_weekly_snapshots for select using (true);
+
+-- 2. Reviewer reputation columns on users (distinct from existing badge_level).
+alter table public.users
+  add column reviewer_calibration numeric(5,2),
+  add column reviewer_tier text
+    check (reviewer_tier is null or reviewer_tier in ('bronze','silver','gold'));
+
+-- 3. Link reviews to logged-in reviewers. Anonymous reviews stay null.
+alter table public.reviews
+  add column reviewer_user_id uuid references public.users(id) on delete set null;
+
+create index reviews_reviewer_user_id_idx
+  on public.reviews (reviewer_user_id) where reviewer_user_id is not null;
+
+-- ROLLBACK (commented; uncomment + run if needed):
+-- alter table public.reviews drop column if exists reviewer_user_id;
+-- alter table public.users
+--   drop column if exists reviewer_calibration,
+--   drop column if exists reviewer_tier;
+-- drop table if exists public.vibe_score_weekly_snapshots;


### PR DESCRIPTION
## Summary

- **Public weekly leaderboard** (`/leaderboard`) with two tabs — "This week" ranks active builders by raw commit count → active days → streak → vibe score (from `streak_logs.commit_count`); "All-time" preserves the existing view
- **Brutalist Poster profile share card** + **Receipt Stub** OG images (1200×630, `next/og`) with profile picture + verified badge (when `github_username` is set)
- **Shareable receipts**: weekly auto (embedded in digest email), per-project on verify success, manual from profile — three trigger types, one stub design, landing pages at `/share/[username]/{weekly,shipped,custom}`
- **ShareButton**: "Share on X" (drafts tweet + preview card), "Copy image" (writes OG PNG to clipboard), "Copy link"
- **GitHub commit signal** on project cards via inline sparkline component — hidden until per-project commit aggregates are stored (component ready, data wiring deferred)
- **Reviewer reputation**: nightly cron computes calibration score from `(reviewer_stars / 5) vs builder_vibe_score_percentile`; Bronze/Silver/Gold tier classifier; ReviewerStats block on profiles + ReviewerByline inline next to each review (only for authenticated reviewers via new `reviews.reviewer_user_id` column)

## Schema (additive-only, one migration)

`supabase/migrations/20260512_social_visibility_pack.sql` adds:
- `vibe_score_weekly_snapshots` table (Monday rows only, used by `quality-rescore` cron via `runWeeklySnapshot`)
- `users.reviewer_calibration` + `users.reviewer_tier` (nullable)
- `reviews.reviewer_user_id` (nullable — anonymous reviews keep null)

No new Vercel cron slots (extends existing `daily` + `quality-rescore` + `weekly-digest`). RLS public-read on snapshots; nightly calibration uses service role.

## Test plan

- [x] `npm run build` ✅
- [x] `npm run lint` ✅
- [x] `npm run test` — 249/249 across 17 files ✅ (added: calibration math, tier classifier, weekly snapshot date helper, weekly climbers, active builders sort)
- [x] Migration applied to Supabase (verified via dashboard SQL editor)
- [x] `/leaderboard` weekly tab loads and shows correct ranking
- [x] `/leaderboard` all-time tab unchanged
- [x] `/api/og/profile/<u>` renders Brutalist Poster with pfp + verified
- [x] `/api/og/receipt/{weekly|shipped|custom}/<u>` renders Receipt Stub
- [x] `/share/<u>/custom?range=30d` loads with OG meta + share buttons
- [x] ShareButton: Copy image writes PNG to clipboard
- [ ] After next Monday's `quality-rescore` run, confirm `vibe_score_weekly_snapshots` populates
- [ ] After overnight `daily` cron run, confirm `users.reviewer_calibration` / `reviewer_tier` populate for reviewers with ≥5 reviews
- [ ] Project cards: confirm GithubSignal hides cleanly for projects without per-project commit aggregates (current state — deferred per-project commit storage)

## Explicitly deferred (post-hackathon)

1. Milestone receipts (rank threshold detection + share)
2. Helpful-vote on reviews (third reputation column)
3. Per-project `commits_7d` storage so GithubSignal lights up
4. Daily (rather than Monday-only) snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added weekly leaderboard view highlighting active builders based on recent activity
  * Introduced shareable receipt pages for weekly achievements, shipped projects, and custom date ranges
  * Added reviewer reputation system with calibration scores and tier badges (bronze, silver, gold)
  * Enhanced profiles with reviewer statistics display (reviews given, calibration, tier)
  * Added GitHub commit activity signals to project cards
  * Generated Open Graph images for receipt sharing on social media

* **Improvements**
  * Leaderboard now displays multiple views with weekly and all-time rankings
  * Reviews now display reviewer credentials and calibration metrics
  * Email digests now include weekly receipt links

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unknownking07/vibe-talent/pull/186)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->