### PR TITLE
feat(profile): add achievements page, shareable badge cards, and profile teaser

### DIFF
--- a/src/app/api/og/achievement/[username]/[id]/route.tsx
+++ b/src/app/api/og/achievement/[username]/[id]/route.tsx
@@ -223,6 +223,44 @@ export async function GET(
   );
 }
 
+/**
+ * Validate that an avatar URL is safe for server-side fetch in next/og.
+ *
+ * Defense-in-depth against SSRF: parse via URL, require https, and reject
+ * obvious localhost / private-network hostnames. Does not protect against
+ * DNS rebinding — for full coverage we'd need to resolve and check IP.
+ */
+function isSafeAvatarUrl(raw: unknown): raw is string {
+  if (typeof raw !== "string" || raw.length === 0) return false;
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "https:") return false;
+  const host = parsed.hostname.toLowerCase();
+  if (
+    host === "localhost" ||
+    host === "0.0.0.0" ||
+    host.endsWith(".localhost") ||
+    host.endsWith(".internal") ||
+    host.endsWith(".local")
+  ) {
+    return false;
+  }
+  // Reject obvious private/loopback IP literals.
+  if (/^127\./.test(host)) return false;
+  if (/^10\./.test(host)) return false;
+  if (/^192\.168\./.test(host)) return false;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return false;
+  if (/^169\.254\./.test(host)) return false; // link-local
+  if (host === "::1" || host.startsWith("[::1") || host.startsWith("fc") || host.startsWith("fd")) {
+    return false;
+  }
+  return true;
+}
+
 function Avatar({
   user,
   size,
@@ -231,7 +269,7 @@ function Avatar({
   size: number;
 }) {
   const url = user.avatar_url;
-  const valid = typeof url === "string" && /^https?:\/\//.test(url);
+  const valid = isSafeAvatarUrl(url);
   if (valid) {
     return (
       <div

--- a/src/app/api/og/achievement/[username]/[id]/route.tsx
+++ b/src/app/api/og/achievement/[username]/[id]/route.tsx
@@ -1,0 +1,284 @@
+import { ImageResponse } from "next/og";
+import { fetchUserByUsernameCached } from "@/lib/supabase/server-queries";
+import { fetchAchievementCounters } from "@/lib/achievements/fetch";
+import { computeAchievements } from "@/lib/achievements/definitions";
+import { getBadgeArt, PALETTES } from "@/lib/achievements/badge-art";
+import { BadgeMedallion } from "@/components/achievements/badge-medallion";
+
+export const runtime = "nodejs";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export async function GET(
+  _req: Request,
+  ctx: { params: Promise<{ username: string; id: string }> },
+) {
+  const { username, id } = await ctx.params;
+
+  const user = await fetchUserByUsernameCached(username);
+  if (!user) {
+    return new Response("Not Found", { status: 404 });
+  }
+
+  const counters = await fetchAchievementCounters(user);
+  const achievements = computeAchievements(counters);
+  const achievement = achievements.find((a) => a.id === id);
+  if (!achievement) {
+    return new Response("Not Found", { status: 404 });
+  }
+
+  const art = getBadgeArt(id);
+  const palette = PALETTES[art.palette];
+  const statusLabel = achievement.earned ? "UNLOCKED" : "IN PROGRESS";
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#0F0F0F",
+          padding: 50,
+          fontFamily: "ui-monospace, Menlo, monospace",
+        }}
+      >
+        <div
+          style={{
+            background: "#FFFFFF",
+            color: "#0F0F0F",
+            padding: "48px 56px",
+            width: "88%",
+            height: "82%",
+            boxShadow: "14px 14px 0 #FF3A00",
+            display: "flex",
+            flexDirection: "column",
+            border: "3px solid #0F0F0F",
+          }}
+        >
+          {/* Header row */}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              borderBottom: "3px dashed #0F0F0F",
+              paddingBottom: 20,
+              marginBottom: 28,
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                fontSize: 18,
+                fontWeight: 900,
+                letterSpacing: "0.18em",
+              }}
+            >
+              VIBE
+              <span style={{ display: "flex", color: "#FF3A00" }}>TALENT</span>
+              <span style={{ display: "flex", color: "#A1A1AA", marginLeft: 12 }}>
+                / ACHIEVEMENT
+              </span>
+            </div>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 12,
+                padding: "6px 14px",
+                background: achievement.earned ? "#DCFCE7" : "#F4F4F5",
+                color: achievement.earned ? "#166534" : "#52525B",
+                border: "2px solid #0F0F0F",
+                fontSize: 16,
+                fontWeight: 900,
+                letterSpacing: "0.12em",
+              }}
+            >
+              {statusLabel}
+            </div>
+          </div>
+
+          {/* Body */}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 56,
+              flex: 1,
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                width: 340,
+                height: 340,
+                flexShrink: 0,
+              }}
+            >
+              <BadgeMedallion
+                paletteKey={art.palette}
+                icon={art.icon}
+                chipLabel={art.chipLabel}
+                size={300}
+                earned={achievement.earned}
+              />
+            </div>
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                flex: 1,
+                minWidth: 0,
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  fontSize: 22,
+                  fontWeight: 900,
+                  letterSpacing: "0.18em",
+                  color: palette.ring,
+                  marginBottom: 8,
+                }}
+              >
+                {achievement.category.toUpperCase()}
+              </div>
+              <div
+                style={{
+                  display: "flex",
+                  fontSize: 64,
+                  fontWeight: 900,
+                  letterSpacing: "-0.02em",
+                  lineHeight: 1.05,
+                  color: "#0F0F0F",
+                  marginBottom: 16,
+                }}
+              >
+                {achievement.title}
+              </div>
+              <div
+                style={{
+                  display: "flex",
+                  fontSize: 26,
+                  fontWeight: 500,
+                  lineHeight: 1.35,
+                  color: "#3F3F46",
+                  marginBottom: 28,
+                }}
+              >
+                {achievement.description}
+              </div>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 14,
+                  paddingTop: 18,
+                  borderTop: "3px dashed #0F0F0F",
+                }}
+              >
+                <Avatar user={user} size={64} />
+                <div
+                  style={{
+                    display: "flex",
+                    flexDirection: "column",
+                  }}
+                >
+                  <div
+                    style={{
+                      display: "flex",
+                      fontSize: 26,
+                      fontWeight: 900,
+                      color: "#0F0F0F",
+                    }}
+                  >
+                    @{user.username}
+                  </div>
+                  <div
+                    style={{
+                      display: "flex",
+                      fontSize: 16,
+                      fontWeight: 700,
+                      color: "#71717A",
+                      letterSpacing: "0.06em",
+                    }}
+                  >
+                    {achievement.earned
+                      ? "EARNED ON VIBETALENT"
+                      : `${achievement.current} / ${achievement.threshold} ${achievement.unit.toUpperCase()}`}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}
+
+function Avatar({
+  user,
+  size,
+}: {
+  user: { username: string; avatar_url: string | null };
+  size: number;
+}) {
+  const url = user.avatar_url;
+  const valid = typeof url === "string" && /^https?:\/\//.test(url);
+  if (valid) {
+    return (
+      <div
+        style={{
+          display: "flex",
+          width: size,
+          height: size,
+          borderRadius: "50%",
+          overflow: "hidden",
+          border: "2.5px solid #0F0F0F",
+          flexShrink: 0,
+        }}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={url}
+          width={size}
+          height={size}
+          alt=""
+          style={{
+            display: "flex",
+            objectFit: "cover",
+            width: size,
+            height: size,
+          }}
+        />
+      </div>
+    );
+  }
+  return (
+    <div
+      style={{
+        display: "flex",
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        border: "2.5px solid #0F0F0F",
+        background: "linear-gradient(135deg, #FF3A00, #FFA07A)",
+        color: "#fff",
+        fontWeight: 900,
+        fontSize: size * 0.42,
+        alignItems: "center",
+        justifyContent: "center",
+        flexShrink: 0,
+      }}
+    >
+      {(user.username[0] ?? "?").toUpperCase()}
+    </div>
+  );
+}

