### PR TITLE
feat(seo): add glossary, comparison pages, and AEO signals

### DIFF
--- a/src/app/glossary/[slug]/page.tsx
+++ b/src/app/glossary/[slug]/page.tsx
@@ -1,0 +1,188 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { BookOpen, ArrowLeft, ArrowRight } from "lucide-react";
+import { siteUrl } from "@/lib/seo";
+import { GLOSSARY_TERMS, getGlossaryTerm } from "@/lib/glossary";
+
+export async function generateStaticParams() {
+  return GLOSSARY_TERMS.map((t) => ({ slug: t.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const term = getGlossaryTerm(slug);
+  if (!term) return { title: "Not found" };
+
+  const url = `${siteUrl}/glossary/${term.slug}`;
+  return {
+    title: term.title,
+    description: term.metaDescription,
+    alternates: { canonical: url },
+    openGraph: {
+      title: term.title,
+      description: term.metaDescription,
+      url,
+      siteName: "VibeTalent",
+      type: "article",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: term.title,
+      description: term.metaDescription,
+    },
+  };
+}
+
+export default async function GlossaryTermPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const term = getGlossaryTerm(slug);
+  if (!term) notFound();
+
+  const url = `${siteUrl}/glossary/${term.slug}`;
+
+  const breadcrumbLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Home", item: siteUrl },
+      { "@type": "ListItem", position: 2, name: "Glossary", item: `${siteUrl}/glossary` },
+      { "@type": "ListItem", position: 3, name: term.shortLabel, item: url },
+    ],
+  };
+
+  const definedTermLd = {
+    "@context": "https://schema.org",
+    "@type": "DefinedTerm",
+    "@id": url,
+    name: term.shortLabel,
+    description: term.summary,
+    url,
+    inDefinedTermSet: {
+      "@type": "DefinedTermSet",
+      "@id": `${siteUrl}/glossary`,
+      name: "VibeTalent Glossary",
+      url: `${siteUrl}/glossary`,
+    },
+    dateModified: "2026-05-22",
+  };
+
+  const related = term.related
+    .map((slug) => getGlossaryTerm(slug))
+    .filter((t): t is NonNullable<typeof t> => Boolean(t));
+
+  return (
+    <article className="mx-auto max-w-3xl px-4 sm:px-6 py-16">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(definedTermLd) }}
+      />
+
+      <Link
+        href="/glossary"
+        className="inline-flex items-center gap-1 text-xs font-bold uppercase text-[var(--text-muted)] hover:text-[var(--accent)] mb-6"
+      >
+        <ArrowLeft size={12} /> Glossary
+      </Link>
+
+      <div
+        className="inline-flex items-center gap-2 px-4 py-1.5 text-xs font-bold uppercase tracking-wide text-[var(--foreground)] mb-6"
+        style={{
+          backgroundColor: "var(--bg-surface)",
+          border: "2px solid var(--border-hard)",
+          boxShadow: "var(--shadow-brutal-sm)",
+        }}
+      >
+        <BookOpen size={14} className="text-[var(--accent)]" />
+        Definition
+      </div>
+
+      <h1 className="text-3xl sm:text-4xl font-extrabold uppercase text-[var(--foreground)] leading-tight mb-6">
+        {term.title}
+      </h1>
+
+      {/* Answer block — the 35-90 word summary lives here so AI engines and
+          humans both get the answer in the first paragraph, not buried below. */}
+      <div
+        className="p-6 sm:p-8 mb-8"
+        style={{
+          backgroundColor: "var(--bg-surface)",
+          border: "2px solid var(--border-hard)",
+          boxShadow: "var(--shadow-brutal)",
+        }}
+      >
+        <p className="text-base text-[var(--foreground)] font-medium leading-relaxed">
+          {term.summary}
+        </p>
+      </div>
+
+      <div className="space-y-5 text-sm sm:text-base text-[var(--text-secondary)] font-medium leading-relaxed">
+        {term.body.map((paragraph, i) => (
+          <p key={i}>{paragraph}</p>
+        ))}
+      </div>
+
+      {related.length > 0 && (
+        <section className="mt-12 pt-8" style={{ borderTop: "2px solid var(--border-hard)" }}>
+          <h2 className="text-lg font-extrabold uppercase text-[var(--foreground)] mb-4">
+            Related terms
+          </h2>
+          <div className="grid sm:grid-cols-2 gap-4">
+            {related.map((r) => (
+              <Link
+                key={r.slug}
+                href={`/glossary/${r.slug}`}
+                className="block p-4 transition-all hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-[2px_2px_0_var(--border-hard)]"
+                style={{
+                  backgroundColor: "var(--bg-surface)",
+                  border: "2px solid var(--border-hard)",
+                  boxShadow: "var(--shadow-brutal-sm)",
+                }}
+              >
+                <h3 className="text-sm font-extrabold uppercase text-[var(--foreground)] mb-1">
+                  {r.shortLabel}
+                </h3>
+                <span className="inline-flex items-center gap-1 text-xs font-bold uppercase text-[var(--accent)]">
+                  Read <ArrowRight size={11} />
+                </span>
+              </Link>
+            ))}
+          </div>
+        </section>
+      )}
+
+      <section className="mt-12 p-6 sm:p-8 text-center"
+        style={{
+          backgroundColor: "var(--bg-inverted)",
+          border: "2px solid var(--border-hard)",
+          boxShadow: "8px 8px 0 var(--accent)",
+        }}
+      >
+        <h2 className="text-xl sm:text-2xl font-extrabold uppercase text-white mb-3">
+          See it in practice
+        </h2>
+        <p className="text-sm text-[var(--text-muted-soft)] font-medium mb-5 max-w-md mx-auto">
+          Browse builders ranked by streak, project quality, and vibe score on the live VibeTalent leaderboard.
+        </p>
+        <Link
+          href="/leaderboard"
+          className="btn-brutal btn-brutal-accent inline-flex items-center gap-2"
+        >
+          View leaderboard <ArrowRight size={14} />
+        </Link>
+      </section>
+    </article>
+  );
+}

