### PR TITLE
fix(github-sync): explicit user-info lookup + stable github_id

### DIFF
--- a/src/app/api/cron/github-sync/route.ts
+++ b/src/app/api/cron/github-sync/route.ts
@@ -71,10 +71,14 @@ export async function GET(req: NextRequest) {
     // first. The previous ASC ordering meant if the function timed out
     // partway through, the back of the queue (heavy users) was the first
     // thing dropped, leaving them stuck for days.
+    //
+    // github_id is also selected so the rename-detection logic below can
+    // verify the username we have on file still points at the same GitHub
+    // account (catches handle reclaims after a rename).
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { data: usersWithGithub, error: usersError } = await (supabase as any)
       .from("users")
-      .select("id, username, github_username, lifetime_contributions")
+      .select("id, username, github_username, github_id, lifetime_contributions")
       .not("github_username", "is", null)
       .neq("github_username", "")
       .order("lifetime_contributions", { ascending: false, nullsFirst: false });
@@ -98,7 +102,10 @@ export async function GET(req: NextRequest) {
     }
 
     // Build a map of user_id -> github_username
-    const userGithubMap = new Map<string, { userId: string; username: string; githubUsername: string }>();
+    const userGithubMap = new Map<
+      string,
+      { userId: string; username: string; githubUsername: string; githubId: number | null }
+    >();
 
     // Add users with github_username from users table
     for (const user of usersWithGithub || []) {
@@ -108,6 +115,7 @@ export async function GET(req: NextRequest) {
           userId: user.id,
           username: user.username || user.id,
           githubUsername: cleaned,
+          githubId: typeof user.github_id === "number" ? user.github_id : null,
         });
       }
     }
@@ -122,6 +130,7 @@ export async function GET(req: NextRequest) {
               userId: link.user_id,
               username: link.user_id, // We don't have username from social_links
               githubUsername: cleaned,
+              githubId: null,
             });
           }
         }
