### PR TITLE
feat(privacy): private repo support with opt-in activity sharing

### DIFF
--- a/src/app/api/cron/github-sync/route.ts
+++ b/src/app/api/cron/github-sync/route.ts
@@ -397,6 +397,14 @@ export async function GET(req: NextRequest) {
                 message: message.slice(0, 500),
                 github_url: githubUrl,
                 created_at: event.created_at,
+                // This cron uses GitHub's *public* Events API (no user token),
+                // which by definition never returns private-repo events. So
+                // every row written here is_private=false. If we later add a
+                // user-token-based fetch for private activity, set is_private
+                // from the payload's `public` flag (false ⇒ is_private=true)
+                // and the feed's share-toggle logic in api/feed/route.ts will
+                // pick it up automatically.
+                is_private: false,
               };
             });
 

--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -57,6 +57,23 @@ function truncate(s: string | null, max: number): string | undefined {
   return trimmed.slice(0, max - 1).trimEnd() + "…";
 }
 
+/** Replacement message text for a private-repo event when the owner has
+ *  opted into sharing activity. Intentionally generic — no repo name, no
+ *  commit subject, no clickable URL. Mirrors the helper in homepage-feed.ts. */
+function anonymizePrivateEventMessage(eventType: string | null | undefined): string {
+  switch (eventType) {
+    case "pr":
+      return "opened a pull request in a private repo";
+    case "create":
+      return "made changes in a private repo";
+    case "issue":
+      return "opened an issue in a private repo";
+    case "push":
+    default:
+      return "pushed to a private repo";
+  }
+}
+
 export async function GET(request: NextRequest) {
   const rawLimit = parseInt(request.nextUrl.searchParams.get("limit") || "100");
   const limit = Math.min(Math.max(isNaN(rawLimit) ? 100 : rawLimit, 1), 200);
@@ -86,7 +103,7 @@ export async function GET(request: NextRequest) {
     ] = await Promise.all([
       supabase
         .from("feed_events")
-        .select("id, event_type, repo_name, message, github_url, created_at, user_id")
+        .select("id, event_type, repo_name, message, github_url, created_at, user_id, is_private")
         .order("created_at", { ascending: false })
         .limit(80)
         .then(
@@ -103,6 +120,8 @@ export async function GET(request: NextRequest) {
         .from("projects")
         .select("id, title, description, tech_stack, live_url, github_url, created_at, user_id")
         .eq("flagged", false)
+        // Public feed strips private repos from the projects source.
+        .eq("is_private", false)
         .order("created_at", { ascending: false })
         .limit(30),
       supabase
@@ -112,7 +131,9 @@ export async function GET(request: NextRequest) {
         .limit(50),
       supabase
         .from("project_endorsements")
-        .select("id, created_at, user_id, project_id, projects!inner(id, title, user_id, flagged)")
+        // is_private comes through the inner join so endorsements on private
+        // projects can be filtered out at merge time.
+        .select("id, created_at, user_id, project_id, projects!inner(id, title, user_id, flagged, is_private)")
         .order("created_at", { ascending: false })
         .limit(PER_SOURCE_LIMIT)
         .then(
@@ -169,7 +190,7 @@ export async function GET(request: NextRequest) {
     const usersResult = referencedUserIds.size > 0
       ? await supabase
           .from("users")
-          .select("id, username, display_name, avatar_url, badge_level, streak, github_username")
+          .select("id, username, display_name, avatar_url, badge_level, streak, github_username, share_private_activity")
           .in("id", [...referencedUserIds])
       : { data: [] };
 
@@ -183,6 +204,7 @@ export async function GET(request: NextRequest) {
       badge_level: string;
       streak: number;
       github_verified: boolean;
+      share_private_activity: boolean;
     }>();
     for (const u of (usersResult.data || [])) {
       userMap.set(u.id, {
@@ -192,14 +214,18 @@ export async function GET(request: NextRequest) {
         badge_level: u.badge_level || "none",
         streak: u.streak || 0,
         github_verified: Boolean(u.github_username),
+        share_private_activity: Boolean(u.share_private_activity),
       });
     }
 
-    // 1. GitHub events
+    // 1. GitHub events — private events are dropped unless the owner has
+    // opted in via settings; even then the event is anonymized.
     if (eventsResult.data && !eventsResult.error) {
       for (const event of eventsResult.data) {
         const user = userMap.get(event.user_id);
         if (!user) continue;
+        if (event.is_private && !user.share_private_activity) continue;
+        const isAnonymized = Boolean(event.is_private);
         feed.push({
           id: `event-${event.id}`,
           type: event.event_type || "push",
@@ -210,9 +236,11 @@ export async function GET(request: NextRequest) {
           streak: user.streak,
           github_verified: user.github_verified,
           date: event.created_at,
-          repo_name: event.repo_name,
-          message: event.message,
-          github_url: event.github_url,
+          repo_name: isAnonymized ? undefined : event.repo_name,
+          message: isAnonymized
+            ? anonymizePrivateEventMessage(event.event_type)
+            : event.message,
+          github_url: isAnonymized ? undefined : event.github_url,
         });
       }
     }
@@ -294,6 +322,9 @@ export async function GET(request: NextRequest) {
           ? endorsement.projects[0]
           : endorsement.projects;
         if (!actor || !projectRow || projectRow.flagged) continue;
+        // Private projects never produce endorsement events in the feed,
+        // even if the endorser is willing — the *owner* hasn't shared.
+        if (projectRow.is_private) continue;
         if (endorsement.user_id === projectRow.user_id) continue; // self
         const owner = userMap.get(projectRow.user_id);
         if (!owner) continue;

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -103,7 +103,9 @@ export async function GET(request: NextRequest) {
     }
 
     const userIds = users.map((u: { id: string }) => u.id);
-    const { data: projects } = await sb.from("projects").select("user_id").in("user_id", userIds).eq("flagged", false);
+    // Leaderboard project_count counts public work only — private repos
+    // shouldn't be visible as a number even if they boost the score.
+    const { data: projects } = await sb.from("projects").select("user_id").in("user_id", userIds).eq("flagged", false).eq("is_private", false);
 
     const leaderboard = users.map((user: { id: string; username: string; avatar_url: string | null; vibe_score: number; streak: number; longest_streak: number; badge_level: string }, index: number) => ({
       rank: index + 1,

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -15,11 +15,16 @@ export async function GET(request: NextRequest) {
 
   try {
     const supabase = await createServerSupabaseClient();
+    // Public listing — never expose private repos here, regardless of caller.
+    // (The RLS policy enforces the same constraint for direct Supabase JS
+    // clients, but this endpoint runs server-side and would otherwise need
+    // to rely on RLS, which depends on the session being attached.)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { data, error } = await (supabase as any)
       .from("projects")
-      .select("id, user_id, title, description, tech_stack, live_url, github_url, image_url, build_time, tags, verified, quality_score, quality_metrics, live_url_ok, endorsement_count, created_at")
+      .select("id, user_id, title, description, tech_stack, live_url, github_url, image_url, build_time, tags, verified, quality_score, quality_metrics, live_url_ok, endorsement_count, is_private, created_at")
       .eq("flagged", false)
+      .eq("is_private", false)
       .order("created_at", { ascending: false })
       .limit(100);
 
@@ -95,6 +100,43 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "github_url must be a valid GitHub repo URL" }, { status: 400 });
     }
 
+    // Pull the GitHub OAuth provider token from the current Supabase session so
+    // we can hit the GitHub API as the user. This is what lets a private repo
+    // resolve (with `repo` scope) instead of 404'ing. The token is only present
+    // immediately after sign-in; on stale sessions it's null and we fall back
+    // to unauthenticated probing, which surfaces the same `needs_repo_scope`
+    // CTA via the 404 path.
+    const { data: { session } } = await supabase.auth.getSession();
+    const providerToken = session?.provider_token ?? undefined;
+
+    // If the user pasted a GitHub URL and we can probe it before insert, we
+    // can capture `is_private` and the reconnect signal up front instead of
+    // creating an unverified row that 404s in the background.
+    let isPrivateOnCreate = false;
+    if (normalizedGithubUrl) {
+      const parsed = parseGithubRepoUrl(normalizedGithubUrl);
+      if (parsed) {
+        const probe = await analyzeRepository(parsed.owner, parsed.repo, providerToken);
+        if (probe.success && probe.metrics) {
+          isPrivateOnCreate = probe.metrics.is_private;
+        } else if (probe.errorCode === "needs_repo_scope") {
+          // Block create with an actionable error. The client renders a
+          // "Reconnect GitHub" button that re-runs OAuth with `repo` scope.
+          return NextResponse.json(
+            {
+              error: "This looks like a private repo. Reconnect GitHub to grant private repo access, then try again.",
+              code: "needs_repo_scope",
+            },
+            { status: 403 }
+          );
+        }
+        // Other errors (rate_limited, not_found, network_error) fall through —
+        // the cron backfill will retry analysis, and the project is created
+        // unverified just like before. `is_private` stays false; if it turns
+        // out to be private, the backfill will flip the flag once it succeeds.
+      }
+    }
+
     // Use authenticated user's ID, NOT client-supplied user_id
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { data, error } = await (supabase as any).from("projects").insert({
@@ -106,6 +148,7 @@ export async function POST(request: NextRequest) {
       github_url: normalizedGithubUrl,
       build_time: build_time ? String(build_time).trim().slice(0, 50) : null,
       tags: Array.isArray(tags) ? tags.slice(0, 10).map((t: string) => String(t).trim().slice(0, 30)) : [],
+      is_private: isPrivateOnCreate,
     }).select().single();
 
     if (error) {
@@ -140,7 +183,7 @@ export async function POST(request: NextRequest) {
           try {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const sb = supabase as any;
-            const qualityResult = await analyzeRepository(repoOwner, repoName);
+            const qualityResult = await analyzeRepository(repoOwner, repoName, providerToken);
 
             // If GitHub analysis fails (rate limit, transient API error, etc.)
             // leave the project unverified so the cron backfill can retry it.
@@ -182,6 +225,9 @@ export async function POST(request: NextRequest) {
               quality_score: qualityScore,
               quality_metrics: qualityMetrics,
               live_url_ok,
+              // Re-sync from the full analysis — the create-time probe may
+              // have failed silently while the post-response probe succeeded.
+              is_private: qualityResult.metrics.is_private,
             }).eq("id", data.id);
 
             if (!updateError) {

--- a/src/app/api/projects/verify/route.ts
+++ b/src/app/api/projects/verify/route.ts
@@ -54,6 +54,12 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
+    // GitHub provider token from the current session — required for private
+    // repos. Stale sessions may not have it; we fall back to unauthenticated
+    // requests, which is fine for public repos but will 404 on private.
+    const { data: { session } } = await supabase.auth.getSession();
+    const providerToken = session?.provider_token ?? undefined;
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sb = supabase as any;
 
@@ -140,7 +146,21 @@ export async function POST(request: Request) {
     // Method 1: Owner match
     if (repoOwner.toLowerCase() === githubUsername.toLowerCase()) {
       // Run quality analysis on the repo
-      const qualityResult = await analyzeRepository(repoOwner, repoName);
+      const qualityResult = await analyzeRepository(repoOwner, repoName, providerToken);
+
+      // Private repo + token lacks `repo` scope → ask the user to reconnect
+      // before falling through to the file-based verification path (which
+      // also can't read private repos with the current scope).
+      if (qualityResult.errorCode === "needs_repo_scope") {
+        return NextResponse.json(
+          {
+            verified: false,
+            reason: "Looks like a private repo. Reconnect GitHub to grant private access and try again.",
+            code: "needs_repo_scope",
+          },
+          { status: 200 }
+        );
+      }
       const qualityScore = qualityResult.success ? (qualityResult.metrics?.quality_score ?? 0) : 0;
       const qualityMetrics = (qualityResult.success && qualityResult.metrics)
         ? {
@@ -177,6 +197,7 @@ export async function POST(request: Request) {
           quality_score: qualityScore,
           quality_metrics: qualityMetrics,
           live_url_ok,
+          is_private: qualityResult.metrics?.is_private ?? false,
         })
         .eq("id", project_id);
 
@@ -240,7 +261,7 @@ export async function POST(request: Request) {
           fileContent.includes(user.id)
         ) {
           // Run quality analysis on the repo
-          const qualityResult = await analyzeRepository(repoOwner, repoName);
+          const qualityResult = await analyzeRepository(repoOwner, repoName, providerToken);
           const qualityScore = qualityResult.success ? (qualityResult.metrics?.quality_score ?? 0) : 0;
           const qualityMetrics = (qualityResult.success && qualityResult.metrics)
             ? {
@@ -277,6 +298,7 @@ export async function POST(request: Request) {
               quality_score: qualityScore,
               quality_metrics: qualityMetrics,
               live_url_ok,
+              is_private: qualityResult.metrics?.is_private ?? false,
             })
             .eq("id", project_id);
 

--- a/src/app/api/users/[username]/route.ts
+++ b/src/app/api/users/[username]/route.ts
@@ -29,6 +29,8 @@ export async function GET(
         .select("id, title, description, tech_stack, live_url, github_url, image_url, build_time, tags, verified, created_at")
         .eq("user_id", user.id)
         .eq("flagged", false)
+        // Public API — strip private repos from the projects list.
+        .eq("is_private", false)
         .order("created_at", { ascending: false }),
       sb
         .from("social_links")

--- a/src/app/api/v1/builders/[username]/route.ts
+++ b/src/app/api/v1/builders/[username]/route.ts
@@ -57,6 +57,8 @@ export async function GET(
         )
         .eq("user_id", user.id)
         .eq("flagged", false)
+        // Public API — strip private repos from the projects list.
+        .eq("is_private", false)
         .order("created_at", { ascending: false }),
       (supabase as any)
         .from("social_links")

--- a/src/app/api/v1/builders/route.ts
+++ b/src/app/api/v1/builders/route.ts
@@ -61,6 +61,9 @@ export async function GET(req: NextRequest) {
         .select("user_id")
         .eq("verified", true)
         .eq("flagged", false)
+        // Verified-only public filter shouldn't count private repos —
+        // exposing them via project totals would defeat the whole feature.
+        .eq("is_private", false)
         .order("user_id", { ascending: true })
         .range(0, MAX_VERIFIED_PROJECTS - 1);
       if (verifiedErr) {
@@ -119,7 +122,9 @@ export async function GET(req: NextRequest) {
       .from("projects")
       .select("user_id, tech_stack, verified")
       .in("user_id", userIds)
-      .eq("flagged", false);
+      .eq("flagged", false)
+      // Builder tech-stack aggregation runs over visible work only.
+      .eq("is_private", false);
 
     if (projectsError) {
       console.error("Failed to fetch projects:", projectsError);

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -51,7 +51,10 @@ export default function LoginPage() {
     const supabase = createClient();
     await supabase.auth.signInWithOAuth({
       provider: "github",
-      options: { redirectTo: `${window.location.origin}/auth/callback` },
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback`,
+        scopes: "read:user user:email repo",
+      },
     });
   };
 

--- a/src/app/auth/profile-setup/page.tsx
+++ b/src/app/auth/profile-setup/page.tsx
@@ -64,6 +64,26 @@ export default function ProfileSetupPage() {
   const [verifiedGithubId, setVerifiedGithubId] = useState<number | null>(null);
   const [connectingGithub, setConnectingGithub] = useState(false);
   const [streakLogged, setStreakLogged] = useState(false);
+  // Set when the user pastes a private repo URL but their OAuth token only
+  // has `public_repo` — onboarding renders a "Reconnect GitHub" button next
+  // to the error so they can re-grant scope without leaving the page.
+  const [needsRepoReconnect, setNeedsRepoReconnect] = useState(false);
+  const [reconnectingGithub, setReconnectingGithub] = useState(false);
+
+  async function handleReconnectGithubForRepoScope() {
+    setReconnectingGithub(true);
+    // Routing back to /auth/profile-setup keeps the user in the onboarding
+    // flow after GitHub redirects them home. The form state will reset, but
+    // the project URL they pasted lives in localStorage if we cared to
+    // restore it — for v1, ask them to paste it again.
+    await supabase.auth.signInWithOAuth({
+      provider: "github",
+      options: {
+        redirectTo: `${window.location.origin}/auth/profile-setup`,
+        scopes: "read:user user:email repo",
+      },
+    });
+  }
 
   // Step 1
   const [profile, setProfile] = useState<ProfileData>({
@@ -411,6 +431,16 @@ export default function ProfileSetupPage() {
 
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
+        // Surface the reconnect path explicitly so a denied private-repo
+        // consent doesn't dead-end the onboarding flow.
+        if (data.code === "needs_repo_scope") {
+          setError(
+            (data.error || "Private repo detected.") +
+              " Reconnect GitHub with private-repo access to continue."
+          );
+          setNeedsRepoReconnect(true);
+          return;
+        }
         throw new Error(data.error || "Failed to save project");
       }
 
@@ -496,6 +526,15 @@ export default function ProfileSetupPage() {
       }}
     >
       {error}
+      {needsRepoReconnect && (
+        <button
+          onClick={handleReconnectGithubForRepoScope}
+          disabled={reconnectingGithub}
+          className="ml-2 underline disabled:opacity-50"
+        >
+          {reconnectingGithub ? "Redirecting..." : "Reconnect GitHub"}
+        </button>
+      )}
     </div>
   ) : null;
 

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -67,7 +67,13 @@ export default function SignUpPage() {
     const supabase = createClient();
     await supabase.auth.signInWithOAuth({
       provider: "github",
-      options: { redirectTo: `${window.location.origin}/auth/callback` },
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback`,
+        // `repo` covers both public + private repos so users can verify a
+        // private codebase. GitHub renders this as "Repositories: Public
+        // and private" on the consent screen.
+        scopes: "read:user user:email repo",
+      },
     });
   };
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -521,7 +521,24 @@ export default function DashboardPage() {
   const chatPollRef = useRef<NodeJS.Timeout | null>(null);
   const [badgeCopied, setBadgeCopied] = useState<string | null>(null);
   const [verifyingProjectId, setVerifyingProjectId] = useState<string | null>(null);
-  const [verifyMessage, setVerifyMessage] = useState<{ projectId: string; success: boolean; text: string } | null>(null);
+  const [verifyMessage, setVerifyMessage] = useState<{ projectId: string; success: boolean; text: string; needsReconnect?: boolean } | null>(null);
+  const [reconnectingGithub, setReconnectingGithub] = useState(false);
+
+  // Re-runs GitHub OAuth with the `repo` scope so private repos resolve. Used
+  // when the verify endpoint hits a 404 + token-lacks-scope condition, which
+  // is the signature of existing users whose pre-migration token only carries
+  // `public_repo`.
+  const handleReconnectGithub = async () => {
+    setReconnectingGithub(true);
+    const supabase = createClient();
+    await supabase.auth.signInWithOAuth({
+      provider: "github",
+      options: {
+        redirectTo: `${window.location.origin}/dashboard`,
+        scopes: "read:user user:email repo",
+      },
+    });
+  };
   const [showVerifyGuide, setShowVerifyGuide] = useState(true);
   const [projectImageFile, setProjectImageFile] = useState<File | null>(null);
   const [projectImagePreview, setProjectImagePreview] = useState<string | null>(null);
@@ -589,7 +606,16 @@ export default function DashboardPage() {
         setVerifyMessage({ projectId, success: true, text: data.reason || "Project verified!" });
         await reloadUser();
       } else {
-        setVerifyMessage({ projectId, success: false, text: data.reason || "Verification failed." });
+        // `needs_repo_scope` means GitHub returned 404 while the user's token
+        // doesn't have `repo` — almost always a private repo on a stale
+        // pre-migration session. Surface a one-click reconnect rather than
+        // a generic "verification failed".
+        setVerifyMessage({
+          projectId,
+          success: false,
+          text: data.reason || "Verification failed.",
+          needsReconnect: data.code === "needs_repo_scope",
+        });
       }
     } catch {
       setVerifyMessage({ projectId, success: false, text: "Verification request failed." });
@@ -1590,6 +1616,15 @@ export default function DashboardPage() {
               {verifyMessage && verifyMessage.projectId === project.id && (
                 <div className={`mt-1 px-4 py-1.5 text-[10px] font-bold uppercase ${verifyMessage.success ? "text-green-600" : "text-orange-600"}`}>
                   {verifyMessage.text}
+                  {verifyMessage.needsReconnect && (
+                    <button
+                      onClick={handleReconnectGithub}
+                      disabled={reconnectingGithub}
+                      className="ml-2 underline disabled:opacity-50"
+                    >
+                      {reconnectingGithub ? "Redirecting..." : "Reconnect GitHub"}
+                    </button>
+                  )}
                 </div>
               )}
             </div>

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -1,4 +1,4 @@
-import { fetchUserByUsernameCached, fetchStreakLogsCached } from "@/lib/supabase/server-queries";
+import { fetchUserByUsernameCached, fetchStreakLogsCached, fetchPrivateProjectsForOwner } from "@/lib/supabase/server-queries";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { ProfileSidebar } from "@/components/profile/profile-sidebar";
@@ -184,6 +184,16 @@ export default async function ProfilePage({
     isOwner = authUser?.id === user.id;
   } catch {
     // Not logged in — isOwner stays false
+  }
+
+  // Merge in the owner's private projects so they see their own work with a
+  // 🔒 badge. Non-owners never get here — the cached fetch above already
+  // stripped private projects.
+  if (isOwner) {
+    const privateProjects = await fetchPrivateProjectsForOwner(user.id);
+    if (privateProjects.length > 0) {
+      user.projects = [...privateProjects, ...(user.projects ?? [])];
+    }
   }
 
   return (

--- a/src/app/profile/[username]/projects/page.tsx
+++ b/src/app/profile/[username]/projects/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 import { ArrowLeft } from "lucide-react";
-import { fetchUserByUsernameCached } from "@/lib/supabase/server-queries";
+import { fetchUserByUsernameCached, fetchPrivateProjectsForOwner } from "@/lib/supabase/server-queries";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { ProfileProjectCard } from "@/components/profile/profile-project-card";
 import { siteUrl } from "@/lib/seo";
@@ -98,6 +98,14 @@ export default async function UserProjectsPage({
     isOwner = authUser?.id === user.id;
   } catch {
     // not logged in
+  }
+
+  // Owner sees their private projects merged in with the public ones.
+  if (isOwner) {
+    const privateProjects = await fetchPrivateProjectsForOwner(user.id);
+    if (privateProjects.length > 0) {
+      user.projects = [...privateProjects, ...(user.projects ?? [])];
+    }
   }
 
   const breadcrumbLd = {

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -10,6 +10,7 @@ import { normalizeSocialHandle } from "@/lib/social-handles";
 import { normalizeExternalUrl } from "@/lib/url-normalize";
 import type { UserWithSocials } from "@/lib/types/database";
 import { EmailPreferences } from "@/components/dashboard/email-preferences";
+import { PrivacyPreferences } from "@/components/dashboard/privacy-preferences";
 import {
   Save,
   Camera,
@@ -604,6 +605,11 @@ export default function SettingsPage() {
       {/* Email Notifications */}
       <div className="mb-8">
         <EmailPreferences />
+      </div>
+
+      {/* Private Repo Privacy */}
+      <div className="mb-8">
+        <PrivacyPreferences />
       </div>
 
       {/* Referral */}

--- a/src/components/dashboard/privacy-preferences.tsx
+++ b/src/components/dashboard/privacy-preferences.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Lock, Check } from "lucide-react";
+import { createClient } from "@/lib/supabase/client";
+
+/**
+ * Single-toggle settings card for "Share private repo activity".
+ *
+ * Default OFF. When ON, the user's private-repo events appear in the public
+ * feed as anonymized rows ("pushed to a private repo") — never with the repo
+ * name, URL, or commit message. Quality scores from private repos count
+ * toward the public leaderboard rank regardless of this toggle; the toggle
+ * only gates *feed visibility*, not score.
+ */
+export function PrivacyPreferences() {
+  const [enabled, setEnabled] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const supabase = createClient();
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (cancelled || !user) {
+        setLoading(false);
+        return;
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (supabase as any)
+        .from("users")
+        .select("share_private_activity")
+        .eq("id", user.id)
+        .single()
+        .then(({ data }: { data: { share_private_activity?: boolean } | null }) => {
+          if (cancelled) return;
+          setEnabled(Boolean(data?.share_private_activity));
+          setLoading(false);
+        });
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  const handleToggle = async () => {
+    if (saving) return;
+    const next = !enabled;
+    const previous = enabled;
+    // Optimistic — flip the visual immediately, revert on failure.
+    setEnabled(next);
+    setSaving(true);
+    setSaved(false);
+    try {
+      const supabase = createClient();
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) throw new Error("not signed in");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { error } = await (supabase as any)
+        .from("users")
+        .update({ share_private_activity: next })
+        .eq("id", user.id);
+      if (error) throw error;
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch {
+      setEnabled(previous);
+    }
+    setSaving(false);
+  };
+
+  return (
+    <div
+      className="p-5"
+      style={{
+        backgroundColor: "var(--bg-surface)",
+        border: "2px solid var(--border-hard)",
+        boxShadow: "var(--shadow-brutal)",
+      }}
+    >
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-base font-extrabold uppercase flex items-center gap-2 text-[var(--foreground)]">
+          <Lock size={16} className="text-[var(--accent)]" />
+          Private Repo Privacy
+        </h2>
+        {saved && (
+          <span className="flex items-center gap-1 text-xs font-bold text-emerald-600">
+            <Check size={12} /> Saved
+          </span>
+        )}
+      </div>
+
+      <div
+        className="flex items-start justify-between gap-3 p-3"
+        style={{ border: "1px solid var(--border-subtle)" }}
+      >
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-bold text-[var(--foreground)]">
+            Share private repo activity in the feed
+          </div>
+          <div className="text-xs text-[var(--text-muted)] mt-1 leading-relaxed">
+            When ON, your private-repo activity shows up in the public feed as
+            generic events (e.g. &ldquo;pushed to a private repo&rdquo;). Repo names,
+            URLs, commit messages, and file paths are <strong>never</strong> shared.
+            When OFF (default), private repos stay completely hidden from the
+            feed. Either way, your quality score still counts toward the
+            leaderboard.
+          </div>
+        </div>
+        <button
+          onClick={handleToggle}
+          disabled={saving || loading}
+          className="w-10 h-6 rounded-full relative cursor-pointer transition-colors shrink-0 disabled:opacity-50"
+          style={{
+            backgroundColor: enabled ? "var(--accent)" : "var(--border-subtle)",
+            border: "2px solid var(--border-hard)",
+          }}
+          aria-label="Toggle private repo activity sharing"
+          aria-pressed={enabled}
+        >
+          <span
+            className="absolute top-0.5 w-3.5 h-3.5 rounded-full bg-[var(--bg-surface)] transition-all"
+            style={{
+              left: enabled ? "calc(100% - 18px)" : "2px",
+              border: "1px solid var(--border-hard)",
+            }}
+          />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/profile/profile-project-card.tsx
+++ b/src/components/profile/profile-project-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { ExternalLink, Flag, CheckCircle, Undo2, Github, ShieldCheck } from "lucide-react";
+import { ExternalLink, Flag, CheckCircle, Undo2, Github, ShieldCheck, Lock } from "lucide-react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import type { Project } from "@/lib/types/database";
@@ -43,7 +43,8 @@ export function ProfileProjectCard({ project, verified = false, isOwner = false 
   const [undoing, setUndoing] = useState(false);
   const [expanded, setExpanded] = useState(false);
   const [verifying, setVerifying] = useState(false);
-  const [verifyMessage, setVerifyMessage] = useState<{ success: boolean; text: string } | null>(null);
+  const [verifyMessage, setVerifyMessage] = useState<{ success: boolean; text: string; needsReconnect?: boolean } | null>(null);
+  const [reconnectingGithub, setReconnectingGithub] = useState(false);
   const reportRef = useRef<HTMLDivElement>(null);
   const isLongDescription = (project.description?.length ?? 0) > 280;
 
@@ -62,12 +63,28 @@ export function ProfileProjectCard({ project, verified = false, isOwner = false 
         setVerifyMessage({ success: true, text: data.reason || "Project verified!" });
         router.refresh();
       } else {
-        setVerifyMessage({ success: false, text: data.reason || data.error || "Verification failed." });
+        setVerifyMessage({
+          success: false,
+          text: data.reason || data.error || "Verification failed.",
+          needsReconnect: data.code === "needs_repo_scope",
+        });
       }
     } catch {
       setVerifyMessage({ success: false, text: "Verification request failed." });
     }
     setVerifying(false);
+  }
+
+  async function handleReconnectGithub() {
+    setReconnectingGithub(true);
+    const supabase = createClient();
+    await supabase.auth.signInWithOAuth({
+      provider: "github",
+      options: {
+        redirectTo: `${window.location.origin}${window.location.pathname}`,
+        scopes: "read:user user:email repo",
+      },
+    });
   }
 
   useEffect(() => {
@@ -231,12 +248,21 @@ export function ProfileProjectCard({ project, verified = false, isOwner = false 
         </div>
       </div>
 
-      {(verified || project.quality_score > 0) && (
+      {(verified || project.quality_score > 0 || project.is_private) && (
         <div className="flex items-center gap-2 flex-wrap">
           {verified && (
             <span className="inline-flex items-center gap-1 text-xs font-bold text-green-600" title="Verified owner">
               <CheckCircle size={14} />
               Verified
+            </span>
+          )}
+          {project.is_private && (
+            <span
+              className="inline-flex items-center gap-1 text-xs font-bold text-[var(--text-secondary)]"
+              title="Private repo — only you can see this card. The repo name and URL are hidden from everyone else."
+            >
+              <Lock size={12} />
+              Private
             </span>
           )}
           <QualityScoreBadge project={project} />
@@ -302,6 +328,15 @@ export function ProfileProjectCard({ project, verified = false, isOwner = false 
               role="status"
             >
               {verifyMessage.text}
+              {verifyMessage.needsReconnect && (
+                <button
+                  onClick={handleReconnectGithub}
+                  disabled={reconnectingGithub}
+                  className="ml-2 underline disabled:opacity-50"
+                >
+                  {reconnectingGithub ? "Redirecting..." : "Reconnect GitHub"}
+                </button>
+              )}
             </p>
           )}
         </div>

--- a/src/lib/__tests__/agent-scoring.test.ts
+++ b/src/lib/__tests__/agent-scoring.test.ts
@@ -3,11 +3,12 @@ import { evaluateUser, matchUsers, generateHireMessage } from "../agent-scoring"
 import type { UserWithSocials, Project } from "../types/database";
 import type { TaskRequest } from "../types/agent";
 
-const projectDefaults: Pick<Project, "quality_score" | "quality_metrics" | "live_url_ok" | "endorsement_count"> = {
+const projectDefaults: Pick<Project, "quality_score" | "quality_metrics" | "live_url_ok" | "endorsement_count" | "is_private"> = {
   quality_score: 0,
   quality_metrics: null,
   live_url_ok: null,
   endorsement_count: 0,
+  is_private: false,
 };
 
 function createMockProject(overrides: Partial<Project> = {}): Project {
@@ -44,6 +45,7 @@ function createMockUser(overrides: Partial<UserWithSocials> = {}): UserWithSocia
     streak_freezes_remaining: 2,
     streak_freezes_used: 0,
     referral_count: 0,
+    share_private_activity: false,
     created_at: "2025-01-01T00:00:00Z",
     social_links: {
       id: "sl-1",

--- a/src/lib/__tests__/scoring-baseline.test.ts
+++ b/src/lib/__tests__/scoring-baseline.test.ts
@@ -22,11 +22,12 @@ import {
 import type { UserWithSocials, Project } from "../types/database";
 import type { TaskRequest } from "../types/agent";
 
-const projectDefaults: Pick<Project, "quality_score" | "quality_metrics" | "live_url_ok" | "endorsement_count"> = {
+const projectDefaults: Pick<Project, "quality_score" | "quality_metrics" | "live_url_ok" | "endorsement_count" | "is_private"> = {
   quality_score: 0,
   quality_metrics: null,
   live_url_ok: null,
   endorsement_count: 0,
+  is_private: false,
 };
 
 function mkProject(overrides: Partial<Project> = {}): Project {
@@ -63,6 +64,7 @@ function mkUser(overrides: Partial<UserWithSocials> = {}): UserWithSocials {
     streak_freezes_remaining: 0,
     streak_freezes_used: 0,
     referral_count: 0,
+    share_private_activity: false,
     created_at: "2025-01-01T00:00:00Z",
     social_links: null,
     projects: [],

--- a/src/lib/github-quality.ts
+++ b/src/lib/github-quality.ts
@@ -24,6 +24,8 @@ export interface RepoQualityMetrics {
   last_commit_date: string | null;
   created_at: string | null;
   repo_age_days: number;
+  // GitHub repo visibility — drives privacy gating across the app.
+  is_private: boolean;
 
   // Computed scores (0-100 each)
   community_score: number;
@@ -34,10 +36,32 @@ export interface RepoQualityMetrics {
   quality_score: number;
 }
 
+// Discriminated error codes so callers can branch on what went wrong without
+// brittle string parsing. `needs_repo_scope` is the signal the project-add
+// flow uses to surface the "Reconnect GitHub" CTA — it means the GitHub API
+// returned 404 for a syntactically valid repo URL while the caller's token
+// only carried `public_repo`, which is what existing pre-migration users have.
+export type RepoAnalysisErrorCode =
+  | "not_found"
+  | "rate_limited"
+  | "needs_repo_scope"
+  | "network_error"
+  | "unknown";
+
 export interface RepoAnalysisResult {
   success: boolean;
   metrics: RepoQualityMetrics | null;
   error?: string;
+  errorCode?: RepoAnalysisErrorCode;
+}
+
+// Parse the comma-separated scope list GitHub returns in X-OAuth-Scopes on
+// every authenticated response (including 404s). An empty/missing header
+// means the request was unauthenticated, not that the token has no scopes.
+function parseOAuthScopes(res: Response): string[] | null {
+  const header = res.headers.get("x-oauth-scopes");
+  if (header === null) return null;
+  return header.split(",").map((s) => s.trim()).filter(Boolean);
 }
 
 const GITHUB_API = "https://api.github.com";
@@ -87,7 +111,11 @@ export function parseGithubRepoUrl(
 
 /**
  * Analyze a GitHub repository and return quality metrics.
- * Uses only public API endpoints — no extra OAuth scopes needed.
+ *
+ * Pass the caller's GitHub OAuth `token` to access their private repos. The
+ * `repo` scope is required for private access; with only `public_repo`, the
+ * API returns 404 for private repos and we surface that as `needs_repo_scope`
+ * so the caller can prompt for a re-auth.
  */
 export async function analyzeRepository(
   owner: string,
@@ -104,9 +132,37 @@ export async function analyzeRepository(
     ]);
 
     if (!repoRes.ok) {
-      if (repoRes.status === 404) return { success: false, metrics: null, error: "Repository not found" };
-      if (repoRes.status === 403) return { success: false, metrics: null, error: "GitHub API rate limit exceeded" };
-      return { success: false, metrics: null, error: `GitHub API error: ${repoRes.status}` };
+      if (repoRes.status === 404) {
+        // A 404 from an authenticated request whose token lacks `repo` is the
+        // signature of a private repo the caller could reach if they re-auth.
+        // We can't be certain without a second probe, but it's the only
+        // actionable signal we have and the false-positive case (truly
+        // missing public repo) still surfaces a useful CTA.
+        const scopes = parseOAuthScopes(repoRes);
+        if (token && scopes && !scopes.includes("repo")) {
+          return {
+            success: false,
+            metrics: null,
+            error: "Private repo — reconnect GitHub to grant private access.",
+            errorCode: "needs_repo_scope",
+          };
+        }
+        return { success: false, metrics: null, error: "Repository not found", errorCode: "not_found" };
+      }
+      if (repoRes.status === 403) {
+        return {
+          success: false,
+          metrics: null,
+          error: "GitHub API rate limit exceeded",
+          errorCode: "rate_limited",
+        };
+      }
+      return {
+        success: false,
+        metrics: null,
+        error: `GitHub API error: ${repoRes.status}`,
+        errorCode: "unknown",
+      };
     }
 
     const repoData = await repoRes.json();
@@ -279,6 +335,7 @@ export async function analyzeRepository(
       last_commit_date: lastPush?.toISOString() || null,
       created_at: repoData.created_at || null,
       repo_age_days: repoAgeDays,
+      is_private: Boolean(repoData.private),
       community_score,
       substance_score,
       maintenance_score,
@@ -291,6 +348,7 @@ export async function analyzeRepository(
       success: false,
       metrics: null,
       error: error instanceof Error ? error.message : "Unknown error analyzing repository",
+      errorCode: "network_error",
     };
   }
 }

--- a/src/lib/homepage-feed.ts
+++ b/src/lib/homepage-feed.ts
@@ -68,6 +68,24 @@ function truncate(s: string | null, max: number): string | undefined {
   return trimmed.slice(0, max - 1).trimEnd() + "…";
 }
 
+/** Replacement message text for a private-repo feed event when the owner has
+ *  opted into sharing activity. Intentionally generic — no repo name, no
+ *  commit subject, no file paths. Even the verb is kept fuzzy so commit
+ *  cadence can't be back-derived. */
+function anonymizePrivateEventMessage(eventType: string | null | undefined): string {
+  switch (eventType) {
+    case "pr":
+      return "opened a pull request in a private repo";
+    case "create":
+      return "made changes in a private repo";
+    case "issue":
+      return "opened an issue in a private repo";
+    case "push":
+    default:
+      return "pushed to a private repo";
+  }
+}
+
 function getPublicClient() {
   return createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -125,7 +143,7 @@ async function _fetchFeed(mode: FeedMode): Promise<FeedItem[]> {
     badgeNotificationsResult,
   ] = await Promise.all([
     sb.from("feed_events")
-      .select("id, event_type, repo_name, message, github_url, created_at, user_id")
+      .select("id, event_type, repo_name, message, github_url, created_at, user_id, is_private")
       .order("created_at", { ascending: false })
       .limit(limits.events)
       .then(
@@ -140,6 +158,8 @@ async function _fetchFeed(mode: FeedMode): Promise<FeedItem[]> {
     sb.from("projects")
       .select("id, title, description, tech_stack, live_url, github_url, created_at, user_id")
       .eq("flagged", false)
+      // Projects in the public feed never include private repos.
+      .eq("is_private", false)
       .order("created_at", { ascending: false })
       .limit(limits.projects),
     sb.from("users")
@@ -147,7 +167,10 @@ async function _fetchFeed(mode: FeedMode): Promise<FeedItem[]> {
       .order("created_at", { ascending: false })
       .limit(limits.recent),
     sb.from("project_endorsements")
-      .select("id, created_at, user_id, project_id, projects!inner(id, title, user_id, flagged)")
+      // `is_private` in the inner-join shape lets the renderer drop endorsements
+      // whose target project is private, so an outsider can never infer the
+      // existence of a private repo from an endorsement event.
+      .select("id, created_at, user_id, project_id, projects!inner(id, title, user_id, flagged, is_private)")
       .order("created_at", { ascending: false })
       .limit(limits.endorsements)
       .then(
@@ -201,7 +224,7 @@ async function _fetchFeed(mode: FeedMode): Promise<FeedItem[]> {
   const usersResult = referencedUserIds.size > 0
     ? await sb
         .from("users")
-        .select("id, username, display_name, avatar_url, badge_level, streak, github_username")
+        .select("id, username, display_name, avatar_url, badge_level, streak, github_username, share_private_activity")
         .in("id", [...referencedUserIds])
     : { data: [] };
 
@@ -215,6 +238,7 @@ async function _fetchFeed(mode: FeedMode): Promise<FeedItem[]> {
     badge_level: string;
     streak: number;
     github_verified: boolean;
+    share_private_activity: boolean;
   }>();
   for (const u of (usersResult.data || [])) {
     userMap.set(u.id, {
@@ -224,16 +248,21 @@ async function _fetchFeed(mode: FeedMode): Promise<FeedItem[]> {
       badge_level: u.badge_level || "none",
       streak: u.streak || 0,
       github_verified: Boolean(u.github_username),
+      share_private_activity: Boolean(u.share_private_activity),
     });
   }
 
   const feed: FeedItem[] = [];
 
-  // 1. GitHub events
+  // 1. GitHub events — private events are dropped unless the owner has
+  // opted in via settings; even then, the event is anonymized (no repo
+  // name, no commit message, no clickable URL).
   if (eventsResult.data && !eventsResult.error) {
     for (const event of eventsResult.data) {
       const user = userMap.get(event.user_id);
       if (!user) continue;
+      if (event.is_private && !user.share_private_activity) continue;
+      const isAnonymized = Boolean(event.is_private);
       feed.push({
         id: `event-${event.id}`,
         type: event.event_type || "push",
@@ -244,9 +273,14 @@ async function _fetchFeed(mode: FeedMode): Promise<FeedItem[]> {
         streak: user.streak,
         github_verified: user.github_verified,
         date: event.created_at,
-        repo_name: event.repo_name,
-        message: event.message,
-        github_url: event.github_url,
+        // For anonymized events we drop the repo identity entirely (undefined,
+        // not empty string) so the renderer treats them as if no repo was
+        // attached — same path as events from sources without a repo link.
+        repo_name: isAnonymized ? undefined : event.repo_name,
+        message: isAnonymized
+          ? anonymizePrivateEventMessage(event.event_type)
+          : event.message,
+        github_url: isAnonymized ? undefined : event.github_url,
       });
     }
   }
@@ -312,7 +346,8 @@ async function _fetchFeed(mode: FeedMode): Promise<FeedItem[]> {
     });
   }
 
-  // 5. Endorsements
+  // 5. Endorsements — drop endorsements whose target project is private so
+  // the endorsement event doesn't leak the existence of the repo.
   if (endorsementsResult.data && !endorsementsResult.error) {
     for (const endorsement of endorsementsResult.data) {
       const actor = userMap.get(endorsement.user_id);
@@ -320,6 +355,7 @@ async function _fetchFeed(mode: FeedMode): Promise<FeedItem[]> {
         ? endorsement.projects[0]
         : endorsement.projects;
       if (!actor || !projectRow || projectRow.flagged) continue;
+      if (projectRow.is_private) continue;
       if (endorsement.user_id === projectRow.user_id) continue;
       const owner = userMap.get(projectRow.user_id);
       if (!owner) continue;

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -32,6 +32,7 @@ const mockProjects: Project[] = [
     quality_metrics: null,
     live_url_ok: null,
     endorsement_count: 0,
+    is_private: false,
     created_at: "2026-02-15T00:00:00Z",
   },
   {
@@ -50,6 +51,7 @@ const mockProjects: Project[] = [
     quality_metrics: null,
     live_url_ok: null,
     endorsement_count: 0,
+    is_private: false,
     created_at: "2026-01-20T00:00:00Z",
   },
   {
@@ -68,6 +70,7 @@ const mockProjects: Project[] = [
     quality_metrics: null,
     live_url_ok: null,
     endorsement_count: 0,
+    is_private: false,
     created_at: "2026-03-01T00:00:00Z",
   },
   {
@@ -86,6 +89,7 @@ const mockProjects: Project[] = [
     quality_metrics: null,
     live_url_ok: null,
     endorsement_count: 0,
+    is_private: false,
     created_at: "2026-02-28T00:00:00Z",
   },
   {
@@ -104,6 +108,7 @@ const mockProjects: Project[] = [
     quality_metrics: null,
     live_url_ok: null,
     endorsement_count: 0,
+    is_private: false,
     created_at: "2026-01-10T00:00:00Z",
   },
   {
@@ -122,6 +127,7 @@ const mockProjects: Project[] = [
     quality_metrics: null,
     live_url_ok: null,
     endorsement_count: 0,
+    is_private: false,
     created_at: "2026-02-10T00:00:00Z",
   },
   {
@@ -140,6 +146,7 @@ const mockProjects: Project[] = [
     quality_metrics: null,
     live_url_ok: null,
     endorsement_count: 0,
+    is_private: false,
     created_at: "2026-01-25T00:00:00Z",
   },
   {
@@ -158,6 +165,7 @@ const mockProjects: Project[] = [
     quality_metrics: null,
     live_url_ok: null,
     endorsement_count: 0,
+    is_private: false,
     created_at: "2026-03-05T00:00:00Z",
   },
   {
@@ -176,6 +184,7 @@ const mockProjects: Project[] = [
     quality_metrics: null,
     live_url_ok: null,
     endorsement_count: 0,
+    is_private: false,
     created_at: "2026-02-20T00:00:00Z",
   },
   {
@@ -194,6 +203,7 @@ const mockProjects: Project[] = [
     quality_metrics: null,
     live_url_ok: null,
     endorsement_count: 0,
+    is_private: false,
     created_at: "2026-01-05T00:00:00Z",
   },
   {
@@ -212,6 +222,7 @@ const mockProjects: Project[] = [
     quality_metrics: null,
     live_url_ok: null,
     endorsement_count: 0,
+    is_private: false,
     created_at: "2026-03-10T00:00:00Z",
   },
 ];
@@ -231,6 +242,7 @@ export const mockUsers: UserWithSocials[] = [
     streak_freezes_remaining: 2,
     streak_freezes_used: 0,
     referral_count: 0,
+    share_private_activity: false,
     created_at: "2025-10-01T00:00:00Z",
     social_links: {
       id: "s1",
@@ -257,6 +269,7 @@ export const mockUsers: UserWithSocials[] = [
     streak_freezes_remaining: 2,
     streak_freezes_used: 0,
     referral_count: 0,
+    share_private_activity: false,
     created_at: "2025-11-15T00:00:00Z",
     social_links: {
       id: "s2",
@@ -283,6 +296,7 @@ export const mockUsers: UserWithSocials[] = [
     streak_freezes_remaining: 2,
     streak_freezes_used: 0,
     referral_count: 0,
+    share_private_activity: false,
     created_at: "2025-12-01T00:00:00Z",
     social_links: {
       id: "s3",
@@ -309,6 +323,7 @@ export const mockUsers: UserWithSocials[] = [
     streak_freezes_remaining: 2,
     streak_freezes_used: 0,
     referral_count: 0,
+    share_private_activity: false,
     created_at: "2025-08-15T00:00:00Z",
     social_links: {
       id: "s4",
@@ -335,6 +350,7 @@ export const mockUsers: UserWithSocials[] = [
     streak_freezes_remaining: 2,
     streak_freezes_used: 0,
     referral_count: 0,
+    share_private_activity: false,
     created_at: "2025-03-01T00:00:00Z",
     social_links: {
       id: "s5",
@@ -361,6 +377,7 @@ export const mockUsers: UserWithSocials[] = [
     streak_freezes_remaining: 2,
     streak_freezes_used: 0,
     referral_count: 0,
+    share_private_activity: false,
     created_at: "2026-01-15T00:00:00Z",
     social_links: {
       id: "s6",
@@ -387,6 +404,7 @@ export const mockUsers: UserWithSocials[] = [
     streak_freezes_remaining: 2,
     streak_freezes_used: 0,
     referral_count: 0,
+    share_private_activity: false,
     created_at: "2025-09-20T00:00:00Z",
     social_links: {
       id: "s7",
@@ -413,6 +431,7 @@ export const mockUsers: UserWithSocials[] = [
     streak_freezes_remaining: 2,
     streak_freezes_used: 0,
     referral_count: 0,
+    share_private_activity: false,
     created_at: "2025-05-10T00:00:00Z",
     social_links: {
       id: "s8",
@@ -439,6 +458,7 @@ export const mockUsers: UserWithSocials[] = [
     streak_freezes_remaining: 2,
     streak_freezes_used: 0,
     referral_count: 0,
+    share_private_activity: false,
     created_at: "2026-01-02T00:00:00Z",
     social_links: {
       id: "s9",
@@ -465,6 +485,7 @@ export const mockUsers: UserWithSocials[] = [
     streak_freezes_remaining: 2,
     streak_freezes_used: 0,
     referral_count: 0,
+    share_private_activity: false,
     created_at: "2025-07-01T00:00:00Z",
     social_links: {
       id: "s10",
@@ -491,6 +512,7 @@ export const mockUsers: UserWithSocials[] = [
     streak_freezes_remaining: 2,
     streak_freezes_used: 0,
     referral_count: 0,
+    share_private_activity: false,
     created_at: "2026-02-01T00:00:00Z",
     social_links: {
       id: "s11",
@@ -517,6 +539,7 @@ export const mockUsers: UserWithSocials[] = [
     streak_freezes_remaining: 2,
     streak_freezes_used: 0,
     referral_count: 0,
+    share_private_activity: false,
     created_at: "2025-06-15T00:00:00Z",
     social_links: {
       id: "s12",

--- a/src/lib/supabase/server-queries.ts
+++ b/src/lib/supabase/server-queries.ts
@@ -3,7 +3,7 @@ import { createClient } from "@supabase/supabase-js";
 import type { UserWithSocials } from "@/lib/types/database";
 
 const USER_FIELDS = "id, username, display_name, bio, avatar_url, github_username, vibe_score, streak, longest_streak, badge_level, created_at";
-const PROJECT_FIELDS = "id, user_id, title, description, tech_stack, live_url, github_url, image_url, build_time, tags, verified, quality_score, quality_metrics, endorsement_count, created_at";
+const PROJECT_FIELDS = "id, user_id, title, description, tech_stack, live_url, github_url, image_url, build_time, tags, verified, quality_score, quality_metrics, endorsement_count, is_private, created_at";
 const SOCIAL_FIELDS = "id, user_id, twitter, telegram, github, website, farcaster";
 
 // Cookie-free client for use inside unstable_cache (no auth context needed for public reads)
@@ -33,10 +33,12 @@ async function _fetchAllUsers(): Promise<UserWithSocials[]> {
   const userIds = users.map((u: UserWithSocials) => u.id);
 
   const [{ data: projects }, { data: socialLinks }, { data: latestLogs }] = await Promise.all([
+    // Listings + leaderboard never expose private repos.
     sb
       .from("projects")
       .select(PROJECT_FIELDS)
-      .in("user_id", userIds),
+      .in("user_id", userIds)
+      .eq("is_private", false),
     sb
       .from("social_links")
       .select(SOCIAL_FIELDS)
@@ -89,11 +91,15 @@ async function _fetchUserByUsername(username: string): Promise<UserWithSocials |
   if (!user) return null;
 
   const [{ data: projects }, { data: socialLinks }] = await Promise.all([
+    // Public profile fetch: private repos are excluded here. The profile page
+    // does a separate uncached read for owners so they still see their own
+    // private projects with a 🔒 badge.
     sb
       .from("projects")
       .select(PROJECT_FIELDS)
       .eq("user_id", user.id)
-            .order("created_at", { ascending: false }),
+      .eq("is_private", false)
+      .order("created_at", { ascending: false }),
     sb
       .from("social_links")
       .select(SOCIAL_FIELDS)
@@ -133,9 +139,9 @@ async function _fetchHomepageData() {
 
   const [usersResult, projectsResult, builderCountResult, projectCountResult, streakResult] = await Promise.all([
     sb.from("users").select(USER_FIELDS).not("username", "is", null).order("vibe_score", { ascending: false }).limit(20),
-    sb.from("projects").select(`${PROJECT_FIELDS}, users!projects_user_id_fkey(username)`).not("live_url", "is", null).order("created_at", { ascending: false }).limit(3),
+    sb.from("projects").select(`${PROJECT_FIELDS}, users!projects_user_id_fkey(username)`).not("live_url", "is", null).eq("is_private", false).order("created_at", { ascending: false }).limit(3),
     sb.from("users").select("id", { count: "exact", head: true }).not("username", "is", null),
-    sb.from("projects").select("id", { count: "exact", head: true }),
+    sb.from("projects").select("id", { count: "exact", head: true }).eq("is_private", false),
     sb.from("users").select("streak").not("username", "is", null),
   ]);
 
@@ -162,7 +168,7 @@ async function _fetchHomepageData() {
   if (allUsers && allUsers.length > 0) {
     const allUserIds = allUsers.map((u: { id: string }) => u.id);
     const [{ data: allProjects }, { data: socials }] = await Promise.all([
-      sb.from("projects").select(PROJECT_FIELDS).in("user_id", allUserIds),
+      sb.from("projects").select(PROJECT_FIELDS).in("user_id", allUserIds).eq("is_private", false),
       sb.from("social_links").select(SOCIAL_FIELDS).in("user_id", allUserIds),
     ]);
 
@@ -203,6 +209,7 @@ async function _fetchAllProjects() {
     .from("projects")
     .select(`${PROJECT_FIELDS}, users!projects_user_id_fkey(username, display_name, avatar_url, badge_level)`)
     .eq("flagged", false)
+    .eq("is_private", false)
     .order("created_at", { ascending: false });
 
   if (error) {
@@ -231,6 +238,25 @@ export const fetchUserByUsernameCached = (username: string) =>
     [`user-${username}`],
     { revalidate: 60, tags: [`user-${username}`] }
   )();
+
+/**
+ * Owner-only fetch for a user's private projects. Kept out of the cached
+ * profile fetch so the same cached response can never leak to a non-owner
+ * viewer. Callers must verify the requesting user owns the row before
+ * merging the results into a profile view.
+ */
+export async function fetchPrivateProjectsForOwner(userId: string): Promise<import("@/lib/types/database").Project[]> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const sb = getPublicClient() as any;
+  const { data, error } = await sb
+    .from("projects")
+    .select(PROJECT_FIELDS)
+    .eq("user_id", userId)
+    .eq("is_private", true)
+    .order("created_at", { ascending: false });
+  if (error || !data) return [];
+  return data;
+}
 
 export const fetchStreakLogsCached = (userId: string) =>
   unstable_cache(

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -14,6 +14,7 @@ export interface User {
   streak_freezes_remaining: number;
   streak_freezes_used: number;
   referral_count: number;
+  share_private_activity: boolean;
   created_at: string;
 }
 
@@ -33,6 +34,7 @@ export interface Project {
   quality_metrics: RepoQualityData | null;
   live_url_ok: boolean | null;
   endorsement_count: number;
+  is_private: boolean;
   created_at: string;
 }
 
@@ -188,6 +190,7 @@ export interface Database {
           streak_freezes_remaining?: number;
           streak_freezes_used?: number;
           referral_count?: number;
+          share_private_activity?: boolean;
         };
         Update: Partial<User>;
       };
@@ -201,6 +204,7 @@ export interface Database {
           quality_metrics?: RepoQualityData | null;
           live_url_ok?: boolean | null;
           endorsement_count?: number;
+          is_private?: boolean;
         };
         Update: Partial<Project>;
       };

--- a/supabase/migrations/20260528_private_repo_support.sql
+++ b/supabase/migrations/20260528_private_repo_support.sql
@@ -1,0 +1,89 @@
+-- Migration: Private Repo Support
+--
+-- Lets users add private GitHub repos that stay confidential by default.
+-- Tightens RLS so private projects are invisible to anyone but their owner,
+-- and adds a per-user opt-in toggle for surfacing anonymized private-repo
+-- activity in the live feed.
+--
+-- Columns added:
+--   projects.is_private              — GitHub repo visibility (set from
+--                                       GitHub API repo.private field)
+--   feed_events.is_private           — denormalized from source project, so
+--                                       the public feed query can filter
+--                                       without a join
+--   users.share_private_activity     — opt-in: when true, the user's private-
+--                                       repo feed events appear publicly as
+--                                       "pushed N commits to a private repo"
+--                                       (no repo name, no commit message, no
+--                                       URL). When false (default), private
+--                                       events are hidden entirely.
+--
+-- Privacy guarantees layered top-to-bottom:
+--   1. RLS prevents anon Supabase JS clients from selecting a private
+--      project unless they're the owner. Service-role server code bypasses
+--      RLS, so app-level filters are still required on every public surface.
+--   2. App-level filters on /api/projects GET, /api/feed, profile pages, and
+--      sitemap strip private rows from non-owner responses.
+--   3. Even when share_private_activity is on, the feed renderer rewrites
+--      private events to omit repo_name / message / github_url.
+--
+-- All changes are additive with NOT NULL DEFAULT false — existing rows get
+-- the safe default and no backfill is needed.
+
+-- 1. Projects: visibility flag
+alter table public.projects
+  add column if not exists is_private boolean not null default false;
+
+-- Partial index: only private rows; non-private is the common case so we
+-- don't want a full-table index that mostly stores `false`.
+create index if not exists idx_projects_is_private
+  on public.projects (is_private)
+  where is_private = true;
+
+-- 2. Users: opt-in toggle for sharing private-repo activity in the feed.
+-- Default false — owners must explicitly turn it on in settings.
+alter table public.users
+  add column if not exists share_private_activity boolean not null default false;
+
+-- 3. Feed events: denormalized visibility flag.
+-- Wrapped because feed_events was created out-of-band (no prior migration),
+-- so this migration stays a no-op on environments where the table is missing.
+do $$
+begin
+  if exists (
+    select 1 from information_schema.tables
+    where table_schema = 'public' and table_name = 'feed_events'
+  ) then
+    execute 'alter table public.feed_events
+      add column if not exists is_private boolean not null default false';
+
+    execute 'create index if not exists idx_feed_events_is_private
+      on public.feed_events (is_private)
+      where is_private = true';
+  end if;
+end $$;
+
+-- 4. RLS: replace the blanket "everyone can SELECT" policy on projects with
+-- a private-aware one. Owners always see their own rows; everyone else only
+-- sees non-private rows.
+drop policy if exists "Projects are viewable by everyone" on public.projects;
+
+create policy "Public projects are viewable by everyone"
+  on public.projects for select
+  using (
+    coalesce(is_private, false) = false
+    or auth.uid() = user_id
+  );
+
+-- ROLLBACK (commented; uncomment + run if needed):
+-- drop policy if exists "Public projects are viewable by everyone" on public.projects;
+-- create policy "Projects are viewable by everyone" on public.projects for select using (true);
+-- alter table public.users drop column if exists share_private_activity;
+-- do $$ begin
+--   if exists (select 1 from information_schema.tables where table_schema='public' and table_name='feed_events') then
+--     execute 'drop index if exists idx_feed_events_is_private';
+--     execute 'alter table public.feed_events drop column if exists is_private';
+--   end if;
+-- end $$;
+-- drop index if exists idx_projects_is_private;
+-- alter table public.projects drop column if exists is_private;


### PR DESCRIPTION
## Summary
- Users can add private GitHub repos. They stay confidential by default — never visible to anyone but the owner.
- Private-repo quality scores still count toward the public leaderboard rank.
- Opt-in toggle in Settings shares anonymized private-repo activity in the feed ("pushed to a private repo") — never repo name, URL, or commit messages.
- GitHub OAuth now requests `repo` scope (matches the Bankr-style "Public and private" consent screen).
- Existing users without `repo` scope get a one-click "Reconnect GitHub" CTA when they try to add a private repo.

## How privacy is enforced (layered)

1. **RLS** — `Public projects are viewable by everyone` policy filters on `is_private = false OR auth.uid() = user_id`. Anon Supabase JS clients can't read private rows.
2. **App-level filters** — every public surface adds `.eq("is_private", false)`: profile page, projects API, `/api/v1/builders`, leaderboard, sitemap inputs, feed (projects + endorsements).
3. **Feed anonymization** — even with the share toggle on, the feed renderer strips `repo_name` / `github_url` / commit message and replaces them with a generic "pushed to a private repo" line.

Owner views (their own profile, dashboard) merge private projects back in via a separate uncached fetch with a 🔒 badge.

## ⚠️ Required before merge

Apply the migration to Supabase:
```
supabase/migrations/20260528_private_repo_support.sql
```

It's additive — 3 `boolean NOT NULL DEFAULT false` columns plus one RLS policy swap. The `feed_events` column add is wrapped in a `DO $$ ... $$` block so it's a no-op if that table doesn't exist on a given environment.

## Test plan
- [ ] Apply migration to Supabase (staging first if available)
- [ ] Sign up via GitHub — consent screen shows "Repositories: Public and private"
- [ ] Add a private repo via dashboard — project is created, marked `is_private=true`, quality_score populated
- [ ] Visit your own profile (logged in) — private project shows with 🔒 Private badge
- [ ] Visit your profile in an incognito window — private project is hidden, public projects unchanged
- [ ] Check feed — private repo doesn't appear (share toggle off, default)
- [ ] Settings → toggle "Share private repo activity" ON
- [ ] Push a commit to a private repo, wait for `github-sync` cron (note: events come from GitHub's *public* events API today, so private events won't flow in until a user-token-based fetch is added — the feed plumbing is in place for when it is)
- [ ] As an existing user (token only has `public_repo`), paste a private repo URL → see "Reconnect GitHub" CTA → click → re-OAuth with `repo` scope → verify succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Private repository support with granular privacy controls
  * New user privacy setting to control sharing of private activity in feeds
  * GitHub reconnect flow to request expanded permissions during project creation and verification
  * Private projects filtered from public feeds and leaderboards
  * Project owners can view their private projects on profile pages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unknownking07/vibe-talent/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->