--- a/src/app/glossary/page.tsx
+++ b/src/app/glossary/page.tsx
@@ -1,0 +1,112 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { BookOpen, ArrowRight } from "lucide-react";
+import { siteUrl } from "@/lib/seo";
+import { GLOSSARY_TERMS } from "@/lib/glossary";
+
+const PAGE_URL = `${siteUrl}/glossary`;
+const PAGE_TITLE = "VibeTalent Glossary — Vibe Coding, Streaks, Scores Explained";
+const PAGE_DESCRIPTION =
+  "Plain-English definitions of the core VibeTalent concepts: vibe coding, vibe coders, coding streaks, and vibe scores. Built so AI search engines and humans can find the answer in one paragraph.";
+
+export const metadata: Metadata = {
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  alternates: { canonical: PAGE_URL },
+  openGraph: {
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    url: PAGE_URL,
+    siteName: "VibeTalent",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+  },
+};
+
+export default function GlossaryIndexPage() {
+  const breadcrumbLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Home", item: siteUrl },
+      { "@type": "ListItem", position: 2, name: "Glossary", item: PAGE_URL },
+    ],
+  };
+
+  const itemListLd = {
+    "@context": "https://schema.org",
+    "@type": "DefinedTermSet",
+    name: "VibeTalent Glossary",
+    url: PAGE_URL,
+    hasDefinedTerm: GLOSSARY_TERMS.map((t) => ({
+      "@type": "DefinedTerm",
+      "@id": `${siteUrl}/glossary/${t.slug}`,
+      name: t.shortLabel,
+      description: t.summary,
+      url: `${siteUrl}/glossary/${t.slug}`,
+    })),
+  };
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 sm:px-6 py-16">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListLd) }}
+      />
+
+      <div className="mb-12">
+        <div
+          className="inline-flex items-center gap-2 px-4 py-1.5 text-xs font-bold uppercase tracking-wide text-[var(--foreground)] mb-6"
+          style={{
+            backgroundColor: "var(--bg-surface)",
+            border: "2px solid var(--border-hard)",
+            boxShadow: "var(--shadow-brutal-sm)",
+          }}
+        >
+          <BookOpen size={14} className="text-[var(--accent)]" />
+          Glossary
+        </div>
+        <h1 className="text-3xl sm:text-4xl font-extrabold uppercase text-[var(--foreground)] leading-tight">
+          The vocabulary of <span className="text-[var(--accent)]">vibe coding.</span>
+        </h1>
+        <p className="mt-4 text-[var(--text-secondary)] font-medium leading-relaxed max-w-2xl">
+          Core terms used across VibeTalent — vibe coding, vibe coders, coding streaks, and vibe scores —
+          defined in one paragraph each so you can find the answer fast.
+        </p>
+      </div>
+
+      <div className="grid sm:grid-cols-2 gap-4">
+        {GLOSSARY_TERMS.map((term) => (
+          <Link
+            key={term.slug}
+            href={`/glossary/${term.slug}`}
+            className="block p-6 transition-all hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-[2px_2px_0_var(--border-hard)]"
+            style={{
+              backgroundColor: "var(--bg-surface)",
+              border: "2px solid var(--border-hard)",
+              boxShadow: "var(--shadow-brutal)",
+            }}
+          >
+            <h2 className="text-lg font-extrabold uppercase text-[var(--foreground)] mb-2">
+              {term.shortLabel}
+            </h2>
+            <p className="text-sm text-[var(--text-secondary)] font-medium leading-relaxed mb-3 line-clamp-4">
+              {term.summary}
+            </p>
+            <span className="inline-flex items-center gap-1 text-xs font-bold uppercase text-[var(--accent)]">
+              Read definition <ArrowRight size={12} />
+            </span>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -51,6 +51,8 @@ export const metadata: Metadata = {
     title: "VibeTalent — Find Vibe Coders Who Actually Ship",
     description: "The marketplace for vibe coders who ship consistently.",
     images: [`${siteUrl}/og-image-v2.jpg`],
+    site: "@vibetalentwork",
+    creator: "@abhiontwt",
   },
   alternates: {
     canonical: siteUrl,

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -91,6 +91,8 @@ This is the existing USDC-based featuring product. The $VIBE-token-based featuri
 
 - Built by @abhiontwt
 - Website: https://www.vibetalent.work
+- X / Twitter: https://x.com/vibetalentwork
+- Telegram: https://t.me/vibetalentwork
 - GitHub: https://github.com/unknownking07/vibe-talent
 `;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -146,7 +146,9 @@ export default async function HomePage() {
                   contactType: "customer service",
                 },
                 sameAs: [
+                  "https://x.com/vibetalentwork",
                   "https://x.com/abhiontwt",
+                  "https://t.me/vibetalentwork",
                   "https://github.com/unknownking07/vibe-talent",
                 ],
               },
@@ -289,7 +291,7 @@ export default async function HomePage() {
         <div className="mx-auto max-w-7xl px-4 sm:px-6 py-20">
           <div className="grid sm:grid-cols-2 gap-12 items-center">
             <div>
-              <h2 className="text-3xl font-extrabold uppercase text-[var(--foreground)]">Why Streaks Matter</h2>
+              <h2 className="text-3xl font-extrabold uppercase text-[var(--foreground)]">Why do coding streaks matter?</h2>
               <p className="mt-4 text-[var(--text-secondary)] font-medium leading-relaxed">
                 Anyone can build a portfolio in a weekend. But maintaining a 90-day coding streak?
                 That takes real dedication. Streaks prove you are not just talented — you are consistent.
@@ -343,7 +345,7 @@ export default async function HomePage() {
       <section className="mx-auto max-w-7xl px-4 sm:px-6 py-20">
         <div className="flex items-center justify-between mb-8">
           <div>
-            <h2 className="text-3xl font-extrabold uppercase text-[var(--foreground)]">Top Talent</h2>
+            <h2 className="text-3xl font-extrabold uppercase text-[var(--foreground)]">Who are the top vibe coders?</h2>
             <p className="mt-2 text-[var(--text-secondary)] font-medium">The most consistent builders on the platform</p>
           </div>
           <Link
@@ -380,8 +382,8 @@ export default async function HomePage() {
         <div className="mx-auto max-w-7xl px-4 sm:px-6 py-20">
           <div className="flex items-center justify-between mb-8">
             <div>
-              <h2 className="text-3xl font-extrabold uppercase text-[var(--foreground)]">Featured Projects</h2>
-              <p className="mt-2 text-[var(--text-secondary)] font-medium">Built by vibe coders, shipped fast</p>
+              <h2 className="text-3xl font-extrabold uppercase text-[var(--foreground)]">What are vibe coders building?</h2>
+              <p className="mt-2 text-[var(--text-secondary)] font-medium">Featured projects built by vibe coders, shipped fast</p>
             </div>
             <Link
               href="/projects"
@@ -422,7 +424,7 @@ export default async function HomePage() {
       >
         <div className="py-16">
           <div className="mx-auto max-w-7xl px-4 sm:px-6 mb-8">
-            <h2 className="text-3xl font-extrabold uppercase text-[var(--foreground)]">What People Say</h2>
+            <h2 className="text-3xl font-extrabold uppercase text-[var(--foreground)]">What do builders say about VibeTalent?</h2>
             <p className="mt-2 text-[var(--text-secondary)] font-medium">Real feedback from the community on X</p>
           </div>
           <TestimonialScroll />
@@ -463,6 +465,7 @@ export default async function HomePage() {
             __html: JSON.stringify({
               "@context": "https://schema.org",
               "@type": "FAQPage",
+              dateModified: "2026-05-22",
               mainEntity: FAQ_ITEMS.map((faq) => ({
                 "@type": "Question",
                 name: faq.q,

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -133,6 +133,7 @@ export default async function PricingPage() {
   const faqLd = {
     "@context": "https://schema.org",
     "@type": "FAQPage",
+    dateModified: "2026-05-22",
     mainEntity: faq.map(({ q, a }) => ({
       "@type": "Question",
       name: q,

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -26,6 +26,7 @@ export default function robots(): MetadataRoute.Robots {
       { userAgent: "PerplexityBot", allow: "/", disallow: privateDisallow },
       { userAgent: "CCBot", allow: "/", disallow: privateDisallow },
       { userAgent: "OAI-SearchBot", allow: "/", disallow: privateDisallow },
+      { userAgent: "Applebot-Extended", allow: "/", disallow: privateDisallow },
       { userAgent: "Bingbot", allow: "/", disallow: privateDisallow },
     ],
     sitemap: `${siteUrl}/sitemap.xml`,

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from "next";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { siteUrl } from "@/lib/seo";
+import { GLOSSARY_TERMS } from "@/lib/glossary";
 
 // Regenerate hourly. Google polls sitemaps on its own schedule and the
 // per-user `<lastmod>` below already signals freshness to crawlers — no
@@ -19,6 +20,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${siteUrl}/roadmap`, lastModified: new Date("2026-04-23") },
     { url: `${siteUrl}/privacy`, lastModified: new Date("2026-04-06") },
     { url: `${siteUrl}/terms`, lastModified: new Date("2026-04-06") },
+    { url: `${siteUrl}/glossary`, lastModified: new Date("2026-05-22") },
+    ...GLOSSARY_TERMS.map((t) => ({
+      url: `${siteUrl}/glossary/${t.slug}`,
+      lastModified: new Date("2026-05-22"),
+    })),
+    { url: `${siteUrl}/vs/upwork`, lastModified: new Date("2026-05-22") },
   ];
 
   try {

--- a/src/app/vs/upwork/page.tsx
+++ b/src/app/vs/upwork/page.tsx
@@ -1,0 +1,339 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Check, X, ArrowRight, Flame, Zap, Shield } from "lucide-react";
+import { siteUrl } from "@/lib/seo";
+
+const PAGE_URL = `${siteUrl}/vs/upwork`;
+const PAGE_TITLE = "VibeTalent vs Upwork — Which Is Better for Hiring Developers?";
+const PAGE_DESCRIPTION =
+  "VibeTalent ranks developers on verifiable proof of work — coding streaks, shipped projects, and GitHub activity. Upwork relies on resumes and client reviews. Side-by-side comparison, pricing, and which platform fits your hiring needs.";
+
+const TL_DR =
+  "VibeTalent ranks developers on verifiable proof of work — daily coding streaks, deployed projects, and GitHub activity — while Upwork relies on self-reported resumes and client reviews that are easy to game. Pick VibeTalent if you want to hire developers based on what they actually ship, especially AI-native builders using Claude Code, Cursor, or Bolt. Pick Upwork if you need a generalist freelance marketplace with escrow and a broad talent pool across non-engineering roles.";
+
+const FAQ = [
+  {
+    q: "What is the main difference between VibeTalent and Upwork?",
+    a: "Upwork is a generalist freelance marketplace where talent is ranked by self-reported skills, client reviews, and resume-style profiles — all of which can be gamed with paid reviews or polished marketing. VibeTalent is a developer-only marketplace where rankings come from verifiable data: GitHub commit streaks, deployed project quality, repo health, and peer endorsements weighted by the endorser's own vibe score. The data refreshes daily and cannot be faked.",
+  },
+  {
+    q: "Is VibeTalent cheaper than Upwork?",
+    a: "VibeTalent is free for both developers and clients. There is no platform fee on hires and no commission on payments. The only paid feature is optional Featured Projects placement, priced in USDC on Base or Solana with no platform markup. Upwork charges freelancers a 10% service fee and adds a payment processing fee on top of that, plus a 5% client marketplace fee on hires.",
+  },
+  {
+    q: "Can I hire AI-native developers on Upwork?",
+    a: "You can search for developers on Upwork who list AI tools in their skill tags, but there is no way to verify that they actually use those tools daily or ship working software with them. VibeTalent was built specifically for vibe coders — developers who use Claude Code, Cursor, Bolt, and Windsurf to ship code every day — and ranks them on the activity that proves they actually do it.",
+  },
+  {
+    q: "Does Upwork show GitHub data?",
+    a: "Upwork lets freelancers link their GitHub profile, but it does not pull commit history, repo quality, or streak data into rankings. The Upwork search algorithm weights job success score, hours billed, and client reviews. VibeTalent makes GitHub activity the core ranking signal — coding streak length is 40% of the vibe score by itself.",
+  },
+  {
+    q: "How does VibeTalent prevent fake reviews?",
+    a: "VibeTalent does not rely on reviews. Rankings come from public GitHub data — commit streaks, repo statistics, deployment status, and contribution patterns — none of which can be paid for or fabricated. Peer endorsements exist but are weighted at only 10% of the vibe score and weighted by the endorser's own score to make collusion economically unattractive.",
+  },
+  {
+    q: "Is Upwork or VibeTalent better for a one-off project?",
+    a: "Upwork is better for one-off non-engineering projects (design, copywriting, virtual assistance, video editing) or for hiring at large scale with escrow protection. VibeTalent is better for finding a developer who can ship a working product fast — whether that is a one-week prototype or an ongoing build relationship — because the platform surfaces builders proven to ship consistently.",
+  },
+];
+
+const COMPARISON_ROWS: { feature: string; vt: string | boolean; up: string | boolean }[] = [
+  { feature: "Talent type", vt: "AI-native developers", up: "Generalist freelancers" },
+  { feature: "Ranking signal", vt: "GitHub streaks + shipped projects", up: "Resumes + client reviews" },
+  { feature: "Verifiable proof of work", vt: true, up: false },
+  { feature: "GitHub commit streak tracking", vt: true, up: false },
+  { feature: "Project quality scoring from repo health", vt: true, up: false },
+  { feature: "AI-powered hire matching", vt: "VibeFinder Bot", up: "Project catalog search" },
+  { feature: "Platform fee for clients", vt: "0%", up: "5% marketplace fee" },
+  { feature: "Service fee for developers", vt: "0%", up: "10% service fee" },
+  { feature: "Crypto payments (USDC)", vt: true, up: false },
+  { feature: "Escrow protection", vt: false, up: true },
+  { feature: "Non-engineering roles", vt: false, up: true },
+  { feature: "Public daily activity feed", vt: true, up: false },
+];
+
+export const metadata: Metadata = {
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  alternates: { canonical: PAGE_URL },
+  openGraph: {
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    url: PAGE_URL,
+    siteName: "VibeTalent",
+    type: "article",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+  },
+};
+
+export default function VsUpworkPage() {
+  const breadcrumbLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Home", item: siteUrl },
+      { "@type": "ListItem", position: 2, name: "Compare", item: `${siteUrl}/vs` },
+      { "@type": "ListItem", position: 3, name: "VibeTalent vs Upwork", item: PAGE_URL },
+    ],
+  };
+
+  const faqLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    dateModified: "2026-05-22",
+    mainEntity: FAQ.map(({ q, a }) => ({
+      "@type": "Question",
+      name: q,
+      acceptedAnswer: { "@type": "Answer", text: a },
+    })),
+  };
+
+  const articleLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    url: PAGE_URL,
+    mainEntityOfPage: { "@type": "WebPage", "@id": PAGE_URL },
+    dateModified: "2026-05-22",
+    author: { "@type": "Organization", "@id": `${siteUrl}/#organization`, name: "VibeTalent" },
+    publisher: { "@type": "Organization", "@id": `${siteUrl}/#organization`, name: "VibeTalent" },
+    about: [
+      { "@type": "Organization", name: "VibeTalent", url: siteUrl },
+      { "@type": "Organization", name: "Upwork", url: "https://www.upwork.com" },
+    ],
+  };
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 sm:px-6 py-16">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+      />
+
+      <div className="mb-10">
+        <div
+          className="inline-flex items-center gap-2 px-4 py-1.5 text-xs font-bold uppercase tracking-wide text-[var(--foreground)] mb-6"
+          style={{
+            backgroundColor: "var(--bg-surface)",
+            border: "2px solid var(--border-hard)",
+            boxShadow: "var(--shadow-brutal-sm)",
+          }}
+        >
+          <Zap size={14} className="text-[var(--accent)]" />
+          Comparison
+        </div>
+        <h1 className="text-3xl sm:text-5xl font-extrabold uppercase text-[var(--foreground)] leading-tight">
+          VibeTalent <span className="text-[var(--text-muted)]">vs</span>{" "}
+          <span className="text-[var(--accent)]">Upwork</span>
+        </h1>
+        <p className="mt-3 text-[var(--text-secondary)] font-medium">
+          Which platform is better for hiring developers in 2026? A side-by-side breakdown.
+        </p>
+      </div>
+
+      {/* Answer block — the TL;DR sits at the top so AI engines pull it into
+          answer boxes and humans can decide in 10 seconds. */}
+      <section
+        className="p-6 sm:p-8 mb-10"
+        style={{
+          backgroundColor: "var(--bg-surface)",
+          border: "2px solid var(--border-hard)",
+          boxShadow: "var(--shadow-brutal)",
+        }}
+      >
+        <h2 className="text-lg font-extrabold uppercase text-[var(--foreground)] mb-4">
+          The short answer
+        </h2>
+        <p className="text-base text-[var(--foreground)] font-medium leading-relaxed">{TL_DR}</p>
+      </section>
+
+      {/* Feature matrix */}
+      <section className="mb-12">
+        <h2 className="text-2xl font-extrabold uppercase text-[var(--foreground)] mb-6">
+          Side-by-side comparison
+        </h2>
+        <div
+          className="overflow-hidden"
+          style={{
+            backgroundColor: "var(--bg-surface)",
+            border: "2px solid var(--border-hard)",
+            boxShadow: "var(--shadow-brutal)",
+          }}
+        >
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr style={{ borderBottom: "2px solid var(--border-hard)" }}>
+                  <th className="text-left p-4 font-extrabold uppercase text-[var(--foreground)]">
+                    Feature
+                  </th>
+                  <th className="text-left p-4 font-extrabold uppercase text-[var(--accent)]">
+                    VibeTalent
+                  </th>
+                  <th className="text-left p-4 font-extrabold uppercase text-[var(--text-muted)]">
+                    Upwork
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {COMPARISON_ROWS.map((row, i) => (
+                  <tr
+                    key={row.feature}
+                    style={{
+                      borderBottom:
+                        i === COMPARISON_ROWS.length - 1
+                          ? "none"
+                          : "1px solid var(--border-subtle)",
+                    }}
+                  >
+                    <td className="p-4 font-semibold text-[var(--foreground)]">{row.feature}</td>
+                    <td className="p-4 font-medium text-[var(--text-secondary)]">
+                      {typeof row.vt === "boolean" ? (
+                        row.vt ? (
+                          <Check size={18} className="text-[var(--accent)]" />
+                        ) : (
+                          <X size={18} className="text-[var(--text-muted)]" />
+                        )
+                      ) : (
+                        row.vt
+                      )}
+                    </td>
+                    <td className="p-4 font-medium text-[var(--text-secondary)]">
+                      {typeof row.up === "boolean" ? (
+                        row.up ? (
+                          <Check size={18} className="text-[var(--accent)]" />
+                        ) : (
+                          <X size={18} className="text-[var(--text-muted)]" />
+                        )
+                      ) : (
+                        row.up
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid sm:grid-cols-2 gap-6 mb-12">
+        <div
+          className="p-6"
+          style={{
+            backgroundColor: "var(--bg-surface)",
+            border: "2px solid var(--border-hard)",
+            boxShadow: "var(--shadow-brutal)",
+          }}
+        >
+          <div className="flex items-center gap-2 mb-3">
+            <Flame size={20} className="text-[var(--accent)]" />
+            <h2 className="text-lg font-extrabold uppercase text-[var(--foreground)]">
+              When VibeTalent wins
+            </h2>
+          </div>
+          <ul className="space-y-2 text-sm text-[var(--text-secondary)] font-medium">
+            <li>You want to hire AI-native developers using Claude Code, Cursor, or Bolt</li>
+            <li>You care more about shipping evidence than years of experience</li>
+            <li>You want to pay in USDC with no platform fees</li>
+            <li>You need a builder who can prototype and ship in days, not months</li>
+            <li>You are tired of fake five-star reviews and want verifiable signal</li>
+          </ul>
+        </div>
+
+        <div
+          className="p-6"
+          style={{
+            backgroundColor: "var(--bg-surface)",
+            border: "2px solid var(--border-hard)",
+            boxShadow: "var(--shadow-brutal)",
+          }}
+        >
+          <div className="flex items-center gap-2 mb-3">
+            <Shield size={20} className="text-[var(--text-muted)]" />
+            <h2 className="text-lg font-extrabold uppercase text-[var(--foreground)]">
+              When Upwork wins
+            </h2>
+          </div>
+          <ul className="space-y-2 text-sm text-[var(--text-secondary)] font-medium">
+            <li>You need non-engineering roles (design, writing, video, admin)</li>
+            <li>You want built-in escrow and dispute resolution</li>
+            <li>You are hiring at large scale across multiple disciplines</li>
+            <li>You need fiat invoicing and tax documents through the platform</li>
+            <li>Your project is heavily resume-driven (regulated industries, agencies)</li>
+          </ul>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section className="mb-12">
+        <h2 className="text-2xl font-extrabold uppercase text-[var(--foreground)] mb-6">
+          Frequently asked questions
+        </h2>
+        <div className="space-y-3">
+          {FAQ.map(({ q, a }) => (
+            <details
+              key={q}
+              className="group p-5"
+              style={{
+                backgroundColor: "var(--bg-surface)",
+                border: "2px solid var(--border-hard)",
+                boxShadow: "var(--shadow-brutal-sm)",
+              }}
+            >
+              <summary className="cursor-pointer font-extrabold uppercase text-sm text-[var(--foreground)] flex items-center justify-between">
+                {q}
+                <ArrowRight
+                  size={14}
+                  className="text-[var(--accent)] transition-transform group-open:rotate-90"
+                />
+              </summary>
+              <p className="mt-3 text-sm text-[var(--text-secondary)] font-medium leading-relaxed">
+                {a}
+              </p>
+            </details>
+          ))}
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section
+        className="p-8 sm:p-10 text-center"
+        style={{
+          backgroundColor: "var(--bg-inverted)",
+          border: "2px solid var(--border-hard)",
+          boxShadow: "8px 8px 0 var(--accent)",
+        }}
+      >
+        <h2 className="text-2xl sm:text-3xl font-extrabold uppercase text-white mb-3">
+          Hire builders who actually ship
+        </h2>
+        <p className="text-sm text-[var(--text-muted-soft)] font-medium mb-6 max-w-md mx-auto">
+          Browse vibe coders ranked by streak, project quality, and verified GitHub activity.
+        </p>
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <Link href="/explore" className="btn-brutal btn-brutal-accent inline-flex items-center gap-2 justify-center">
+            Explore talent <ArrowRight size={14} />
+          </Link>
+          <Link href="/agent" className="btn-brutal btn-brutal-secondary inline-flex items-center gap-2 justify-center">
+            Try VibeFinder Bot
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/lib/glossary.ts
+++ b/src/lib/glossary.ts
@@ -1,0 +1,83 @@
+// Central glossary content. Each term gets its own URL at /glossary/[slug] so
+// AI answer engines (ChatGPT, Perplexity, Google AI Overviews) can cite a
+// focused, single-topic page instead of scraping the homepage FAQ. The
+// `summary` is the 35-90 word "answer block" we render at the top of every
+// term page and embed in the DefinedTerm JSON-LD — that's what gets pulled
+// into AI answers, so keep it self-contained and free of context dependencies.
+
+export type GlossaryTerm = {
+  slug: string;
+  title: string;
+  shortLabel: string;
+  summary: string;
+  body: string[];
+  related: string[];
+  metaDescription: string;
+};
+
+export const GLOSSARY_TERMS: GlossaryTerm[] = [
+  {
+    slug: "vibe-coding",
+    title: "What is vibe coding?",
+    shortLabel: "Vibe Coding",
+    summary:
+      "Vibe coding is the practice of building software using AI-powered IDEs and coding assistants — tools like Claude Code, Cursor, Bolt, and Windsurf. Instead of following long planning cycles, vibe coders stay in flow state, ship features daily, and let the working product speak louder than documentation. The goal is consistent output: commits every day, projects deployed, and a verifiable track record of shipping.",
+    body: [
+      "Vibe coding describes a shift in how software gets built. Traditional development cycles depend on lengthy specs, sprint planning, code reviews, and approvals before any production code ships. Vibe coding inverts that — the developer stays in a tight loop with an AI assistant, generates working code in minutes instead of hours, and pushes commits the same day. The cadence is measured in daily shipping, not biweekly sprints.",
+      "The philosophy treats AI coding tools as the new primitive. Claude Code, Cursor, Bolt, and Windsurf handle boilerplate, scaffolding, and repetitive logic, freeing the developer to focus on product decisions, architecture, and rapid iteration. The result is that one motivated vibe coder can ship what previously took a full team — but only if they actually do it every day.",
+      "Consistency matters more than raw talent in this model. A vibe coder with a 200-day coding streak is more valuable than one with a polished resume but irregular output, because the streak is verifiable proof of work that cannot be faked. That is why VibeTalent ranks developers on shipping signals — streaks, deployed projects, and repo health — instead of credentials.",
+    ],
+    related: ["vibe-coder", "coding-streak", "vibe-score"],
+    metaDescription:
+      "Vibe coding means building software with AI tools like Claude Code, Cursor, and Bolt — staying in flow, shipping every day, and letting working code be the resume.",
+  },
+  {
+    slug: "vibe-coder",
+    title: "What is a vibe coder?",
+    shortLabel: "Vibe Coder",
+    summary:
+      "A vibe coder is a developer who builds software using AI-powered tools and ships code every single day. The defining traits are speed, consistency, and a public track record of working projects. Rather than relying on credentials or a polished resume, a vibe coder's reputation is verified by their coding streak, deployed projects, and quality of their GitHub activity.",
+    body: [
+      "Vibe coders are the next generation of independent builders. They use AI coding assistants — Claude Code, Cursor, Bolt, Windsurf, GitHub Copilot — as a force multiplier, not a crutch. The output is real, deployed software shipped at a cadence that traditional teams cannot match.",
+      "The most distinctive trait is daily shipping. A vibe coder commits to GitHub every day, deploys updates frequently, and treats their public repos as a living portfolio. This is fundamentally different from a developer with a strong resume but sporadic output — clients can verify a vibe coder's work in seconds by checking their commit history, demo links, and project quality.",
+      "VibeTalent surfaces vibe coders by ranking them on verifiable signals: coding streak length, project shipping rate, repo health (stars, forks, deployment status), and peer endorsements from other vibe coders. The leaderboard rewards builders who show up every day, not those who interview well.",
+    ],
+    related: ["vibe-coding", "coding-streak", "vibe-score"],
+    metaDescription:
+      "A vibe coder is a developer who ships code daily using AI tools and proves their skill through coding streaks, deployed projects, and public GitHub activity.",
+  },
+  {
+    slug: "coding-streak",
+    title: "What is a coding streak?",
+    shortLabel: "Coding Streak",
+    summary:
+      "A coding streak is the number of consecutive days a developer has pushed at least one commit to a public GitHub repository. VibeTalent syncs streaks daily and resets them to zero if a full calendar day (UTC) passes without a commit. Streaks are the single hardest signal to fake — you cannot buy a 200-day streak — which makes them the most reliable proof of a developer's consistency and discipline.",
+    body: [
+      "Coding streaks measure raw consistency. A 30-day streak means 30 consecutive days of commits. A 365-day streak means a developer shipped code every single day for a year — including weekends, holidays, and travel. The longer the streak, the more meaningful the signal.",
+      "VibeTalent tracks streaks automatically from GitHub. Any commit to any public repository counts. The streak resets to zero if a full UTC day passes without a commit, so there is no way to game it short of actually coding every day. Past streak achievements are preserved as permanent badges even if a current streak resets.",
+      "For clients evaluating developers, streak length is often a stronger predictor of delivery reliability than years of experience or interview performance. A long streak demonstrates intrinsic motivation and the kind of sustained discipline that translates directly into project success. That is why VibeTalent weights streak length at 40% of the overall vibe score.",
+    ],
+    related: ["vibe-score", "vibe-coding", "vibe-coder"],
+    metaDescription:
+      "A coding streak counts consecutive days of GitHub commits. VibeTalent tracks streaks daily — they're the most unfakeable proof of a developer's consistency.",
+  },
+  {
+    slug: "vibe-score",
+    title: "What is a vibe score?",
+    shortLabel: "Vibe Score",
+    summary:
+      "A vibe score is VibeTalent's composite reputation metric — a single number that summarizes how consistently and effectively a developer ships code. It combines four weighted inputs: coding streak (40%), project quality based on GitHub repo health (30%), GitHub activity such as commits, PRs, and reviews (20%), and peer endorsements weighted by the endorser's own vibe score (10%).",
+    body: [
+      "The vibe score exists because resumes, LinkedIn profiles, and interview performance are all easy to fake. A vibe score is not. Every input is pulled from verifiable, public data — GitHub commits, repository statistics, and endorsements from other ranked developers — and the formula is transparent.",
+      "The 40/30/20/10 weighting reflects what actually matters for hiring decisions. Streak length is weighted highest because it is the hardest signal to game and the strongest predictor of future delivery. Project quality (deployment status, stars, forks, commit frequency) ranks next because shipped products beat abandoned side projects. GitHub activity covers the broader contribution surface — PRs, code reviews, issues. Peer endorsements add a social-graph layer but are deliberately weighted lightest to prevent collusion.",
+      "Vibe scores update daily as new commits and project changes come in. The score is public on every developer's profile, used to rank the global leaderboard, and consumed by VibeFinder Bot to match clients with builders who fit a project's requirements.",
+    ],
+    related: ["coding-streak", "vibe-coder", "vibe-coding"],
+    metaDescription:
+      "A vibe score is VibeTalent's reputation metric: 40% streak + 30% project quality + 20% GitHub activity + 10% peer endorsements. Updated daily from verifiable data.",
+  },
+];
+
+export function getGlossaryTerm(slug: string): GlossaryTerm | undefined {
+  return GLOSSARY_TERMS.find((t) => t.slug === slug);
+}


### PR DESCRIPTION
## Summary
- Adds `/glossary` (index + 4 term pages) and `/vs/upwork` comparison page — citation-ready content for ChatGPT, Perplexity, and Google AI Overviews. Each page has a 35-90 word answer block at the top and DefinedTerm / Article / FAQPage JSON-LD.
- Strengthens brand-entity signals: `twitter:site=@vibetalentwork`, Organization `sameAs` now lists X + founder X + Telegram + GitHub.
- AEO polish: 4 homepage H2s rephrased as questions, `dateModified` added to FAQPage schemas, `Applebot-Extended` added to robots allowlist, llms.txt route gained X/Telegram contacts.
- Sitemap wired up with all 6 new URLs.

Audit score: 91 → ~96.

## Test plan
- [ ] `pnpm dev` and visit `/glossary`, `/glossary/vibe-coding`, `/vs/upwork` — verify rendering, breadcrumbs, and 4 related-term cards on each term page
- [ ] `curl /sitemap.xml` — confirm glossary URLs + `/vs/upwork` present
- [ ] `curl /robots.txt | grep Applebot-Extended` — verify allowlist entry
- [ ] `curl /llms.txt | grep vibetalentwork` — verify X/Telegram links
- [ ] View source on `/` — confirm `<meta name="twitter:site" content="@vibetalentwork">` and Organization `sameAs` array
- [ ] Paste `/glossary/vibe-coding` URL into [Google Rich Results Test](https://search.google.com/test/rich-results) — confirm DefinedTerm + BreadcrumbList schemas parse
- [ ] Paste `/vs/upwork` URL into Rich Results Test — confirm Article + FAQPage schemas parse

## Next moves (off-site, post-merge)
- Resubmit sitemap in Google Search Console
- Use URL Inspection → Request Indexing on each new page
- Submit to Bing Webmaster Tools (or rely on IndexNow if wired)
- Create Wikidata entry for VibeTalent

🤖 Generated with [Claude Code](https://claude.com/claude-code)