@@ -165,15 +174,138 @@ export async function GET(req: NextRequest) {
       const batchResults = await Promise.allSettled(
         batch.map(async (userInfo) => {
           try {
-            // Try the events API first (for the activity feed). Failure here
-            // is NON-fatal — we still fetch the heatmap below for lifetime
-            // and 30d totals. Previously a single 403 (rate-limit) on this
-            // call would skip a user entirely, so most users never got their
-            // volume scoring populated.
+            // Step 1: resolve the canonical GitHub identity via /users/{name}.
+            //
+            // Previously we tried to detect renames from events[0].actor.login
+            // on the events fetch, but that only fires when the user has
+            // recent public events AND GitHub's events redirect actually
+            // surfaces them — a user could rename and stay invisible to us
+            // until they generated activity on the new handle, OR if their
+            // old handle was reclaimed by someone else (404 path), we'd
+            // hard-skip and never recover.
+            //
+            // /users/{name} is reliable: it follows renames via stable
+            // numeric ID, always returns the canonical login + id, and
+            // 404s only on real deletion. Costs +1 API call per user per
+            // run — with GITHUB_TOKEN's 5000/hr ceiling, irrelevant.
+            let userNotFound = false;
+            let userInfoApiError: string | null = null;
+            let reclaimDetected = false;
+
+            const userInfoController = new AbortController();
+            const userInfoTimeoutId = setTimeout(
+              () => userInfoController.abort(),
+              EVENTS_API_TIMEOUT_MS
+            );
+            try {
+              const response = await fetch(
+                `https://api.github.com/users/${encodeURIComponent(userInfo.githubUsername)}`,
+                { headers: ghApiHeaders, signal: userInfoController.signal }
+              );
+
+              if (response.status === 404) {
+                userNotFound = true;
+              } else if (!response.ok) {
+                userInfoApiError = response.status === 403
+                  ? "rate limit exceeded"
+                  : `HTTP ${response.status}`;
+              } else {
+                const body = await response.json();
+                const apiLogin: string | undefined =
+                  typeof body?.login === "string" ? body.login : undefined;
+                const apiId: number | undefined =
+                  typeof body?.id === "number" ? body.id : undefined;
+
+                // Reclaim guard: if we have a github_id on file and the
+                // username's current owner has a *different* id, somebody
+                // took the old handle after our user renamed away. Bail
+                // out — we'd otherwise pull a stranger's commits into our
+                // user's feed. Admin can manually re-link with the new
+                // handle.
+                if (
+                  userInfo.githubId !== null &&
+                  typeof apiId === "number" &&
+                  apiId !== userInfo.githubId
+                ) {
+                  reclaimDetected = true;
+                  console.warn(
+                    `[github-sync] handle reclaim suspected for user ${userInfo.userId}: ` +
+                    `stored github_id=${userInfo.githubId}, "${userInfo.githubUsername}" now owned by id=${apiId}`
+                  );
+                } else {
+                  // Apply rename and/or backfill github_id from the response.
+                  const dbUpdates: Record<string, string | number> = {};
+                  const loginChanged =
+                    apiLogin &&
+                    apiLogin.toLowerCase() !== userInfo.githubUsername.toLowerCase();
+
+                  if (loginChanged) {
+                    console.log(
+                      `[github-sync] username rename for user ${userInfo.userId}: ` +
+                      `stored="${userInfo.githubUsername}" → canonical="${apiLogin}"`
+                    );
+                    dbUpdates.github_username = apiLogin!;
+                  }
+                  if (typeof apiId === "number" && userInfo.githubId === null) {
+                    dbUpdates.github_id = apiId;
+                  }
+
+                  if (Object.keys(dbUpdates).length > 0) {
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    await (supabase as any)
+                      .from("users")
+                      .update(dbUpdates)
+                      .eq("id", userInfo.userId);
+                  }
+                  if (loginChanged) {
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    await (supabase as any)
+                      .from("social_links")
+                      .upsert(
+                        { user_id: userInfo.userId, github: apiLogin! },
+                        { onConflict: "user_id" }
+                      );
+                    // Use the canonical handle for the rest of this iteration.
+                    userInfo.githubUsername = apiLogin!;
+                  }
+                  if (typeof apiId === "number") {
+                    userInfo.githubId = apiId;
+                  }
+                }
+              }
+            } catch (err) {
+              userInfoApiError = err instanceof Error && err.name === "AbortError"
+                ? `timeout after ${EVENTS_API_TIMEOUT_MS}ms`
+                : err instanceof Error
+                  ? err.message
+                  : "fetch failed";
+            } finally {
+              clearTimeout(userInfoTimeoutId);
+            }
+
+            if (userNotFound) {
+              return { userInfo, status: "skipped", reason: "GitHub user not found" };
+            }
+            if (reclaimDetected) {
+              return {
+                userInfo,
+                status: "skipped",
+                reason: "GitHub handle reclaimed by another account (github_id mismatch)",
+              };
+            }
+            // If user-info failed (rate limit / timeout / transient), fall
+            // through and try events with the stored handle anyway — the
+            // events redirect will still pick up activity in the common
+            // case. We just lose the rename-detection upside for this run.
+
+            // Step 2: events feed for the (now canonical) handle. Failure
+            // here is NON-fatal — we still fetch the heatmap below for
+            // lifetime and 30d totals. Previously a single 403 (rate-limit)
+            // on this call would skip a user entirely, so most users never
+            // got their volume scoring populated.
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             let recentEvents: any[] = [];
-            let eventsApiError: string | null = null;
-            let userNotFound = false;
+            let eventsApiError: string | null = userInfoApiError;
 
             const eventsController = new AbortController();
             const eventsTimeoutId = setTimeout(
@@ -186,50 +318,12 @@ export async function GET(req: NextRequest) {
                 { headers: ghApiHeaders, signal: eventsController.signal }
               );
 
-              if (response.status === 404) {
-                userNotFound = true;
-              } else if (!response.ok) {
+              if (!response.ok) {
                 eventsApiError = response.status === 403
                   ? "rate limit exceeded"
                   : `HTTP ${response.status}`;
               } else {
                 const events = await response.json();
-
-                // Detect GitHub username drift. When a user renames their
-                // GitHub handle, /users/{old}/events redirects transparently,
-                // but actor.login on the response carries the new canonical
-                // handle. Compare against what we have stored — if it's
-                // changed, refresh users.github_username and social_links.github
-                // so verify-backfill, share cards, and profile links stop
-                // pointing at the old name. Without this, the only way to
-                // sync was for the user to log out + back in via GitHub OAuth.
-                const canonicalLogin: string | undefined = events[0]?.actor?.login;
-                if (
-                  canonicalLogin &&
-                  canonicalLogin.toLowerCase() !== userInfo.githubUsername.toLowerCase()
-                ) {
-                  console.log(
-                    `[github-sync] username drift for user ${userInfo.userId}: ` +
-                    `stored="${userInfo.githubUsername}" → canonical="${canonicalLogin}"`
-                  );
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  await (supabase as any)
-                    .from("users")
-                    .update({ github_username: canonicalLogin })
-                    .eq("id", userInfo.userId);
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  await (supabase as any)
-                    .from("social_links")
-                    .upsert(
-                      { user_id: userInfo.userId, github: canonicalLogin },
-                      { onConflict: "user_id" }
-                    );
-                  // Use the canonical handle for the rest of this iteration —
-                  // mostly cosmetic since GitHub redirects, but keeps
-                  // fetchGitHubContributions and log lines on the right name.
-                  userInfo.githubUsername = canonicalLogin;
-                }
-
                 const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
                 recentEvents = events.filter(
                   (event: { type: string; created_at: string }) =>
@@ -245,11 +339,6 @@ export async function GET(req: NextRequest) {
                   : "fetch failed";
             } finally {
               clearTimeout(eventsTimeoutId);
-            }
-
-            // Hard skip only if GitHub explicitly says the user doesn't exist.
-            if (userNotFound) {
-              return { userInfo, status: "skipped", reason: "GitHub user not found" };
             }
 
             // Save events to feed_events table for the activity feed (only

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -73,13 +73,27 @@ export async function GET(request: Request) {
           user.user_metadata?.user_name ||
           user.user_metadata?.preferred_username ||
           null;
+        // GitHub's stable numeric ID lands in identity_data.sub (OIDC-style
+        // subject identifier — string-encoded). We coerce here once because
+        // github-sync uses this on every run to tell a legitimate rename
+        // apart from a handle reclaim; a missing or stale value silently
+        // disables that guard. provider_id on the row itself isn't exposed
+        // through Supabase's JS SDK so we don't depend on it.
+        const rawGithubId = ghData.sub ?? ghData.provider_id ?? null;
+        const parsedGithubId =
+          rawGithubId != null && /^\d+$/.test(String(rawGithubId))
+            ? Number(rawGithubId)
+            : null;
+        const githubId = parsedGithubId !== null && Number.isFinite(parsedGithubId)
+          ? parsedGithubId
+          : null;
 
         // Use service role client for DB operations to bypass RLS
         const adminSb = createAdminClient();
 
         const { data: profile } = await adminSb
           .from("users")
-          .select("username, avatar_url, github_username")
+          .select("username, avatar_url, github_username, github_id")
           .eq("id", user.id)
           .single();
 
@@ -90,7 +104,7 @@ export async function GET(request: Request) {
         // branch only fires for returning users whose row already exists —
         // e.g. avatar refresh or Google→GitHub linkIdentity recovery.
         if (profile) {
-          const updates: Record<string, string> = {};
+          const updates: Record<string, string | number> = {};
 
           // Always sync avatar from OAuth provider on login
           if (oauthAvatar) {
@@ -99,6 +113,13 @@ export async function GET(request: Request) {
 
           if (githubUsername) {
             updates.github_username = githubUsername;
+          }
+          // Backfill github_id once. Don't overwrite — a row with github_id
+          // already set has been canonicalized and the unique partial index
+          // would reject a conflicting value anyway.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          if (githubId !== null && (profile as any).github_id == null) {
+            updates.github_id = githubId;
           }
 
           // NOTE: display_name is intentionally NOT touched here. Profile-setup

--- a/src/app/auth/profile-setup/page.tsx
+++ b/src/app/auth/profile-setup/page.tsx
@@ -58,6 +58,10 @@ export default function ProfileSetupPage() {
   const [userId, setUserId] = useState<string | null>(null);
   const [oauthAvatarUrl, setOauthAvatarUrl] = useState<string | null>(null);
   const [verifiedGithub, setVerifiedGithub] = useState<string | null>(null);
+  // GitHub's stable numeric ID, captured from OAuth identity. Persisted on
+  // the initial users row insert below so github-sync can use it to tell a
+  // rename apart from a reclaim.
+  const [verifiedGithubId, setVerifiedGithubId] = useState<number | null>(null);
   const [connectingGithub, setConnectingGithub] = useState(false);
   const [streakLogged, setStreakLogged] = useState(false);
 
@@ -117,7 +121,7 @@ export default function ProfileSetupPage() {
       // or a prior linkIdentity flow). This is the only trusted source.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const { data: userRow } = await (supabase.from("users") as any)
-        .select("display_name, github_username")
+        .select("display_name, github_username, github_id")
         .eq("id", user.id)
         .single();
       if (userRow?.display_name) {
@@ -126,6 +130,9 @@ export default function ProfileSetupPage() {
       if (userRow?.github_username) {
         setVerifiedGithub(userRow.github_username);
         setSocials((s) => ({ ...s, github: userRow.github_username }));
+        if (typeof userRow.github_id === "number") {
+          setVerifiedGithubId(userRow.github_id);
+        }
       } else {
         // GitHub might be linked in Supabase auth but not yet synced to the
         // users table (happens when linkIdentity succeeds but the redirect
@@ -140,13 +147,26 @@ export default function ProfileSetupPage() {
           user.user_metadata?.user_name ||
           user.user_metadata?.preferred_username ||
           null;
+        // GitHub's stable numeric ID. Lives in identity_data.sub (OIDC-style
+        // subject id). github-sync uses it to distinguish a legitimate
+        // rename from a handle reclaim, so capturing it on every OAuth-
+        // mediated write keeps that guard accurate.
+        const rawGhId = ghData.sub ?? ghData.provider_id ?? null;
+        const ghId =
+          rawGhId != null && /^\d+$/.test(String(rawGhId)) ? Number(rawGhId) : null;
         if (ghUsername) {
           setVerifiedGithub(ghUsername);
           setSocials((s) => ({ ...s, github: ghUsername }));
+          if (ghId !== null && Number.isFinite(ghId)) {
+            setVerifiedGithubId(ghId);
+          }
           // Sync to DB so the rest of the app sees it
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           await (supabase.from("users") as any)
-            .update({ github_username: ghUsername })
+            .update({
+              github_username: ghUsername,
+              ...(ghId !== null && Number.isFinite(ghId) ? { github_id: ghId } : {}),
+            })
             .eq("id", user.id);
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           await (supabase.from("social_links") as any).upsert(
@@ -210,9 +230,10 @@ export default function ProfileSetupPage() {
     setLoading(true);
 
     try {
-      // github_username must be written here because this is the first INSERT
-      // for GitHub-first OAuth signups — users.username is NOT NULL, so no
-      // row exists when /auth/callback runs, and its UPDATE silently no-ops.
+      // github_username (and github_id) must be written here because this is
+      // the first INSERT for GitHub-first OAuth signups — users.username is
+      // NOT NULL, so no row exists when /auth/callback runs, and its UPDATE
+      // silently no-ops.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const { error: dbError } = await (supabase.from("users") as any).upsert(
         {
@@ -222,6 +243,7 @@ export default function ProfileSetupPage() {
           bio: profile.bio || null,
           ...(oauthAvatarUrl ? { avatar_url: oauthAvatarUrl } : {}),
           ...(verifiedGithub ? { github_username: verifiedGithub } : {}),
+          ...(verifiedGithubId !== null ? { github_id: verifiedGithubId } : {}),
         },
         { onConflict: "id" }
       );

--- a/supabase/migrations/20260516_add_github_id.sql
+++ b/supabase/migrations/20260516_add_github_id.sql
@@ -1,0 +1,50 @@
+-- Stable GitHub numeric ID per user. GitHub usernames are mutable; numeric
+-- IDs are not. Storing the ID lets us survive renames AND detect handle
+-- reclaims (someone else takes the old username after a rename) — neither
+-- of which the prior github_username-only model could handle.
+--
+-- Populated from:
+--   1. auth.identities.provider_id for users who linked GitHub via OAuth
+--      (backfilled below for existing rows).
+--   2. /auth/callback and /auth/profile-setup, which capture it from the
+--      OAuth identity going forward.
+--
+-- The github-sync cron uses this to verify the username it has on file
+-- still points at the same GitHub account on every run.
+
+ALTER TABLE public.users ADD COLUMN IF NOT EXISTS github_id BIGINT;
+
+-- Backfill from existing OAuth identity records. provider_id is TEXT in
+-- auth.identities but GitHub uses numeric IDs — defensive numeric regex
+-- check before the cast so any unexpected shape skips silently rather
+-- than aborting the whole migration.
+--
+-- Subquery form (rather than UPDATE...FROM) so a user with multiple
+-- historical GitHub identities — possible if they unlinked and relinked
+-- a different account — gets the most-recent one rather than an
+-- arbitrary join row.
+UPDATE public.users u
+SET github_id = (
+  SELECT i.provider_id::bigint
+  FROM auth.identities i
+  WHERE i.user_id = u.id
+    AND i.provider = 'github'
+    AND i.provider_id ~ '^[0-9]+$'
+  ORDER BY i.last_sign_in_at DESC NULLS LAST, i.updated_at DESC NULLS LAST
+  LIMIT 1
+)
+WHERE u.github_id IS NULL
+  AND EXISTS (
+    SELECT 1 FROM auth.identities i
+    WHERE i.user_id = u.id
+      AND i.provider = 'github'
+      AND i.provider_id ~ '^[0-9]+$'
+  );
+
+-- A given GitHub account should map to at most one VibeTalent user.
+-- Partial index so NULL rows (users without a linked GitHub) coexist
+-- freely. Plain (non-CONCURRENT) since migrations run in a transaction
+-- and the users table is small enough that the lock is sub-second.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_github_id_unique
+  ON public.users (github_id)
+  WHERE github_id IS NOT NULL;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -320,6 +320,15 @@ ALTER TABLE projects ADD COLUMN IF NOT EXISTS last_verify_attempt_at TIMESTAMPTZ
 -- Add github_username column to users (populated from GitHub OAuth on login)
 ALTER TABLE users ADD COLUMN IF NOT EXISTS github_username TEXT;
 
+-- Stable GitHub numeric ID per user. Captured from OAuth identity_data on
+-- signup/login and verified by the github-sync cron. Lets us detect both
+-- renames (username changes, id stays) AND reclaims (username stays, id
+-- differs because someone else took the old handle).
+ALTER TABLE users ADD COLUMN IF NOT EXISTS github_id BIGINT;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_github_id_unique
+  ON users (github_id)
+  WHERE github_id IS NOT NULL;
+
 -- Add display_name column to users (Twitter-style "real name" above @username).
 -- Nullable — optional field. Auto-populated from OAuth metadata on first signup
 -- via the profile-setup flow, editable in settings afterwards.


### PR DESCRIPTION
## Summary

- Replaces the brittle `events[0]?.actor?.login` rename detection in the github-sync cron with an explicit `GET /users/{stored_name}` lookup that follows renames via GitHub's stable numeric ID — works regardless of recent public activity, and stops hard-skipping renamed-then-reclaimed handles.
- Adds `users.github_id BIGINT` (nullable, partial unique index) and backfills from `auth.identities` for everyone already OAuth'd; the cron uses it as a reclaim guard so we never pull a stranger's commits into the wrong VibeTalent profile after a handle reclaim.
- `/auth/callback` and `/auth/profile-setup` now capture `github_id` from `identity_data.sub` on every OAuth-mediated write, so freshly onboarded users have the stable ID on day one.

## Why

A user renamed on GitHub and their commits stopped appearing on the feed. Logout/login didn't help. Root cause: the rename detector only fires when `/users/{old}/events/public` returns at least one event whose `actor.login` matches the new handle. If the events list is empty (no recent activity, redirect quirk) or 404s (handle reclaimed), the cron silently keeps using the stale username forever.

## Deployment

1. **Migration is already applied to prod.** (`20260516_add_github_id.sql` run via SQL editor on 2026-05-16.)
2. After merge, affected users get their renames picked up on the next cron tick (≤ 6h). No manual intervention required.

## Test plan

- [ ] Trigger `/api/cron/github-sync` manually with `CRON_SECRET` bearer and confirm 200 + non-empty `synced` count
- [ ] Pick a recently renamed user; verify `users.github_username` updates to the new handle and `users.github_id` is populated
- [ ] Confirm their next push appears on the feed
- [ ] Sign in via GitHub OAuth on a fresh account; verify both `github_username` and `github_id` get set on the initial profile-setup write
- [ ] No regression on the heatmap / streak_logs path (existing users with healthy syncs continue to update lifetime + 30d totals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of GitHub account renames and reclaims by leveraging stable numeric GitHub identifiers for more reliable tracking across authentication and sync operations.

* **New Features**
  * Enhanced GitHub identity verification with persistent numeric identifiers for greater reliability during authentication and profile management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unknownking07/vibe-talent/pull/188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->