### PR TITLE
perf(leaderboard): instant weekly tab switches + parallel queries

### DIFF
--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -50,21 +50,26 @@ export async function GET(request: NextRequest) {
       if (topUserIds.length === 0) {
         return NextResponse.json(
           { leaderboard: [], range: "week", mode: "active" },
-          { headers: { "Cache-Control": "public, s-maxage=60, stale-while-revalidate=120" } },
+          { headers: { "Cache-Control": "public, max-age=30, s-maxage=60, stale-while-revalidate=120" } },
         );
       }
 
-      const { data: users } = await sb
-        .from("users")
-        .select("id, username, avatar_url, vibe_score, streak")
-        .in("id", topUserIds)
-        .not("username", "is", null);
+      // Top-user details and the full ranking list are independent — run them in parallel.
+      const [usersRes, allRankedRes] = await Promise.all([
+        sb
+          .from("users")
+          .select("id, username, avatar_url, vibe_score, streak")
+          .in("id", topUserIds)
+          .not("username", "is", null),
+        sb
+          .from("users")
+          .select("id")
+          .not("username", "is", null)
+          .order("vibe_score", { ascending: false }),
+      ]);
+      const users = usersRes.data;
+      const allRanked = allRankedRes.data;
 
-      const { data: allRanked } = await sb
-        .from("users")
-        .select("id")
-        .not("username", "is", null)
-        .order("vibe_score", { ascending: false });
       const rankByUserId = new Map<string, number>();
       (allRanked ?? []).forEach((u: { id: string }, i: number) => rankByUserId.set(u.id, i + 1));
 
@@ -81,7 +86,7 @@ export async function GET(request: NextRequest) {
 
       return NextResponse.json(
         { leaderboard: builders, range: "week", mode: "active" },
-        { headers: { "Cache-Control": "public, s-maxage=60, stale-while-revalidate=120" } },
+        { headers: { "Cache-Control": "public, max-age=30, s-maxage=60, stale-while-revalidate=120" } },
       );
     }
 
@@ -115,7 +120,7 @@ export async function GET(request: NextRequest) {
       { leaderboard },
       {
         headers: {
-          "Cache-Control": "public, s-maxage=60, stale-while-revalidate=120",
+          "Cache-Control": "public, max-age=30, s-maxage=60, stale-while-revalidate=120",
         },
       }
     );

--- a/src/components/leaderboard/leaderboard-tabs.tsx
+++ b/src/components/leaderboard/leaderboard-tabs.tsx
@@ -1,14 +1,58 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { WeeklyTab } from "./weekly-tab";
 import { AllTimeTab } from "./all-time-tab";
 import type { UserWithSocials } from "@/lib/types/database";
+import type { ActiveBuilderRowProps } from "./active-builder-row";
 
 type Tab = "week" | "all";
 
+type WeeklyApiRow = {
+  username: string;
+  avatar_url: string | null;
+  currentRank: number;
+  activeDays7d: number;
+  commits7d: number;
+  streak: number;
+  vibeScore: number;
+};
+
 export function LeaderboardTabs({ users }: { users: UserWithSocials[] }) {
   const [tab, setTab] = useState<Tab>("week");
+  const [weeklyRows, setWeeklyRows] = useState<ActiveBuilderRowProps[] | null>(null);
+  const [weeklyError, setWeeklyError] = useState<string | null>(null);
+
+  // Fetch once on mount and keep the data in parent state, so toggling tabs
+  // doesn't unmount/remount the weekly view or re-trigger the fetch.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/leaderboard?range=week&limit=50");
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const json = await res.json();
+        if (cancelled) return;
+        const props: ActiveBuilderRowProps[] = (json.leaderboard ?? []).map(
+          (r: WeeklyApiRow, idx: number) => ({
+            position: idx + 1,
+            username: r.username,
+            avatarUrl: r.avatar_url,
+            currentRank: r.currentRank,
+            activeDays7d: r.activeDays7d,
+            commits7d: r.commits7d,
+            streak: r.streak,
+            vibeScore: r.vibeScore,
+            isCrown: idx === 0,
+          }),
+        );
+        setWeeklyRows(props);
+      } catch (e) {
+        if (!cancelled) setWeeklyError((e as Error).message);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
 
   return (
     <div>
@@ -31,7 +75,7 @@ export function LeaderboardTabs({ users }: { users: UserWithSocials[] }) {
         </button>
       </div>
 
-      {tab === "week" ? <WeeklyTab /> : <AllTimeTab users={users} />}
+      {tab === "week" ? <WeeklyTab rows={weeklyRows} error={weeklyError} /> : <AllTimeTab users={users} />}
     </div>
   );
 }

--- a/src/components/leaderboard/weekly-tab.tsx
+++ b/src/components/leaderboard/weekly-tab.tsx
@@ -1,49 +1,11 @@
-"use client";
-
-import { useEffect, useState } from "react";
 import { ActiveBuilderRow, type ActiveBuilderRowProps } from "./active-builder-row";
 
-export function WeeklyTab() {
-  const [rows, setRows] = useState<ActiveBuilderRowProps[] | null>(null);
-  const [error, setError] = useState<string | null>(null);
+interface Props {
+  rows: ActiveBuilderRowProps[] | null;
+  error: string | null;
+}
 
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const res = await fetch("/api/leaderboard?range=week&limit=50");
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const json = await res.json();
-        if (cancelled) return;
-        const props: ActiveBuilderRowProps[] = (json.leaderboard ?? []).map(
-          (r: {
-            username: string;
-            avatar_url: string | null;
-            currentRank: number;
-            activeDays7d: number;
-            commits7d: number;
-            streak: number;
-            vibeScore: number;
-          }, idx: number) => ({
-            position: idx + 1,
-            username: r.username,
-            avatarUrl: r.avatar_url,
-            currentRank: r.currentRank,
-            activeDays7d: r.activeDays7d,
-            commits7d: r.commits7d,
-            streak: r.streak,
-            vibeScore: r.vibeScore,
-            isCrown: idx === 0,
-          }),
-        );
-        setRows(props);
-      } catch (e) {
-        if (!cancelled) setError((e as Error).message);
-      }
-    })();
-    return () => { cancelled = true; };
-  }, []);
-
+export function WeeklyTab({ rows, error }: Props) {
   if (error) {
     return (
       <div className="text-[13px] text-[var(--status-error-text)] bg-[var(--status-error-bg)] border border-[var(--status-error-border)] p-4 rounded">


### PR DESCRIPTION
## Summary
- **Weekly tab no longer re-fetches on tab switch.** Lifted the fetch + state out of `WeeklyTab` into `LeaderboardTabs`, so toggling between "This week" and "All-time" preserves the data. Subsequent switches are instant.
- **Backend queries 2 + 3 run in parallel.** The top-user details fetch and the global ranking fetch in `/api/leaderboard?range=week` are independent — wrapped them in `Promise.all` to save one Supabase round-trip per request.
- **Browser-side cache.** Added `max-age=30` to `Cache-Control` (previously only `s-maxage` was set, so only the Vercel CDN cached). Quick re-visits within 30s now skip the network entirely.

## Why it was slow
Every time you clicked "This week", `WeeklyTab` was unmounted/remounted (conditional render in the tabs component), and its `useEffect` fired a fresh `fetch()` — there was no client cache and no browser cache header. On the backend, the weekly handler did 3 sequential Supabase round-trips, with one of them being a full `users` table scan to compute global ranks.

## Test plan
- [x] Load `/leaderboard` → "ACTIVE BUILDERS" renders with 50 rows
- [x] Switch to "All-time", back to "This week" — verified only **1** total `/api/leaderboard?range=week` request fired
- [x] Confirmed response header is now `public, max-age=30, s-maxage=60, stale-while-revalidate=120`
- [x] No "Loading…" flicker when switching back to weekly
- [ ] Verify in prod after deploy that p50 backend latency drops on the weekly endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved caching strategy for the weekly leaderboard, reducing load times and server requests.
  * Enhanced data processing for faster leaderboard updates and responses.
  * Optimized cache headers to ensure efficient content delivery.
  * Streamlined data fetching for better overall application performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unknownking07/vibe-talent/pull/196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->