### PR TITLE
fix(privacy): resolve CodeRabbit findings on private repo support

### DIFF
--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import { feedLimiter, checkRateLimit, getIP } from "@/lib/rate-limit";
 import type { FeedItem, BadgeTier } from "@/components/feed/feed-types";
+import { anonymizePrivateEventMessage } from "@/lib/feed-utils";
 
 function getPublicClient() {
   return createClient(
@@ -57,22 +58,6 @@ function truncate(s: string | null, max: number): string | undefined {
   return trimmed.slice(0, max - 1).trimEnd() + "…";
 }
 
-/** Replacement message text for a private-repo event when the owner has
- *  opted into sharing activity. Intentionally generic — no repo name, no
- *  commit subject, no clickable URL. Mirrors the helper in homepage-feed.ts. */
-function anonymizePrivateEventMessage(eventType: string | null | undefined): string {
-  switch (eventType) {
-    case "pr":
-      return "opened a pull request in a private repo";
-    case "create":
-      return "made changes in a private repo";
-    case "issue":
-      return "opened an issue in a private repo";
-    case "push":
-    default:
-      return "pushed to a private repo";
-  }
-}
 
 export async function GET(request: NextRequest) {
   const rawLimit = parseInt(request.nextUrl.searchParams.get("limit") || "100");

--- a/src/app/auth/profile-setup/page.tsx
+++ b/src/app/auth/profile-setup/page.tsx
@@ -72,6 +72,10 @@ export default function ProfileSetupPage() {
 
   async function handleReconnectGithubForRepoScope() {
     setReconnectingGithub(true);
+    // Create the client inside the handler (self-contained, matches the
+    // reconnect handlers in dashboard/page.tsx and profile-project-card.tsx)
+    // rather than reaching for the component-scope instance defined later.
+    const supabase = createClient();
     // Routing back to /auth/profile-setup keeps the user in the onboarding
     // flow after GitHub redirects them home. The form state will reset, but
     // the project URL they pasted lives in localStorage if we cared to

--- a/src/components/dashboard/privacy-preferences.tsx
+++ b/src/components/dashboard/privacy-preferences.tsx
@@ -18,6 +18,7 @@ export function PrivacyPreferences() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
+  const [error, setError] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -50,20 +51,24 @@ export function PrivacyPreferences() {
     setEnabled(next);
     setSaving(true);
     setSaved(false);
+    setError(false);
     try {
       const supabase = createClient();
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) throw new Error("not signed in");
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { error } = await (supabase as any)
+      const { error: updateError } = await (supabase as any)
         .from("users")
         .update({ share_private_activity: next })
         .eq("id", user.id);
-      if (error) throw error;
+      if (updateError) throw updateError;
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
     } catch {
+      // Revert the optimistic flip and tell the user it didn't stick.
       setEnabled(previous);
+      setError(true);
+      setTimeout(() => setError(false), 4000);
     }
     setSaving(false);
   };
@@ -85,6 +90,11 @@ export function PrivacyPreferences() {
         {saved && (
           <span className="flex items-center gap-1 text-xs font-bold text-emerald-600">
             <Check size={12} /> Saved
+          </span>
+        )}
+        {error && (
+          <span className="text-xs font-bold text-red-500" role="status">
+            Couldn&apos;t save — try again
           </span>
         )}
       </div>
@@ -115,7 +125,8 @@ export function PrivacyPreferences() {
             border: "2px solid var(--border-hard)",
           }}
           aria-label="Toggle private repo activity sharing"
-          aria-pressed={enabled}
+          role="switch"
+          aria-checked={enabled}
         >
           <span
             className="absolute top-0.5 w-3.5 h-3.5 rounded-full bg-[var(--bg-surface)] transition-all"

--- a/src/lib/__tests__/feed-utils.test.ts
+++ b/src/lib/__tests__/feed-utils.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Tests for feed anonymization helpers.
+ *
+ * anonymizePrivateEventMessage is privacy-critical: it's the text shown in
+ * the public feed for a private-repo event when the owner has opted into
+ * sharing. These tests lock the mapping so a future edit can't accidentally
+ * leak a repo name / commit subject through the message, or change the copy
+ * silently.
+ */
+import { describe, it, expect } from "vitest";
+import { anonymizePrivateEventMessage } from "../feed-utils";
+
+describe("anonymizePrivateEventMessage", () => {
+  it("maps each known event type to a generic private-repo message", () => {
+    expect(anonymizePrivateEventMessage("pr")).toBe(
+      "opened a pull request in a private repo"
+    );
+    expect(anonymizePrivateEventMessage("create")).toBe(
+      "made changes in a private repo"
+    );
+    expect(anonymizePrivateEventMessage("issue")).toBe(
+      "opened an issue in a private repo"
+    );
+    expect(anonymizePrivateEventMessage("push")).toBe("pushed to a private repo");
+  });
+
+  it("falls back to the push message for null/undefined/unknown types", () => {
+    expect(anonymizePrivateEventMessage(null)).toBe("pushed to a private repo");
+    expect(anonymizePrivateEventMessage(undefined)).toBe(
+      "pushed to a private repo"
+    );
+    expect(anonymizePrivateEventMessage("something_unexpected")).toBe(
+      "pushed to a private repo"
+    );
+  });
+
+  it("never echoes back the input (no repo/commit data can leak through)", () => {
+    const secret = "my-secret-private-repo-name";
+    expect(anonymizePrivateEventMessage(secret)).not.toContain(secret);
+  });
+});

--- a/src/lib/feed-utils.ts
+++ b/src/lib/feed-utils.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared helpers for the Live Network Feed, used by both the server-side
+ * fetcher (`homepage-feed.ts`) and the client-polled API route
+ * (`api/feed/route.ts`). Keeping these in one place guarantees the homepage
+ * feed and the /feed page anonymize private activity identically.
+ */
+
+/**
+ * Replacement message text for a private-repo feed event when the owner has
+ * opted into sharing activity. Intentionally generic — no repo name, no
+ * commit subject, no file paths, no clickable URL. Even the verb is kept
+ * fuzzy so commit cadence can't be back-derived.
+ */
+export function anonymizePrivateEventMessage(
+  eventType: string | null | undefined
+): string {
+  switch (eventType) {
+    case "pr":
+      return "opened a pull request in a private repo";
+    case "create":
+      return "made changes in a private repo";
+    case "issue":
+      return "opened an issue in a private repo";
+    case "push":
+    default:
+      return "pushed to a private repo";
+  }
+}

--- a/src/lib/homepage-feed.ts
+++ b/src/lib/homepage-feed.ts
@@ -24,6 +24,7 @@
 import { unstable_cache } from "next/cache";
 import { createClient } from "@supabase/supabase-js";
 import type { FeedItem, BadgeTier } from "@/components/feed/feed-types";
+import { anonymizePrivateEventMessage } from "@/lib/feed-utils";
 
 /** Re-export under the legacy name so existing callers keep compiling.
  *  New code should import `FeedItem` from `@/components/feed/feed-types`. */
@@ -68,23 +69,6 @@ function truncate(s: string | null, max: number): string | undefined {
   return trimmed.slice(0, max - 1).trimEnd() + "…";
 }
 
-/** Replacement message text for a private-repo feed event when the owner has
- *  opted into sharing activity. Intentionally generic — no repo name, no
- *  commit subject, no file paths. Even the verb is kept fuzzy so commit
- *  cadence can't be back-derived. */
-function anonymizePrivateEventMessage(eventType: string | null | undefined): string {
-  switch (eventType) {
-    case "pr":
-      return "opened a pull request in a private repo";
-    case "create":
-      return "made changes in a private repo";
-    case "issue":
-      return "opened an issue in a private repo";
-    case "push":
-    default:
-      return "pushed to a private repo";
-  }
-}
 
 function getPublicClient() {
   return createClient(

--- a/src/lib/supabase/server-queries.ts
+++ b/src/lib/supabase/server-queries.ts
@@ -255,8 +255,10 @@ export const fetchUserByUsernameCached = (username: string) =>
  * in unstable_cache (cookies() isn't allowed there).
  */
 export async function fetchPrivateProjectsForOwner(userId: string): Promise<import("@/lib/types/database").Project[]> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const sb = (await createServerSupabaseClient()) as any;
+  // Keep the generic SupabaseClient<Database> typing from
+  // createServerSupabaseClient — no `as any` cast — so the projects query is
+  // type-checked against the schema.
+  const sb = await createServerSupabaseClient();
   const { data, error } = await sb
     .from("projects")
     .select(PROJECT_FIELDS)
@@ -264,7 +266,7 @@ export async function fetchPrivateProjectsForOwner(userId: string): Promise<impo
     .eq("is_private", true)
     .order("created_at", { ascending: false });
   if (error || !data) return [];
-  return data;
+  return data as unknown as import("@/lib/types/database").Project[];
 }
 
 export const fetchStreakLogsCached = (userId: string) =>

--- a/src/lib/supabase/server-queries.ts
+++ b/src/lib/supabase/server-queries.ts
@@ -1,5 +1,6 @@
 import { unstable_cache } from "next/cache";
 import { createClient } from "@supabase/supabase-js";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
 import type { UserWithSocials } from "@/lib/types/database";
 
 const USER_FIELDS = "id, username, display_name, bio, avatar_url, github_username, vibe_score, streak, longest_streak, badge_level, created_at";
@@ -244,10 +245,18 @@ export const fetchUserByUsernameCached = (username: string) =>
  * profile fetch so the same cached response can never leak to a non-owner
  * viewer. Callers must verify the requesting user owns the row before
  * merging the results into a profile view.
+ *
+ * Uses the cookie-aware server client (NOT the anon getPublicClient) on
+ * purpose: the projects RLS policy only returns private rows when
+ * `auth.uid() = user_id`, and that predicate is null under the anon key —
+ * so an anon client would always return [] here and silently hide the
+ * owner's own private projects. The authenticated client carries the
+ * owner's session JWT so RLS matches. This is also why it can't be wrapped
+ * in unstable_cache (cookies() isn't allowed there).
  */
 export async function fetchPrivateProjectsForOwner(userId: string): Promise<import("@/lib/types/database").Project[]> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const sb = getPublicClient() as any;
+  const sb = (await createServerSupabaseClient()) as any;
   const { data, error } = await sb
     .from("projects")
     .select(PROJECT_FIELDS)


### PR DESCRIPTION
Follow-up to #197. Addresses all CodeRabbit review findings.

## Fixes

**🔴 Real bug — owner couldn't see their own private projects** (`server-queries.ts`)
`fetchPrivateProjectsForOwner` used the cookie-free anon client, but the projects RLS policy only returns private rows when `auth.uid() = user_id`. Under the anon key `auth.uid()` is null, so the owner-only view of private projects silently returned `[]` every time — the advertised "owner sees their own private projects with a 🔒 badge" was broken. Now uses the cookie-aware `createServerSupabaseClient()` so the request carries the owner's session JWT and RLS matches.

**🟠 Dedup feed helper** (`feed-utils.ts`, `api/feed/route.ts`, `homepage-feed.ts`)
`anonymizePrivateEventMessage` was duplicated verbatim in two files. Extracted to `src/lib/feed-utils.ts` and imported in both so the homepage feed and `/feed` API can never drift in how they scrub private activity.

**🧹 Privacy toggle UX + a11y** (`privacy-preferences.tsx`)
- Show an inline "Couldn't save — try again" message on update failure instead of silently reverting.
- Use `role="switch"` + `aria-checked` instead of `aria-pressed` for correct toggle semantics.

**🧹 Consistency** (`profile-setup/page.tsx`)
Create the Supabase client inside the reconnect handler (matches the dashboard + profile-card reconnect handlers) rather than reaching for the component-scope instance defined later.

## Verification
- `tsc --noEmit`: clean
- `eslint src`: clean
- `npm test`: 249 passed
- `next build`: ✓ Compiled successfully

No schema changes. No migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Privacy preferences toggle now displays error messages when save operations fail, with automatic retry capability.

* **Bug Fixes**
  * Improved private project access by using authenticated server-side queries instead of public client access.

* **Accessibility**
  * Enhanced privacy preferences toggle with improved accessibility attributes and switch role declarations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unknownking07/vibe-talent/pull/198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->