--- a/src/app/profile/[username]/achievements/page.tsx
+++ b/src/app/profile/[username]/achievements/page.tsx
@@ -1,0 +1,169 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import type { Metadata } from "next";
+import { fetchUserByUsernameCached } from "@/lib/supabase/server-queries";
+import { fetchAchievementCounters } from "@/lib/achievements/fetch";
+import { computeAchievements } from "@/lib/achievements/definitions";
+import { AchievementsGrid } from "@/components/achievements/achievements-grid";
+import { siteUrl } from "@/lib/seo";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ username: string }>;
+}): Promise<Metadata> {
+  const { username: rawMeta } = await params;
+  const username = rawMeta?.trim();
+  const user = await fetchUserByUsernameCached(username);
+
+  if (!user) {
+    return { title: "Achievements" };
+  }
+
+  const title = `@${user.username}'s Achievements — VibeTalent`;
+  const description = `Badges earned by @${user.username} on VibeTalent — streaks, projects, endorsements, and more.`;
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: `${siteUrl}/profile/${username}/achievements`,
+    },
+    openGraph: {
+      title,
+      description,
+      url: `${siteUrl}/profile/${username}/achievements`,
+      type: "profile",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+  };
+}
+
+export const revalidate = 3600;
+
+export default async function AchievementsPage({
+  params,
+}: {
+  params: Promise<{ username: string }>;
+}) {
+  const { username: rawUsername } = await params;
+  const username = rawUsername?.trim();
+
+  if (!username || username.length > 50 || !/^[a-zA-Z0-9_.\- ]+$/.test(username)) {
+    return (
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 py-20 text-center">
+        <h1 className="text-2xl font-extrabold uppercase text-[var(--foreground)]">
+          Invalid username
+        </h1>
+        <p className="mt-2 font-medium text-[var(--text-secondary)]">
+          This is not a valid username.
+        </p>
+      </div>
+    );
+  }
+
+  const user = await fetchUserByUsernameCached(username);
+
+  if (!user) {
+    return (
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 py-20 text-center">
+        <h1 className="text-2xl font-extrabold uppercase text-[var(--foreground)]">
+          Builder not found
+        </h1>
+        <p className="mt-2 font-medium text-[var(--text-secondary)]">
+          @{username} does not exist on VibeTalent.
+        </p>
+      </div>
+    );
+  }
+
+  const counters = await fetchAchievementCounters(user);
+  const achievements = computeAchievements(counters);
+  const earnedCount = achievements.filter((a) => a.earned).length;
+  const totalCount = achievements.length;
+  const overallPercent = Math.round((earnedCount / totalCount) * 100);
+
+  return (
+    <div className="flex justify-center p-4 sm:p-8">
+      <div className="w-full max-w-[1200px] flex flex-col gap-6">
+        {/* Back to profile */}
+        <Link
+          href={`/profile/${user.username}`}
+          className="inline-flex w-fit items-center gap-1.5 text-xs font-extrabold uppercase tracking-wide"
+          style={{ color: "var(--text-secondary)" }}
+        >
+          <ArrowLeft size={14} strokeWidth={3} />
+          Back to @{user.username}
+        </Link>
+
+        {/* Header card */}
+        <section
+          className="p-6"
+          style={{
+            backgroundColor: "var(--bg-surface)",
+            border: "2px solid var(--border-hard)",
+            boxShadow: "var(--shadow-brutal)",
+          }}
+        >
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-col gap-1">
+              <h1
+                className="text-2xl font-extrabold uppercase tracking-wide"
+                style={{ color: "var(--foreground)" }}
+              >
+                Achievements
+              </h1>
+              <p
+                className="text-sm font-medium"
+                style={{ color: "var(--text-secondary)" }}
+              >
+                Badges earned by @{user.username}
+              </p>
+            </div>
+            <div className="flex flex-col items-start gap-1 sm:items-end">
+              <div
+                className="text-3xl font-extrabold tabular-nums"
+                style={{ color: "var(--foreground)" }}
+              >
+                {earnedCount}
+                <span style={{ color: "var(--text-muted)" }}>
+                  {" / "}
+                  {totalCount}
+                </span>
+              </div>
+              <div
+                className="text-[10px] font-extrabold uppercase tracking-wide"
+                style={{ color: "var(--text-secondary)" }}
+              >
+                Unlocked
+              </div>
+            </div>
+          </div>
+          <div
+            className="mt-5 h-3 w-full overflow-hidden"
+            style={{
+              backgroundColor: "var(--bg-base)",
+              border: "2px solid var(--border-hard)",
+            }}
+          >
+            <div
+              className="h-full"
+              style={{
+                width: `${overallPercent}%`,
+                backgroundColor: "var(--badge-gold, #EAB308)",
+                transition: "width 200ms ease-out",
+              }}
+            />
+          </div>
+        </section>
+
+        {/* Grouped grid */}
+        <AchievementsGrid achievements={achievements} username={user.username} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/profile/[username]/achievements/page.tsx
+++ b/src/app/profile/[username]/achievements/page.tsx
@@ -22,17 +22,18 @@ export async function generateMetadata({
 
   const title = `@${user.username}'s Achievements — VibeTalent`;
   const description = `Badges earned by @${user.username} on VibeTalent — streaks, projects, endorsements, and more.`;
+  const encodedUsername = encodeURIComponent(user.username);
 
   return {
     title,
     description,
     alternates: {
-      canonical: `${siteUrl}/profile/${username}/achievements`,
+      canonical: `${siteUrl}/profile/${encodedUsername}/achievements`,
     },
     openGraph: {
       title,
       description,
-      url: `${siteUrl}/profile/${username}/achievements`,
+      url: `${siteUrl}/profile/${encodedUsername}/achievements`,
       type: "profile",
     },
     twitter: {

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -5,6 +5,9 @@ import { ProfileSidebar } from "@/components/profile/profile-sidebar";
 import { StatsRibbon } from "@/components/profile/stats-ribbon";
 import { ProfileHeatmap } from "@/components/profile/profile-heatmap";
 import { ReviewerStats } from "@/components/profile/reviewer-stats";
+import { AchievementsTeaser } from "@/components/achievements/achievements-teaser";
+import { fetchAchievementCounters } from "@/lib/achievements/fetch";
+import { computeAchievements } from "@/lib/achievements/definitions";
 import type { ReviewerTier } from "@/lib/reviewer/tier";
 import { extractSocialHandle } from "@/lib/social-handles";
 import { ProfileProjectCard } from "@/components/profile/profile-project-card";
@@ -94,6 +97,8 @@ export default async function ProfilePage({
   }
 
   const heatmapData = await fetchStreakLogsCached(user.id);
+  const achievementCounters = await fetchAchievementCounters(user);
+  const achievements = computeAchievements(achievementCounters);
 
   // Fetch reviewer reputation data — kept outside the cached user fetch so we
   // don't bust the per-username cache when only review counts change.
@@ -216,6 +221,9 @@ export default async function ProfilePage({
             vibeScore={user.vibe_score}
             projectCount={(user.projects ?? []).length}
           />
+
+          {/* Achievements Teaser */}
+          <AchievementsTeaser achievements={achievements} username={user.username} />
 
           {/* Heatmap Section */}
           <section

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -97,8 +97,16 @@ export default async function ProfilePage({
   }
 
   const heatmapData = await fetchStreakLogsCached(user.id);
-  const achievementCounters = await fetchAchievementCounters(user);
-  const achievements = computeAchievements(achievementCounters);
+
+  // Achievements are non-core to profile rendering — if the aggregator
+  // fails (Supabase blip, etc.) we still want the profile page to load.
+  let achievements: ReturnType<typeof computeAchievements> = [];
+  try {
+    const achievementCounters = await fetchAchievementCounters(user);
+    achievements = computeAchievements(achievementCounters);
+  } catch (err) {
+    console.error("[profile] achievements compute failed:", err);
+  }
 
   // Fetch reviewer reputation data — kept outside the cached user fetch so we
   // don't bust the per-username cache when only review counts change.

--- a/src/app/share/achievement/[username]/[id]/page.tsx
+++ b/src/app/share/achievement/[username]/[id]/page.tsx
@@ -1,0 +1,159 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { ArrowRight } from "lucide-react";
+import { fetchUserByUsernameCached } from "@/lib/supabase/server-queries";
+import { fetchAchievementCounters } from "@/lib/achievements/fetch";
+import { computeAchievements } from "@/lib/achievements/definitions";
+import { getBadgeArt } from "@/lib/achievements/badge-art";
+import { BadgeMedallion } from "@/components/achievements/badge-medallion";
+import { siteUrl } from "@/lib/seo";
+
+interface PageParams {
+  params: Promise<{ username: string; id: string }>;
+}
+
+export async function generateMetadata({ params }: PageParams): Promise<Metadata> {
+  const { username, id } = await params;
+  const user = await fetchUserByUsernameCached(username);
+
+  if (!user) return { title: "Achievement — VibeTalent" };
+
+  const counters = await fetchAchievementCounters(user);
+  const achievements = computeAchievements(counters);
+  const a = achievements.find((x) => x.id === id);
+  if (!a) return { title: "Achievement — VibeTalent" };
+
+  const title = `@${user.username} unlocked "${a.title}" — VibeTalent`;
+  const description = `${a.description} See @${user.username}'s achievements on VibeTalent.`;
+  const ogUrl = `${siteUrl}/api/og/achievement/${user.username}/${a.id}`;
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: `${siteUrl}/share/achievement/${user.username}/${a.id}`,
+    },
+    openGraph: {
+      title,
+      description,
+      url: `${siteUrl}/share/achievement/${user.username}/${a.id}`,
+      type: "article",
+      images: [{ url: ogUrl, width: 1200, height: 630, alt: a.title }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [ogUrl],
+    },
+  };
+}
+
+export const revalidate = 3600;
+
+export default async function ShareAchievementPage({ params }: PageParams) {
+  const { username: rawUsername, id } = await params;
+  const username = rawUsername?.trim();
+
+  if (!username || username.length > 50 || !/^[a-zA-Z0-9_.\- ]+$/.test(username)) {
+    return <NotFound />;
+  }
+
+  const user = await fetchUserByUsernameCached(username);
+  if (!user) return <NotFound />;
+
+  const counters = await fetchAchievementCounters(user);
+  const achievements = computeAchievements(counters);
+  const achievement = achievements.find((a) => a.id === id);
+  if (!achievement) return <NotFound />;
+
+  const art = getBadgeArt(id);
+
+  return (
+    <div className="flex justify-center p-4 sm:p-8">
+      <div className="w-full max-w-[720px] flex flex-col gap-6">
+        <section
+          className="flex flex-col items-center gap-6 p-8 text-center sm:p-12"
+          style={{
+            backgroundColor: "var(--bg-surface)",
+            border: "2px solid var(--border-hard)",
+            boxShadow: "var(--shadow-brutal)",
+          }}
+        >
+          <div className="mt-2">
+            <BadgeMedallion
+              paletteKey={art.palette}
+              icon={art.icon}
+              chipLabel={art.chipLabel}
+              size={180}
+              earned={achievement.earned}
+            />
+          </div>
+          <div className="flex flex-col items-center gap-2">
+            <span
+              className="text-xs font-extrabold uppercase tracking-widest"
+              style={{ color: "var(--text-secondary)" }}
+            >
+              {achievement.category}
+            </span>
+            <h1
+              className="text-3xl font-extrabold uppercase tracking-tight"
+              style={{ color: "var(--foreground)" }}
+            >
+              {achievement.title}
+            </h1>
+            <p
+              className="max-w-md text-sm font-medium leading-relaxed"
+              style={{ color: "var(--text-secondary)" }}
+            >
+              {achievement.description}
+            </p>
+          </div>
+          <div
+            className="inline-flex items-center gap-2 px-4 py-2 text-xs font-extrabold uppercase tracking-wide"
+            style={{
+              backgroundColor: achievement.earned
+                ? "var(--status-success-bg, #DCFCE7)"
+                : "var(--bg-base)",
+              color: achievement.earned
+                ? "var(--status-success-text, #166534)"
+                : "var(--text-muted)",
+              border: "2px solid var(--border-hard)",
+            }}
+          >
+            {achievement.earned
+              ? `Unlocked by @${user.username}`
+              : `${achievement.current} / ${achievement.threshold} ${achievement.unit} · in progress`}
+          </div>
+        </section>
+
+        <Link
+          href={`/profile/${user.username}/achievements`}
+          className="inline-flex items-center justify-center gap-2 px-5 py-3 text-sm font-extrabold uppercase tracking-wide"
+          style={{
+            backgroundColor: "var(--bg-inverted)",
+            color: "var(--bg-base)",
+            border: "2px solid var(--border-hard)",
+            boxShadow: "var(--shadow-brutal-sm)",
+          }}
+        >
+          View all of @{user.username}&apos;s achievements
+          <ArrowRight size={16} strokeWidth={3} />
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function NotFound() {
+  return (
+    <div className="mx-auto max-w-7xl px-4 sm:px-6 py-20 text-center">
+      <h1 className="text-2xl font-extrabold uppercase text-[var(--foreground)]">
+        Achievement not found
+      </h1>
+      <p className="mt-2 font-medium text-[var(--text-secondary)]">
+        This achievement link is invalid or has expired.
+      </p>
+    </div>
+  );
+}

--- a/src/app/share/achievement/[username]/[id]/page.tsx
+++ b/src/app/share/achievement/[username]/[id]/page.tsx
@@ -23,20 +23,24 @@ export async function generateMetadata({ params }: PageParams): Promise<Metadata
   const a = achievements.find((x) => x.id === id);
   if (!a) return { title: "Achievement — VibeTalent" };
 
-  const title = `@${user.username} unlocked "${a.title}" — VibeTalent`;
+  const verb = a.earned ? "unlocked" : "is progressing toward";
+  const title = `@${user.username} ${verb} "${a.title}" — VibeTalent`;
   const description = `${a.description} See @${user.username}'s achievements on VibeTalent.`;
-  const ogUrl = `${siteUrl}/api/og/achievement/${user.username}/${a.id}`;
+  const encodedUser = encodeURIComponent(user.username);
+  const encodedId = encodeURIComponent(a.id);
+  const ogUrl = `${siteUrl}/api/og/achievement/${encodedUser}/${encodedId}`;
+  const shareUrl = `${siteUrl}/share/achievement/${encodedUser}/${encodedId}`;
 
   return {
     title,
     description,
     alternates: {
-      canonical: `${siteUrl}/share/achievement/${user.username}/${a.id}`,
+      canonical: shareUrl,
     },
     openGraph: {
       title,
       description,
-      url: `${siteUrl}/share/achievement/${user.username}/${a.id}`,
+      url: shareUrl,
       type: "article",
       images: [{ url: ogUrl, width: 1200, height: 630, alt: a.title }],
     },

--- a/src/components/achievements/achievement-card.tsx
+++ b/src/components/achievements/achievement-card.tsx
@@ -13,6 +13,11 @@ export function AchievementCard({ achievement, username }: AchievementCardProps)
   const { id, title, description, threshold, current, earned, percent, unit } = achievement;
   const showProgressNumbers = threshold > 1;
   const art = getBadgeArt(id);
+  // Defensive clamp — `percent` is already clamped at compute time, but
+  // belt-and-suspenders before piping it into a CSS width.
+  const safePercent = Number.isFinite(percent)
+    ? Math.max(0, Math.min(100, percent))
+    : 0;
 
   return (
     <div
@@ -94,11 +99,17 @@ export function AchievementCard({ achievement, username }: AchievementCardProps)
               backgroundColor: "var(--bg-base)",
               border: "1px solid var(--border-hard)",
             }}
+            role="progressbar"
+            aria-label={`${title} progress`}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={safePercent}
+            aria-valuetext={`${current.toLocaleString()} of ${threshold.toLocaleString()} ${unit}`}
           >
             <div
               className="h-full"
               style={{
-                width: `${percent}%`,
+                width: `${safePercent}%`,
                 backgroundColor: earned
                   ? "var(--badge-gold, #EAB308)"
                   : "var(--text-muted)",
@@ -111,7 +122,7 @@ export function AchievementCard({ achievement, username }: AchievementCardProps)
               {current.toLocaleString()} / {threshold.toLocaleString()} {unit}
             </span>
             <span style={{ color: earned ? "var(--foreground)" : "var(--text-muted)" }}>
-              {percent}%
+              {safePercent}%
             </span>
           </div>
         </div>

--- a/src/components/achievements/achievement-card.tsx
+++ b/src/components/achievements/achievement-card.tsx
@@ -1,0 +1,121 @@
+import { Check, Lock } from "lucide-react";
+import type { AchievementState } from "@/lib/achievements/definitions";
+import { getBadgeArt } from "@/lib/achievements/badge-art";
+import { BadgeMedallion } from "@/components/achievements/badge-medallion";
+import { AchievementShareMenu } from "@/components/achievements/achievement-share-menu";
+
+interface AchievementCardProps {
+  achievement: AchievementState;
+  username: string;
+}
+
+export function AchievementCard({ achievement, username }: AchievementCardProps) {
+  const { id, title, description, threshold, current, earned, percent, unit } = achievement;
+  const showProgressNumbers = threshold > 1;
+  const art = getBadgeArt(id);
+
+  return (
+    <div
+      className="relative flex flex-col gap-3 p-5"
+      style={{
+        backgroundColor: earned
+          ? "var(--bg-surface)"
+          : "var(--bg-surface-light, var(--bg-surface))",
+        border: "2px solid var(--border-hard)",
+        boxShadow: earned ? "var(--shadow-brutal-sm)" : "none",
+        opacity: earned ? 1 : 0.92,
+      }}
+    >
+      <div className="flex items-start gap-4">
+        <BadgeMedallion
+          paletteKey={art.palette}
+          icon={art.icon}
+          chipLabel={art.chipLabel}
+          size={72}
+          earned={earned}
+        />
+        <div className="flex min-w-0 flex-1 flex-col gap-1.5 pt-1">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
+              <h3
+                className="text-sm font-extrabold uppercase tracking-wide"
+                style={{ color: "var(--foreground)" }}
+              >
+                {title}
+              </h3>
+              {earned ? (
+                <span
+                  className="inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-extrabold uppercase"
+                  style={{
+                    backgroundColor: "var(--status-success-bg, #DCFCE7)",
+                    color: "var(--status-success-text, #166534)",
+                    border: "1px solid var(--border-hard)",
+                  }}
+                >
+                  <Check size={10} strokeWidth={3} />
+                  Earned
+                </span>
+              ) : (
+                <span
+                  className="inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-extrabold uppercase"
+                  style={{
+                    backgroundColor: "var(--bg-base)",
+                    color: "var(--text-muted)",
+                    border: "1px solid var(--border-hard)",
+                  }}
+                >
+                  <Lock size={10} strokeWidth={3} />
+                  Locked
+                </span>
+              )}
+            </div>
+            {earned ? (
+              <AchievementShareMenu
+                username={username}
+                achievementId={id}
+                title={title}
+              />
+            ) : null}
+          </div>
+          <p
+            className="text-xs font-medium leading-snug"
+            style={{ color: "var(--text-secondary)" }}
+          >
+            {description}
+          </p>
+        </div>
+      </div>
+
+      {showProgressNumbers && (
+        <div className="flex flex-col gap-1.5">
+          <div
+            className="h-2 w-full overflow-hidden"
+            style={{
+              backgroundColor: "var(--bg-base)",
+              border: "1px solid var(--border-hard)",
+            }}
+          >
+            <div
+              className="h-full"
+              style={{
+                width: `${percent}%`,
+                backgroundColor: earned
+                  ? "var(--badge-gold, #EAB308)"
+                  : "var(--text-muted)",
+                transition: "width 200ms ease-out",
+              }}
+            />
+          </div>
+          <div className="flex items-center justify-between text-[10px] font-bold uppercase tracking-wide">
+            <span style={{ color: "var(--text-secondary)" }}>
+              {current.toLocaleString()} / {threshold.toLocaleString()} {unit}
+            </span>
+            <span style={{ color: earned ? "var(--foreground)" : "var(--text-muted)" }}>
+              {percent}%
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/achievements/achievement-share-menu.tsx
+++ b/src/components/achievements/achievement-share-menu.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  Share2,
+  Link as LinkIcon,
+  Download,
+  ImageIcon,
+  Check,
+  X,
+} from "lucide-react";
+
+interface AchievementShareMenuProps {
+  username: string;
+  achievementId: string;
+  title: string;
+}
+
+type Status =
+  | "idle"
+  | "copying-image"
+  | "image-copied"
+  | "image-error"
+  | "downloading"
+  | "downloaded"
+  | "copying-link"
+  | "link-copied"
+  | "error";
+
+export function AchievementShareMenu({ username, achievementId, title }: AchievementShareMenuProps) {
+  const [open, setOpen] = useState(false);
+  const [status, setStatus] = useState<Status>("idle");
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onClick(e: MouseEvent) {
+      if (!containerRef.current?.contains(e.target as Node)) setOpen(false);
+    }
+    function onEsc(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onClick);
+    document.addEventListener("keydown", onEsc);
+    return () => {
+      document.removeEventListener("mousedown", onClick);
+      document.removeEventListener("keydown", onEsc);
+    };
+  }, [open]);
+
+  const sharePath = `/share/achievement/${encodeURIComponent(username)}/${encodeURIComponent(achievementId)}`;
+  const imagePath = `/api/og/achievement/${encodeURIComponent(username)}/${encodeURIComponent(achievementId)}`;
+
+  async function copyImage() {
+    setStatus("copying-image");
+    try {
+      // Safari requires the ClipboardItem to be created synchronously
+      // in the user-gesture handler — pass the Promise directly.
+      const blobPromise = fetch(imagePath).then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.blob();
+      });
+      // ClipboardItem with a Promise is supported by Chrome/Edge/Safari.
+      // Firefox lacks image clipboard support and will throw — we surface
+      // that as an error and let the user fall back to Download.
+      await navigator.clipboard.write([
+        new ClipboardItem({ "image/png": blobPromise }),
+      ]);
+      setStatus("image-copied");
+      setTimeout(() => setStatus("idle"), 1800);
+    } catch {
+      setStatus("image-error");
+      setTimeout(() => setStatus("idle"), 2200);
+    }
+  }
+
+  async function downloadImage() {
+    setStatus("downloading");
+    try {
+      const res = await fetch(imagePath);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const blob = await res.blob();
+      const blobUrl = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = blobUrl;
+      a.download = `vibetalent-${username}-${achievementId}.png`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(blobUrl);
+      setStatus("downloaded");
+      setTimeout(() => setStatus("idle"), 1500);
+    } catch {
+      setStatus("error");
+      setTimeout(() => setStatus("idle"), 1500);
+    }
+  }
+
+  async function copyLink() {
+    setStatus("copying-link");
+    try {
+      const url = new URL(sharePath, window.location.origin).toString();
+      await navigator.clipboard.writeText(url);
+      setStatus("link-copied");
+      setTimeout(() => setStatus("idle"), 1500);
+    } catch {
+      setStatus("error");
+      setTimeout(() => setStatus("idle"), 1500);
+    }
+  }
+
+  function shareOnX() {
+    const text = `I just earned the "${title}" achievement on VibeTalent`;
+    const url = new URL(sharePath, window.location.origin).toString();
+    const intent = `https://x.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`;
+    window.open(intent, "_blank", "noopener,noreferrer");
+    setOpen(false);
+  }
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-label={`Share ${title} achievement`}
+        aria-expanded={open}
+        className="inline-flex items-center gap-1.5 px-2.5 py-1 text-[10px] font-extrabold uppercase tracking-wide"
+        style={{
+          backgroundColor: "var(--accent, #FF3A00)",
+          color: "#FFFFFF",
+          border: "2px solid var(--border-hard)",
+          boxShadow: "var(--shadow-brutal-xs, 2px 2px 0 var(--border-hard))",
+          cursor: "pointer",
+        }}
+      >
+        <Share2 size={11} strokeWidth={3} />
+        Share
+      </button>
+      {open ? (
+        <div
+          role="menu"
+          className="absolute right-0 top-9 z-20 w-56"
+          style={{
+            backgroundColor: "var(--bg-surface)",
+            border: "2px solid var(--border-hard)",
+            boxShadow: "var(--shadow-brutal-sm)",
+          }}
+        >
+          <button
+            type="button"
+            onClick={copyImage}
+            role="menuitem"
+            disabled={status === "copying-image"}
+            className="flex w-full items-center gap-2 px-3 py-2.5 text-xs font-extrabold uppercase tracking-wide"
+            style={{ color: "var(--foreground)" }}
+          >
+            {status === "image-copied" ? (
+              <Check size={14} strokeWidth={3} />
+            ) : (
+              <ImageIcon size={14} strokeWidth={2.5} />
+            )}
+            {status === "copying-image"
+              ? "Copying…"
+              : status === "image-copied"
+                ? "Image copied"
+                : "Copy image"}
+          </button>
+          <button
+            type="button"
+            onClick={downloadImage}
+            role="menuitem"
+            disabled={status === "downloading"}
+            className="flex w-full items-center gap-2 px-3 py-2.5 text-xs font-extrabold uppercase tracking-wide"
+            style={{ color: "var(--foreground)" }}
+          >
+            {status === "downloaded" ? (
+              <Check size={14} strokeWidth={3} />
+            ) : (
+              <Download size={14} strokeWidth={2.5} />
+            )}
+            {status === "downloading"
+              ? "Preparing…"
+              : status === "downloaded"
+                ? "Saved"
+                : "Download PNG"}
+          </button>
+          <button
+            type="button"
+            onClick={copyLink}
+            role="menuitem"
+            disabled={status === "copying-link"}
+            className="flex w-full items-center gap-2 px-3 py-2.5 text-xs font-extrabold uppercase tracking-wide"
+            style={{ color: "var(--foreground)" }}
+          >
+            {status === "link-copied" ? (
+              <Check size={14} strokeWidth={3} />
+            ) : (
+              <LinkIcon size={14} strokeWidth={2.5} />
+            )}
+            {status === "link-copied" ? "Link copied" : "Copy link"}
+          </button>
+          <button
+            type="button"
+            onClick={shareOnX}
+            role="menuitem"
+            className="flex w-full items-center gap-2 px-3 py-2.5 text-xs font-extrabold uppercase tracking-wide"
+            style={{ color: "var(--foreground)" }}
+          >
+            <span aria-hidden="true" className="text-[15px] leading-none">𝕏</span>
+            Share on X
+          </button>
+          {status === "image-error" ? (
+            <div
+              className="flex items-center gap-2 px-3 py-2 text-[10px] font-extrabold uppercase"
+              style={{ color: "var(--accent, #FF3A00)" }}
+            >
+              <X size={12} strokeWidth={3} />
+              Browser blocked image copy — try Download
+            </div>
+          ) : null}
+          {status === "error" ? (
+            <div
+              className="flex items-center gap-2 px-3 py-2 text-[10px] font-extrabold uppercase"
+              style={{ color: "var(--accent, #FF3A00)" }}
+            >
+              <X size={12} strokeWidth={3} />
+              Something went wrong
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/achievements/achievement-share-menu.tsx
+++ b/src/components/achievements/achievement-share-menu.tsx
@@ -138,7 +138,6 @@ export function AchievementShareMenu({ username, achievementId, title }: Achieve
       </button>
       {open ? (
         <div
-          role="menu"
           className="absolute right-0 top-9 z-20 w-56"
           style={{
             backgroundColor: "var(--bg-surface)",
@@ -149,8 +148,7 @@ export function AchievementShareMenu({ username, achievementId, title }: Achieve
           <button
             type="button"
             onClick={copyImage}
-            role="menuitem"
-            disabled={status === "copying-image"}
+disabled={status === "copying-image"}
             className="flex w-full items-center gap-2 px-3 py-2.5 text-xs font-extrabold uppercase tracking-wide"
             style={{ color: "var(--foreground)" }}
           >
@@ -168,8 +166,7 @@ export function AchievementShareMenu({ username, achievementId, title }: Achieve
           <button
             type="button"
             onClick={downloadImage}
-            role="menuitem"
-            disabled={status === "downloading"}
+disabled={status === "downloading"}
             className="flex w-full items-center gap-2 px-3 py-2.5 text-xs font-extrabold uppercase tracking-wide"
             style={{ color: "var(--foreground)" }}
           >
@@ -187,8 +184,7 @@ export function AchievementShareMenu({ username, achievementId, title }: Achieve
           <button
             type="button"
             onClick={copyLink}
-            role="menuitem"
-            disabled={status === "copying-link"}
+disabled={status === "copying-link"}
             className="flex w-full items-center gap-2 px-3 py-2.5 text-xs font-extrabold uppercase tracking-wide"
             style={{ color: "var(--foreground)" }}
           >
@@ -202,8 +198,7 @@ export function AchievementShareMenu({ username, achievementId, title }: Achieve
           <button
             type="button"
             onClick={shareOnX}
-            role="menuitem"
-            className="flex w-full items-center gap-2 px-3 py-2.5 text-xs font-extrabold uppercase tracking-wide"
+className="flex w-full items-center gap-2 px-3 py-2.5 text-xs font-extrabold uppercase tracking-wide"
             style={{ color: "var(--foreground)" }}
           >
             <span aria-hidden="true" className="text-[15px] leading-none">𝕏</span>

--- a/src/components/achievements/achievements-grid.tsx
+++ b/src/components/achievements/achievements-grid.tsx
@@ -1,0 +1,49 @@
+import { AchievementCard } from "@/components/achievements/achievement-card";
+import {
+  CATEGORY_LABELS,
+  CATEGORY_ORDER,
+  type AchievementState,
+} from "@/lib/achievements/definitions";
+
+interface AchievementsGridProps {
+  achievements: AchievementState[];
+  username: string;
+}
+
+export function AchievementsGrid({ achievements, username }: AchievementsGridProps) {
+  const grouped = CATEGORY_ORDER.map((cat) => ({
+    cat,
+    items: achievements.filter((a) => a.category === cat),
+  })).filter((g) => g.items.length > 0);
+
+  return (
+    <div className="flex flex-col gap-8">
+      {grouped.map(({ cat, items }) => {
+        const earnedInCat = items.filter((i) => i.earned).length;
+        return (
+          <section key={cat} className="flex flex-col gap-3">
+            <div className="flex items-baseline justify-between">
+              <h2
+                className="text-base font-extrabold uppercase tracking-wide"
+                style={{ color: "var(--foreground)" }}
+              >
+                {CATEGORY_LABELS[cat]}
+              </h2>
+              <span
+                className="text-xs font-bold uppercase tracking-wide"
+                style={{ color: "var(--text-secondary)" }}
+              >
+                {earnedInCat} / {items.length} unlocked
+              </span>
+            </div>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {items.map((a) => (
+                <AchievementCard key={a.id} achievement={a} username={username} />
+              ))}
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/achievements/achievements-teaser.tsx
+++ b/src/components/achievements/achievements-teaser.tsx
@@ -1,0 +1,308 @@
+import Link from "next/link";
+import { ArrowRight, Trophy } from "lucide-react";
+import { getBadgeArt } from "@/lib/achievements/badge-art";
+import { BadgeMedallion } from "@/components/achievements/badge-medallion";
+import {
+  CATEGORY_ORDER,
+  type AchievementState,
+} from "@/lib/achievements/definitions";
+
+interface AchievementsTeaserProps {
+  achievements: AchievementState[];
+  username: string;
+}
+
+export function AchievementsTeaser({
+  achievements,
+  username,
+}: AchievementsTeaserProps) {
+  const total = achievements.length;
+  const earnedCount = achievements.filter((a) => a.earned).length;
+  const percent = total > 0 ? Math.round((earnedCount / total) * 100) : 0;
+
+  // Sort by category (matches the full page grouping) so the teaser
+  // reads as a curated collection rather than a random pile.
+  const ordered = CATEGORY_ORDER.flatMap((cat) =>
+    achievements.filter((a) => a.category === cat),
+  );
+
+  // "Next up" = the locked badge closest to unlocking. Drops badges
+  // at 0% so we don't dangle distant goals — only show real momentum.
+  const nextUp = achievements
+    .filter((a) => !a.earned && a.percent > 0)
+    .sort((a, b) => b.percent - a.percent)[0];
+
+  return (
+    <section
+      className="overflow-hidden"
+      style={{
+        backgroundColor: "var(--bg-surface)",
+        border: "2px solid var(--border-hard)",
+        boxShadow: "var(--shadow-brutal)",
+      }}
+    >
+      {/* Header */}
+      <div
+        className="flex flex-wrap items-center justify-between gap-3 px-6 py-4"
+        style={{ borderBottom: "2px solid var(--border-hard)" }}
+      >
+        <div className="flex items-center gap-2.5">
+          <div
+            className="flex h-7 w-7 items-center justify-center"
+            style={{
+              backgroundColor: "var(--accent, #FF3A00)",
+              border: "2px solid var(--border-hard)",
+            }}
+          >
+            <Trophy size={14} strokeWidth={3} color="#fff" />
+          </div>
+          <h3
+            className="text-base font-extrabold uppercase tracking-wide"
+            style={{ color: "var(--foreground)" }}
+          >
+            Achievements
+          </h3>
+        </div>
+        <Link
+          href={`/profile/${username}/achievements`}
+          className="inline-flex items-center gap-1.5 btn-brutal btn-brutal-dark text-xs py-1.5 px-4"
+        >
+          View all
+          <ArrowRight size={14} strokeWidth={3} />
+        </Link>
+      </div>
+
+      {earnedCount === 0 && !nextUp ? (
+        <EmptyState />
+      ) : (
+        <>
+          <div className="flex flex-col gap-6 px-6 py-6 sm:flex-row sm:items-stretch sm:gap-8">
+            <ProgressRing
+              earnedCount={earnedCount}
+              total={total}
+              percent={percent}
+            />
+            <div className="flex-1">
+              <BadgeShelf achievements={ordered} username={username} />
+            </div>
+          </div>
+
+          {nextUp ? <NextUpBanner achievement={nextUp} /> : null}
+        </>
+      )}
+    </section>
+  );
+}
+
+// ─── Progress ring ────────────────────────────────────────────────
+
+interface ProgressRingProps {
+  earnedCount: number;
+  total: number;
+  percent: number;
+}
+
+function ProgressRing({ earnedCount, total, percent }: ProgressRingProps) {
+  const radius = 52;
+  const circumference = 2 * Math.PI * radius;
+  const dashOffset = circumference - (percent / 100) * circumference;
+
+  return (
+    <div
+      className="flex shrink-0 flex-col items-center justify-center gap-2 px-4 py-4 sm:w-[160px]"
+      style={{
+        backgroundColor: "var(--bg-base)",
+        border: "2px solid var(--border-hard)",
+      }}
+    >
+      <div className="relative flex items-center justify-center">
+        <svg
+          width={128}
+          height={128}
+          viewBox="0 0 128 128"
+          style={{ transform: "rotate(-90deg)" }}
+        >
+          {/* Track */}
+          <circle
+            cx="64"
+            cy="64"
+            r={radius}
+            fill="none"
+            stroke="var(--bg-surface-light, #2a2a2a)"
+            strokeWidth="10"
+          />
+          {/* Progress */}
+          <circle
+            cx="64"
+            cy="64"
+            r={radius}
+            fill="none"
+            stroke="var(--accent, #FF3A00)"
+            strokeWidth="10"
+            strokeLinecap="butt"
+            strokeDasharray={circumference}
+            strokeDashoffset={dashOffset}
+          />
+        </svg>
+        <div className="absolute flex flex-col items-center leading-none">
+          <span
+            className="text-3xl font-extrabold tabular-nums"
+            style={{ color: "var(--foreground)" }}
+          >
+            {earnedCount}
+          </span>
+          <span
+            className="mt-0.5 text-[10px] font-extrabold uppercase tracking-widest"
+            style={{ color: "var(--text-muted)" }}
+          >
+            of {total}
+          </span>
+        </div>
+      </div>
+      <div
+        className="text-[10px] font-extrabold uppercase tracking-widest"
+        style={{ color: "var(--text-secondary)" }}
+      >
+        Unlocked
+      </div>
+    </div>
+  );
+}
+
+// ─── Badge shelf (all 20 slots) ───────────────────────────────────
+
+interface BadgeShelfProps {
+  achievements: AchievementState[];
+  username: string;
+}
+
+function BadgeShelf({ achievements, username }: BadgeShelfProps) {
+  return (
+    <Link
+      href={`/profile/${username}/achievements`}
+      className="block"
+      aria-label="View all achievements"
+    >
+      <div
+        className="grid grid-cols-[repeat(auto-fill,minmax(54px,1fr))] gap-x-3 gap-y-4 sm:gap-x-4"
+        style={{ rowGap: 22 }}
+      >
+        {achievements.map((a) => {
+          const art = getBadgeArt(a.id);
+          return (
+            <div
+              key={a.id}
+              className="flex flex-col items-center"
+              title={
+                a.earned
+                  ? a.title
+                  : `${a.title} — ${a.current}/${a.threshold} ${a.unit}`
+              }
+            >
+              <BadgeMedallion
+                paletteKey={art.palette}
+                icon={art.icon}
+                chipLabel={art.chipLabel}
+                size={48}
+                earned={a.earned}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </Link>
+  );
+}
+
+// ─── Next up banner ───────────────────────────────────────────────
+
+interface NextUpBannerProps {
+  achievement: AchievementState;
+}
+
+function NextUpBanner({ achievement }: NextUpBannerProps) {
+  const art = getBadgeArt(achievement.id);
+  const remaining = achievement.threshold - achievement.current;
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-4 px-6 py-4"
+      style={{
+        borderTop: "2px dashed var(--border-hard)",
+        backgroundColor: "var(--bg-base)",
+      }}
+    >
+      <div className="flex shrink-0 items-center gap-3">
+        <BadgeMedallion
+          paletteKey={art.palette}
+          icon={art.icon}
+          chipLabel={art.chipLabel}
+          size={44}
+          earned={false}
+        />
+        <div className="flex flex-col">
+          <span
+            className="text-[9px] font-extrabold uppercase tracking-widest"
+            style={{ color: "var(--text-muted)" }}
+          >
+            Next up
+          </span>
+          <span
+            className="text-sm font-extrabold uppercase tracking-wide"
+            style={{ color: "var(--foreground)" }}
+          >
+            {achievement.title}
+          </span>
+        </div>
+      </div>
+      <div className="flex min-w-[180px] flex-1 flex-col gap-1.5">
+        <div
+          className="h-2 w-full overflow-hidden"
+          style={{
+            backgroundColor: "var(--bg-surface)",
+            border: "1px solid var(--border-hard)",
+          }}
+        >
+          <div
+            className="h-full"
+            style={{
+              width: `${achievement.percent}%`,
+              backgroundColor: "var(--accent, #FF3A00)",
+            }}
+          />
+        </div>
+        <div className="flex items-center justify-between text-[10px] font-bold uppercase tracking-wide">
+          <span style={{ color: "var(--text-secondary)" }}>
+            {achievement.current.toLocaleString()} / {achievement.threshold.toLocaleString()}{" "}
+            {achievement.unit}
+          </span>
+          <span style={{ color: "var(--foreground)" }}>
+            {remaining.toLocaleString()} to go
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Empty state ──────────────────────────────────────────────────
+
+function EmptyState() {
+  return (
+    <div
+      className="flex flex-col items-center justify-center gap-2 px-6 py-10 text-center"
+    >
+      <Trophy
+        size={28}
+        strokeWidth={2.5}
+        style={{ color: "var(--text-muted)" }}
+      />
+      <p
+        className="text-xs font-extrabold uppercase tracking-wide"
+        style={{ color: "var(--text-muted)" }}
+      >
+        No achievements yet — start a streak to earn your first badge
+      </p>
+    </div>
+  );
+}

--- a/src/components/achievements/badge-medallion.tsx
+++ b/src/components/achievements/badge-medallion.tsx
@@ -1,0 +1,176 @@
+import {
+  Flame,
+  Rocket,
+  Package,
+  Boxes,
+  BadgeCheck,
+  Star,
+  ThumbsUp,
+  Heart,
+  PartyPopper,
+  Briefcase,
+  Zap,
+  Target,
+  Handshake,
+  Trophy,
+  Github,
+  Megaphone,
+  Sunrise,
+  type LucideIcon,
+} from "lucide-react";
+import {
+  PALETTES,
+  type IconSlug,
+  type PaletteKey,
+} from "@/lib/achievements/badge-art";
+
+const ICONS: Record<IconSlug, LucideIcon> = {
+  flame: Flame,
+  rocket: Rocket,
+  package: Package,
+  boxes: Boxes,
+  "badge-check": BadgeCheck,
+  star: Star,
+  "thumbs-up": ThumbsUp,
+  heart: Heart,
+  "party-popper": PartyPopper,
+  briefcase: Briefcase,
+  zap: Zap,
+  target: Target,
+  handshake: Handshake,
+  trophy: Trophy,
+  github: Github,
+  megaphone: Megaphone,
+  sunrise: Sunrise,
+};
+
+const LOCKED_PALETTE = {
+  ring: "#52525B",
+  inner: "#A1A1AA",
+  glow: "#D4D4D8",
+  chip: "#52525B",
+  chipText: "#F4F4F5",
+};
+
+interface BadgeMedallionProps {
+  paletteKey: PaletteKey;
+  icon: IconSlug;
+  chipLabel?: string;
+  size?: number;
+  earned?: boolean;
+}
+
+/**
+ * Custom SVG medallion shown for each achievement.
+ *
+ * Renders as a div wrapper (for absolute positioning of the icon) + an
+ * inline SVG for the rings. This composition works in both the DOM and
+ * the next/og edge runtime (Satori supports flex + absolute positioning).
+ */
+export function BadgeMedallion({
+  paletteKey,
+  icon,
+  chipLabel,
+  size = 96,
+  earned = true,
+}: BadgeMedallionProps) {
+  const palette = earned ? PALETTES[paletteKey] : LOCKED_PALETTE;
+  const Icon = ICONS[icon] ?? Star;
+  const gradId = `bm-${paletteKey}-${icon}-${earned ? "on" : "off"}`;
+  const iconSize = Math.round(size * 0.42);
+  const chipFontSize = Math.max(9, Math.round(size * 0.13));
+  const chipHeight = Math.round(size * 0.22);
+  const chipMinWidth = Math.round(size * 0.32);
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        width: size,
+        height: size,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        flexShrink: 0,
+      }}
+      aria-hidden="true"
+    >
+      <svg
+        viewBox="0 0 100 100"
+        width={size}
+        height={size}
+        style={{ position: "absolute", top: 0, left: 0, display: "flex" }}
+      >
+        <defs>
+          <radialGradient id={gradId} cx="50%" cy="40%" r="60%">
+            <stop offset="0%" stopColor={palette.glow} />
+            <stop offset="100%" stopColor={palette.inner} />
+          </radialGradient>
+        </defs>
+        {/* Outer ring */}
+        <circle
+          cx="50"
+          cy="50"
+          r="46"
+          fill={palette.ring}
+          stroke="#0F0F0F"
+          strokeWidth="3"
+        />
+        {/* Inner gradient disc */}
+        <circle
+          cx="50"
+          cy="50"
+          r="34"
+          fill={`url(#${gradId})`}
+          stroke="#0F0F0F"
+          strokeWidth="2"
+        />
+        {/* Subtle inner highlight arc on top */}
+        <path
+          d="M 28 38 A 26 26 0 0 1 72 38"
+          fill="none"
+          stroke={palette.glow}
+          strokeWidth="2"
+          strokeLinecap="round"
+          opacity={earned ? 0.55 : 0.25}
+        />
+      </svg>
+      <Icon
+        size={iconSize}
+        color="#FFFFFF"
+        strokeWidth={2.5}
+        style={{
+          position: "relative",
+          zIndex: 1,
+          filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.45))",
+        }}
+      />
+      {chipLabel ? (
+        <div
+          style={{
+            position: "absolute",
+            bottom: -Math.round(chipHeight / 3),
+            left: "50%",
+            transform: "translateX(-50%)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            minWidth: chipMinWidth,
+            height: chipHeight,
+            padding: "0 8px",
+            backgroundColor: palette.chip,
+            color: palette.chipText,
+            border: "2px solid #0F0F0F",
+            fontSize: chipFontSize,
+            fontWeight: 900,
+            letterSpacing: "0.04em",
+            lineHeight: 1,
+            whiteSpace: "nowrap",
+          }}
+        >
+          {chipLabel}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/layout/navbar-client.tsx
+++ b/src/components/layout/navbar-client.tsx
@@ -809,6 +809,13 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
                   My Profile
                 </Link>
                 <Link
+                  href={`/profile/${userProfile.username}/achievements`}
+                  onClick={() => setMobileOpen(false)}
+                  className="block px-4 py-3 text-sm font-bold uppercase tracking-wide text-[var(--foreground)]"
+                >
+                  Achievements
+                </Link>
+                <Link
                   href="/settings"
                   onClick={() => setMobileOpen(false)}
                   className="block px-4 py-3 text-sm font-bold uppercase tracking-wide text-[var(--foreground)]"

--- a/src/components/layout/navbar-client.tsx
+++ b/src/components/layout/navbar-client.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname, useRouter } from "next/navigation";
-import { Menu, X, LogOut, Settings, Sparkles, User, Users, BadgeCheck, ChevronDown } from "lucide-react";
+import { Menu, X, LogOut, Settings, Sparkles, Trophy, User, Users, BadgeCheck, ChevronDown } from "lucide-react";
 import { useState, useEffect, useRef, useCallback } from "react";
 import { createClient } from "@/lib/supabase/client";
 import { NotificationBell } from "@/components/ui/notification-bell";
@@ -573,6 +573,16 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
                   >
                     <User size={16} />
                     My Profile
+                  </Link>
+                  <Link
+                    href={`/profile/${userProfile?.username || ""}/achievements`}
+                    role="menuitem"
+                    onClick={() => setProfileDropdownOpen(false)}
+                    className="flex items-center gap-2 px-4 py-3 text-sm font-bold uppercase tracking-wide transition-colors"
+                    style={{ color: "var(--foreground)" }}
+                  >
+                    <Trophy size={16} />
+                    Achievements
                   </Link>
                   <Link
                     href={userProfile && !userProfile.display_name ? "/settings?complete=name" : "/settings"}

--- a/src/lib/achievements/badge-art.ts
+++ b/src/lib/achievements/badge-art.ts
@@ -1,0 +1,163 @@
+/**
+ * Visual identity for each achievement badge.
+ *
+ * Each badge has a palette (color theme), an icon name (resolved at render),
+ * and an optional chip label shown on the medallion ribbon (usually the
+ * unlock threshold, e.g. "30", "10").
+ */
+
+export type PaletteKey =
+  | "bronze"
+  | "silver"
+  | "gold"
+  | "diamond"
+  | "emerald"
+  | "amber"
+  | "rose"
+  | "violet"
+  | "sky"
+  | "orange";
+
+export interface BadgePalette {
+  /** Outer ring color */
+  ring: string;
+  /** Inner disc base color */
+  inner: string;
+  /** Highlight/glow for gradient center */
+  glow: string;
+  /** Chip background */
+  chip: string;
+  /** Chip text */
+  chipText: string;
+}
+
+export const PALETTES: Record<PaletteKey, BadgePalette> = {
+  bronze: {
+    ring: "#7A4A1F",
+    inner: "#C97A3A",
+    glow: "#F2B07A",
+    chip: "#7A4A1F",
+    chipText: "#FFE4C8",
+  },
+  silver: {
+    ring: "#5B5F66",
+    inner: "#B0B6BF",
+    glow: "#EAEEF3",
+    chip: "#5B5F66",
+    chipText: "#FFFFFF",
+  },
+  gold: {
+    ring: "#8A5A00",
+    inner: "#F0B400",
+    glow: "#FFE489",
+    chip: "#8A5A00",
+    chipText: "#FFF3C2",
+  },
+  diamond: {
+    ring: "#0E6F86",
+    inner: "#3FBADD",
+    glow: "#A8EDFC",
+    chip: "#0E6F86",
+    chipText: "#E0F8FE",
+  },
+  emerald: {
+    ring: "#065F46",
+    inner: "#10B981",
+    glow: "#6EE7B7",
+    chip: "#065F46",
+    chipText: "#D1FAE5",
+  },
+  amber: {
+    ring: "#92400E",
+    inner: "#F59E0B",
+    glow: "#FCD34D",
+    chip: "#92400E",
+    chipText: "#FEF3C7",
+  },
+  rose: {
+    ring: "#9D174D",
+    inner: "#EC4899",
+    glow: "#F9A8D4",
+    chip: "#9D174D",
+    chipText: "#FCE7F3",
+  },
+  violet: {
+    ring: "#4C1D95",
+    inner: "#8B5CF6",
+    glow: "#C4B5FD",
+    chip: "#4C1D95",
+    chipText: "#EDE9FE",
+  },
+  sky: {
+    ring: "#075985",
+    inner: "#0EA5E9",
+    glow: "#7DD3FC",
+    chip: "#075985",
+    chipText: "#E0F2FE",
+  },
+  orange: {
+    ring: "#9A2D00",
+    inner: "#FF3A00",
+    glow: "#FF9D7A",
+    chip: "#9A2D00",
+    chipText: "#FFE0D1",
+  },
+};
+
+export type IconSlug =
+  | "flame"
+  | "rocket"
+  | "package"
+  | "boxes"
+  | "badge-check"
+  | "star"
+  | "thumbs-up"
+  | "heart"
+  | "party-popper"
+  | "briefcase"
+  | "zap"
+  | "target"
+  | "handshake"
+  | "trophy"
+  | "github"
+  | "megaphone"
+  | "sunrise";
+
+export interface BadgeArt {
+  palette: PaletteKey;
+  icon: IconSlug;
+  /** Bottom chip label (usually the threshold). Falsy hides the chip. */
+  chipLabel?: string;
+}
+
+export const BADGE_ART: Record<string, BadgeArt> = {
+  streak_bronze: { palette: "bronze", icon: "flame", chipLabel: "30" },
+  streak_silver: { palette: "silver", icon: "flame", chipLabel: "90" },
+  streak_gold: { palette: "gold", icon: "flame", chipLabel: "180" },
+  streak_diamond: { palette: "diamond", icon: "flame", chipLabel: "365" },
+
+  project_first: { palette: "emerald", icon: "rocket", chipLabel: "1" },
+  project_builder: { palette: "emerald", icon: "package", chipLabel: "5" },
+  project_prolific: { palette: "emerald", icon: "boxes", chipLabel: "10" },
+  project_verified: { palette: "sky", icon: "badge-check" },
+  project_quality: { palette: "gold", icon: "star", chipLabel: "70+" },
+
+  endorse_first: { palette: "rose", icon: "thumbs-up", chipLabel: "1" },
+  endorse_liked: { palette: "rose", icon: "heart", chipLabel: "10" },
+  endorse_crowd: { palette: "rose", icon: "party-popper", chipLabel: "50" },
+
+  hire_first: { palette: "amber", icon: "briefcase", chipLabel: "1" },
+  hire_hot: { palette: "amber", icon: "zap", chipLabel: "5" },
+  hire_sealed: { palette: "emerald", icon: "target" },
+
+  review_helpful: { palette: "violet", icon: "handshake", chipLabel: "5" },
+  review_pillar: { palette: "violet", icon: "trophy", chipLabel: "25" },
+
+  github_linked: { palette: "sky", icon: "github" },
+  referral_first: { palette: "orange", icon: "megaphone" },
+  founding_member: { palette: "orange", icon: "sunrise" },
+};
+
+export function getBadgeArt(id: string): BadgeArt {
+  return BADGE_ART[id] ?? { palette: "silver", icon: "star" };
+}

--- a/src/lib/achievements/definitions.ts
+++ b/src/lib/achievements/definitions.ts
@@ -1,0 +1,278 @@
+/**
+ * Achievement definitions for the profile achievements page.
+ *
+ * Each achievement is computed-on-read from existing user data — no
+ * dedicated achievements_earned table. Progress is shown for tiered
+ * achievements; binary ones are either earned or not.
+ */
+
+export type AchievementCategory =
+  | "consistency"
+  | "projects"
+  | "community"
+  | "career"
+  | "contributor"
+  | "identity";
+
+export interface AchievementCounters {
+  longestStreak: number;
+  projectCount: number;
+  verifiedProjectCount: number;
+  topQualityScore: number;
+  endorsementsReceived: number;
+  hireRequestsReceived: number;
+  completedHires: number;
+  reviewsGiven: number;
+  hasGithubLinked: boolean;
+  referralCount: number;
+  joinedAt: string | null;
+}
+
+export interface AchievementDefinition {
+  id: string;
+  title: string;
+  description: string;
+  category: AchievementCategory;
+  threshold: number;
+  unit: string;
+  progress: (c: AchievementCounters) => number;
+}
+
+export interface AchievementState extends AchievementDefinition {
+  current: number;
+  earned: boolean;
+  percent: number;
+}
+
+const FOUNDING_CUTOFF = "2026-01-01";
+
+export const ACHIEVEMENTS: AchievementDefinition[] = [
+  // CONSISTENCY — streak tiers
+  {
+    id: "streak_bronze",
+    title: "Bronze Streak",
+    description: "Log a 30-day coding streak.",
+    category: "consistency",
+    threshold: 30,
+    unit: "days",
+    progress: (c) => Math.min(c.longestStreak, 30),
+  },
+  {
+    id: "streak_silver",
+    title: "Silver Streak",
+    description: "Log a 90-day coding streak.",
+    category: "consistency",
+    threshold: 90,
+    unit: "days",
+    progress: (c) => Math.min(c.longestStreak, 90),
+  },
+  {
+    id: "streak_gold",
+    title: "Gold Streak",
+    description: "Log a 180-day coding streak.",
+    category: "consistency",
+    threshold: 180,
+    unit: "days",
+    progress: (c) => Math.min(c.longestStreak, 180),
+  },
+  {
+    id: "streak_diamond",
+    title: "Diamond Streak",
+    description: "Log a full-year 365-day coding streak.",
+    category: "consistency",
+    threshold: 365,
+    unit: "days",
+    progress: (c) => Math.min(c.longestStreak, 365),
+  },
+
+  // PROJECTS — shipping tiers
+  {
+    id: "project_first",
+    title: "First Ship",
+    description: "Add your first project to your profile.",
+    category: "projects",
+    threshold: 1,
+    unit: "projects",
+    progress: (c) => Math.min(c.projectCount, 1),
+  },
+  {
+    id: "project_builder",
+    title: "Builder",
+    description: "Ship 5 projects.",
+    category: "projects",
+    threshold: 5,
+    unit: "projects",
+    progress: (c) => Math.min(c.projectCount, 5),
+  },
+  {
+    id: "project_prolific",
+    title: "Prolific",
+    description: "Ship 10 projects.",
+    category: "projects",
+    threshold: 10,
+    unit: "projects",
+    progress: (c) => Math.min(c.projectCount, 10),
+  },
+  {
+    id: "project_verified",
+    title: "Verified Builder",
+    description: "Get one project verified via GitHub.",
+    category: "projects",
+    threshold: 1,
+    unit: "verified",
+    progress: (c) => Math.min(c.verifiedProjectCount, 1),
+  },
+  {
+    id: "project_quality",
+    title: "Quality Coder",
+    description: "Ship a project with a quality score of 70 or higher.",
+    category: "projects",
+    threshold: 70,
+    unit: "score",
+    progress: (c) => Math.min(c.topQualityScore, 70),
+  },
+
+  // COMMUNITY — endorsement tiers
+  {
+    id: "endorse_first",
+    title: "First Cheer",
+    description: "Receive your first project endorsement.",
+    category: "community",
+    threshold: 1,
+    unit: "endorsements",
+    progress: (c) => Math.min(c.endorsementsReceived, 1),
+  },
+  {
+    id: "endorse_liked",
+    title: "Well-Liked",
+    description: "Earn 10 endorsements across your projects.",
+    category: "community",
+    threshold: 10,
+    unit: "endorsements",
+    progress: (c) => Math.min(c.endorsementsReceived, 10),
+  },
+  {
+    id: "endorse_crowd",
+    title: "Crowd Favorite",
+    description: "Earn 50 endorsements across your projects.",
+    category: "community",
+    threshold: 50,
+    unit: "endorsements",
+    progress: (c) => Math.min(c.endorsementsReceived, 50),
+  },
+
+  // CAREER — hire signal tiers
+  {
+    id: "hire_first",
+    title: "In Demand",
+    description: "Receive your first hire request from a recruiter or client.",
+    category: "career",
+    threshold: 1,
+    unit: "requests",
+    progress: (c) => Math.min(c.hireRequestsReceived, 1),
+  },
+  {
+    id: "hire_hot",
+    title: "Hot Hire",
+    description: "Receive 5 hire requests.",
+    category: "career",
+    threshold: 5,
+    unit: "requests",
+    progress: (c) => Math.min(c.hireRequestsReceived, 5),
+  },
+  {
+    id: "hire_sealed",
+    title: "Sealed the Deal",
+    description: "Complete your first hired gig.",
+    category: "career",
+    threshold: 1,
+    unit: "completed",
+    progress: (c) => Math.min(c.completedHires, 1),
+  },
+
+  // CONTRIBUTOR — review activity
+  {
+    id: "review_helpful",
+    title: "Helpful Reviewer",
+    description: "Submit 5 reviews on other builders' work.",
+    category: "contributor",
+    threshold: 5,
+    unit: "reviews",
+    progress: (c) => Math.min(c.reviewsGiven, 5),
+  },
+  {
+    id: "review_pillar",
+    title: "Community Pillar",
+    description: "Submit 25 reviews on other builders' work.",
+    category: "contributor",
+    threshold: 25,
+    unit: "reviews",
+    progress: (c) => Math.min(c.reviewsGiven, 25),
+  },
+
+  // IDENTITY — profile setup & growth
+  {
+    id: "github_linked",
+    title: "GitHub Linked",
+    description: "Connect your GitHub account to your profile.",
+    category: "identity",
+    threshold: 1,
+    unit: "linked",
+    progress: (c) => (c.hasGithubLinked ? 1 : 0),
+  },
+  {
+    id: "referral_first",
+    title: "Word of Mouth",
+    description: "Refer a friend who signs up to VibeTalent.",
+    category: "identity",
+    threshold: 1,
+    unit: "referrals",
+    progress: (c) => Math.min(c.referralCount, 1),
+  },
+  {
+    id: "founding_member",
+    title: "Founding Member",
+    description: "Joined VibeTalent before 2026 — a true early adopter.",
+    category: "identity",
+    threshold: 1,
+    unit: "joined",
+    progress: (c) =>
+      c.joinedAt && c.joinedAt < FOUNDING_CUTOFF ? 1 : 0,
+  },
+];
+
+export const CATEGORY_LABELS: Record<AchievementCategory, string> = {
+  consistency: "Consistency",
+  projects: "Projects",
+  community: "Community",
+  career: "Career",
+  contributor: "Contributor",
+  identity: "Identity",
+};
+
+export const CATEGORY_ORDER: AchievementCategory[] = [
+  "consistency",
+  "projects",
+  "community",
+  "career",
+  "contributor",
+  "identity",
+];
+
+export function computeAchievements(c: AchievementCounters): AchievementState[] {
+  return ACHIEVEMENTS.map((def) => {
+    const current = def.progress(c);
+    const earned = current >= def.threshold;
+    const percent = Math.min(100, Math.round((current / def.threshold) * 100));
+    return { ...def, current, earned, percent };
+  });
+}
+
+export function groupByCategory(
+  states: AchievementState[]
+): Record<AchievementCategory, AchievementState[]> {
+  const out = {} as Record<AchievementCategory, AchievementState[]>;
+  for (const cat of CATEGORY_ORDER) out[cat] = [];
+  for (const s of states) out[s.category].push(s);
+  return out;
+}

--- a/src/lib/achievements/definitions.ts
+++ b/src/lib/achievements/definitions.ts
@@ -263,7 +263,11 @@ export function computeAchievements(c: AchievementCounters): AchievementState[] 
   return ACHIEVEMENTS.map((def) => {
     const current = def.progress(c);
     const earned = current >= def.threshold;
-    const percent = Math.min(100, Math.round((current / def.threshold) * 100));
+    const rawPercent =
+      def.threshold > 0 ? Math.round((current / def.threshold) * 100) : 0;
+    const percent = Number.isFinite(rawPercent)
+      ? Math.max(0, Math.min(100, rawPercent))
+      : 0;
     return { ...def, current, earned, percent };
   });
 }

--- a/src/lib/achievements/fetch.ts
+++ b/src/lib/achievements/fetch.ts
@@ -1,0 +1,86 @@
+/**
+ * Server-side aggregator that turns a user + their data into the counters
+ * needed to compute achievement states.
+ *
+ * Most counters come from data already on the cached UserWithSocials shape;
+ * only hire_requests and reviews need extra queries.
+ */
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import type { UserWithSocials } from "@/lib/types/database";
+import type { AchievementCounters } from "@/lib/achievements/definitions";
+
+export async function fetchAchievementCounters(
+  user: UserWithSocials
+): Promise<AchievementCounters> {
+  const projects = user.projects ?? [];
+
+  const projectCount = projects.length;
+  const verifiedProjectCount = projects.filter((p) => p.verified).length;
+  const topQualityScore = projects.reduce(
+    (max, p) => Math.max(max, p.quality_score ?? 0),
+    0
+  );
+  const endorsementsReceived = projects.reduce(
+    (sum, p) => sum + (p.endorsement_count ?? 0),
+    0
+  );
+
+  const hasGithubLinked = Boolean(
+    user.github_username || user.social_links?.github
+  );
+
+  let hireRequestsReceived = 0;
+  let completedHires = 0;
+  let reviewsGiven = 0;
+  let referralCount = 0;
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sb = createAdminClient() as any;
+
+    const [hireAll, hireReplied, reviewsCount, userRow] = await Promise.all([
+      sb
+        .from("hire_requests")
+        .select("id", { count: "exact", head: true })
+        .eq("builder_id", user.id),
+      sb
+        .from("hire_requests")
+        .select("id", { count: "exact", head: true })
+        .eq("builder_id", user.id)
+        .eq("status", "replied"),
+      sb
+        .from("reviews")
+        .select("id", { count: "exact", head: true })
+        .eq("reviewer_user_id", user.id),
+      sb
+        .from("users")
+        .select("referral_count")
+        .eq("id", user.id)
+        .single(),
+    ]);
+
+    hireRequestsReceived = hireAll?.count ?? 0;
+    completedHires = hireReplied?.count ?? 0;
+    reviewsGiven = reviewsCount?.count ?? 0;
+    referralCount = userRow?.data?.referral_count ?? 0;
+  } catch (err) {
+    // Counter queries are non-critical — fall through with zeros so the
+    // achievements page still renders if Supabase is briefly unavailable.
+    console.error("[achievements] counter fetch failed:", err);
+  }
+
+  return {
+    longestStreak: user.longest_streak ?? 0,
+    projectCount,
+    verifiedProjectCount,
+    topQualityScore,
+    endorsementsReceived,
+    hireRequestsReceived,
+    completedHires,
+    reviewsGiven,
+    hasGithubLinked,
+    referralCount,
+    joinedAt: user.created_at ?? null,
+  };
+}

--- a/src/lib/achievements/fetch.ts
+++ b/src/lib/achievements/fetch.ts
@@ -60,13 +60,33 @@ export async function fetchAchievementCounters(
         .single(),
     ]);
 
-    hireRequestsReceived = hireAll?.count ?? 0;
-    completedHires = hireReplied?.count ?? 0;
-    reviewsGiven = reviewsCount?.count ?? 0;
-    referralCount = userRow?.data?.referral_count ?? 0;
+    // supabase-js v2 resolves with {data, error, count} — it doesn't throw
+    // on RLS/SQL errors. Check each .error explicitly and log; fall back
+    // to 0 so a partial outage on one counter doesn't zero out the rest.
+    if (hireAll?.error) {
+      console.error("[achievements] hire_requests count failed:", hireAll.error);
+    } else {
+      hireRequestsReceived = hireAll?.count ?? 0;
+    }
+    if (hireReplied?.error) {
+      console.error("[achievements] hire_replied count failed:", hireReplied.error);
+    } else {
+      completedHires = hireReplied?.count ?? 0;
+    }
+    if (reviewsCount?.error) {
+      console.error("[achievements] reviews count failed:", reviewsCount.error);
+    } else {
+      reviewsGiven = reviewsCount?.count ?? 0;
+    }
+    if (userRow?.error) {
+      console.error("[achievements] referral_count lookup failed:", userRow.error);
+    } else {
+      referralCount = userRow?.data?.referral_count ?? 0;
+    }
   } catch (err) {
-    // Counter queries are non-critical — fall through with zeros so the
-    // achievements page still renders if Supabase is briefly unavailable.
+    // Only thrown errors (network, client init) land here — query-level
+    // errors are already handled above. Fall through with zeros so the
+    // page still renders.
     console.error("[achievements] counter fetch failed:", err);
   }
 


### PR DESCRIPTION
## Summary

Adds an eFootball-style trophy case for builders. **20 badges across 6 categories** computed on-read from existing data — no new DB tables, no migrations.

- **Achievements page** at `/profile/[username]/achievements` — public, grouped by category, shows locked badges with progress bars and \"how to earn\" copy
- **Profile teaser** on every `/profile/[username]` — circular progress ring + full 20-badge collection (Pokedex-style locked silhouettes) + \"next up\" momentum banner
- **Per-badge shareable cards** — every earned badge has a `SHARE` button that opens a menu: **Copy image** (PNG to clipboard, Safari-compatible), **Download PNG**, **Copy link**, **Share on X**
- **OG share infrastructure** — `/api/og/achievement/[username]/[id]` renders a 1200×630 brand-styled PNG via `next/og`; `/share/achievement/[username]/[id]` is the share landing page with proper OG meta so Twitter/Discord/LinkedIn auto-render the preview
- **20 custom SVG medallions** — circular hard-bordered medals with 10 themed palettes (bronze/silver/gold/diamond/emerald/amber/rose/violet/sky/orange), white lucide icons (Flame, Rocket, Package, Boxes, BadgeCheck, Star, ThumbsUp, Heart, PartyPopper, Briefcase, Zap, Target, Handshake, Trophy, GitHub, Megaphone, Sunrise), threshold chips. Works in both DOM and `next/og` edge renderer.

### Why compute-on-read

Pre-revenue hackathon scope — no `achievements_earned` table, no migrations, no notification fanouts. Counters are derived from `users.longest_streak`, `projects` aggregates, `hire_requests`, `reviews`, and `referral_count` on each request. ISR cached at 1 hour.

### The 20 badges

| Category | Badges |
|---|---|
| Consistency | Bronze / Silver / Gold / Diamond Streak (30/90/180/365 days) |
| Projects | First Ship · Builder (5) · Prolific (10) · Verified Builder · Quality Coder (score ≥ 70) |
| Community | First Cheer · Well-Liked (10) · Crowd Favorite (50 endorsements) |
| Career | In Demand · Hot Hire (5) · Sealed the Deal (1 completed) |
| Contributor | Helpful Reviewer (5) · Community Pillar (25 reviews) |
| Identity | GitHub Linked · Word of Mouth (referral) · Founding Member (joined < 2026) |

To add new badges later, append to \`ACHIEVEMENTS\` in [definitions.ts](src/lib/achievements/definitions.ts) + matching art entry in [badge-art.ts](src/lib/achievements/badge-art.ts) — counters, grid, share, and OG image pick it up automatically.

## Test plan

- [ ] Visit \`/profile/<username>\` — Achievements teaser renders between Stats Ribbon and Heatmap
- [ ] Circular ring shows correct \`earned / total\` and percent
- [ ] All 20 badges visible; earned ones colored, locked ones grey silhouettes
- [ ] \"Next up\" banner shows the highest-percent locked badge with progress bar
- [ ] Click \"View all\" → lands on \`/profile/<username>/achievements\` with grouped grid
- [ ] Click \`SHARE\` on an earned badge → menu opens with Copy image / Download PNG / Copy link / Share on X
- [ ] **Copy image** writes a PNG to clipboard (paste into Twitter/Slack/Discord) — Chrome/Edge/Safari; Firefox shows graceful fallback message
- [ ] **Download PNG** saves a 1200×630 PNG locally
- [ ] **Copy link** copies the \`/share/achievement/...\` URL
- [ ] Paste the share URL in Twitter/Discord/iMessage → OG image preview renders
- [ ] Navbar \"Achievements\" dropdown entry links to your own page
- [ ] Empty profile (0 earned) shows a trophy + \"start a streak\" empty state
- [ ] Mobile: teaser stacks ring above shelf; achievement cards single-column

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a comprehensive achievements system with multiple categories and progress tracking
  * Added a dedicated achievements page displaying all earned and locked achievements with category grouping
  * Added an achievements summary section on user profiles showing unlock progress
  * Enabled sharing individual achievements with image export, download, and social sharing options
  * Added achievements link to user profile menu

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unknownking07/vibe-talent/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->