### PR TITLE
fix(landing): auth-aware "Start your streak" CTA

### DIFF
--- a/src/components/homepage/end-game-ladder-cta.tsx
+++ b/src/components/homepage/end-game-ladder-cta.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { createClient } from "@/lib/supabase/client";
+
+// Client-only auth check so the homepage can still render from the ISR cache
+// (see hero-cta.tsx for the same reasoning). Logged-in users land on
+// /dashboard; everyone else goes through /auth/signup.
+export function EndGameLadderCTA() {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  useEffect(() => {
+    const supabase = createClient();
+    let cancelled = false;
+
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (!cancelled) setIsLoggedIn(!!user);
+    });
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange(
+      (_event, session) => {
+        if (!cancelled) setIsLoggedIn(!!session?.user);
+      },
+    );
+
+    return () => {
+      cancelled = true;
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  return (
+    <Link
+      href={isLoggedIn ? "/dashboard" : "/auth/signup"}
+      className="btn-brutal btn-brutal-primary text-sm sm:text-base inline-flex"
+    >
+      Start your streak today
+      <ArrowRight size={16} />
+    </Link>
+  );
+}

--- a/src/components/homepage/end-game-ladder.tsx
+++ b/src/components/homepage/end-game-ladder.tsx
@@ -20,9 +20,9 @@
  */
 
 import { Fragment } from "react";
-import Link from "next/link";
 import { ArrowRight, Github, Flame, Trophy, Mail } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
+import { EndGameLadderCTA } from "./end-game-ladder-cta";
 
 interface Step {
   number: string;
@@ -112,15 +112,10 @@ export function EndGameLadder() {
 
       {/* Bottom CTA — gives the ladder a clear close-out instead of just
           dangling. Same destination as the hero's primary CTA so we don't
-          fork the funnel. */}
+          fork the funnel. Auth-aware: logged-in users skip /auth/signup and
+          go straight to /dashboard. */}
       <div className="mt-10 text-center">
-        <Link
-          href="/auth/signup"
-          className="btn-brutal btn-brutal-primary text-sm sm:text-base inline-flex"
-        >
-          Start your streak today
-          <ArrowRight size={16} />
-        </Link>
+        <EndGameLadderCTA />
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- The bottom CTA in the "Four steps to getting hired" ladder was hardcoded to `/auth/signup`, so already-signed-in users got bounced back through the auth flow when they clicked it.
- Extracted the CTA into a small client component (`EndGameLadderCTA`) that re-checks auth on mount and routes logged-in users to `/dashboard`, logged-out users to `/auth/signup`.
- Mirrors the pattern already used by `HeroCTAClient` so the homepage still renders from the ISR cache (calling `getCurrentUser()` during SSR would mark it dynamic).

## Test plan
- [ ] Logged out: clicking "Start your streak today" goes to `/auth/signup`
- [ ] Logged in: clicking "Start your streak today" goes to `/dashboard`
- [ ] Homepage still served from ISR cache (no per-visit origin hit)
- [ ] Sign-in / sign-out in another tab updates the CTA destination without a hard refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the "Start your streak today" call-to-action to be auth-aware. Logged-in users are now directed to the dashboard, while new users are directed to sign up, streamlining the user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unknownking07/vibe-talent/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->