### PR TITLE
fix(auth): drop GitHub repo scope — public-only OAuth (no scary consent screen)

### DIFF
--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -100,18 +100,18 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "github_url must be a valid GitHub repo URL" }, { status: 400 });
     }
 
-    // Pull the GitHub OAuth provider token from the current Supabase session so
-    // we can hit the GitHub API as the user. This is what lets a private repo
-    // resolve (with `repo` scope) instead of 404'ing. The token is only present
-    // immediately after sign-in; on stale sessions it's null and we fall back
-    // to unauthenticated probing, which surfaces the same `needs_repo_scope`
-    // CTA via the 404 path.
+    // Pull the GitHub OAuth provider token from the current Supabase session
+    // (present briefly right after sign-in) to read repo metadata as the user
+    // and avoid unauthenticated rate limits. We only ever READ — never write.
     const { data: { session } } = await supabase.auth.getSession();
     const providerToken = session?.provider_token ?? undefined;
 
-    // If the user pasted a GitHub URL and we can probe it before insert, we
-    // can capture `is_private` and the reconnect signal up front instead of
-    // creating an unverified row that 404s in the background.
+    // Probe the repo before insert so we capture is_private up front. Note:
+    // private repos aren't supported yet — our OAuth is public-only (GitHub
+    // OAuth Apps can't grant read-only private access; the `repo` scope is
+    // read+write+admin, which we won't ask users for). Read-only private
+    // support is coming via a fine-grained GitHub App. Until then, a private
+    // repo is detected here and rejected with a clear message.
     let isPrivateOnCreate = false;
     if (normalizedGithubUrl) {
       const parsed = parseGithubRepoUrl(normalizedGithubUrl);
@@ -120,14 +120,15 @@ export async function POST(request: NextRequest) {
         if (probe.success && probe.metrics) {
           isPrivateOnCreate = probe.metrics.is_private;
         } else if (probe.errorCode === "needs_repo_scope") {
-          // Block create with an actionable error. The client renders a
-          // "Reconnect GitHub" button that re-runs OAuth with `repo` scope.
+          // We could see this is a private repo (token had public-only scope).
+          // Don't create a misleading "public" row — reject with an honest,
+          // non-actionable message (there's no scope for the user to grant).
           return NextResponse.json(
             {
-              error: "This looks like a private repo. Reconnect GitHub to grant private repo access, then try again.",
-              code: "needs_repo_scope",
+              error: "Private repositories aren't supported yet — support is coming soon. Add a public repo or a live URL for now.",
+              code: "private_unsupported",
             },
-            { status: 403 }
+            { status: 400 }
           );
         }
         // Other errors (rate_limited, not_found, network_error) fall through —

--- a/src/app/api/projects/verify/route.ts
+++ b/src/app/api/projects/verify/route.ts
@@ -148,15 +148,16 @@ export async function POST(request: Request) {
       // Run quality analysis on the repo
       const qualityResult = await analyzeRepository(repoOwner, repoName, providerToken);
 
-      // Private repo + token lacks `repo` scope → ask the user to reconnect
-      // before falling through to the file-based verification path (which
-      // also can't read private repos with the current scope).
+      // Detected a private repo (our public-only OAuth can't read it). Private
+      // repos aren't supported yet — read-only support is coming via a GitHub
+      // App. Give an honest message rather than prompting a scope grant that
+      // doesn't exist for OAuth Apps.
       if (qualityResult.errorCode === "needs_repo_scope") {
         return NextResponse.json(
           {
             verified: false,
-            reason: "Looks like a private repo. Reconnect GitHub to grant private access and try again.",
-            code: "needs_repo_scope",
+            reason: "Private repositories aren't supported yet — support is coming soon. Public repos verify automatically.",
+            code: "private_unsupported",
           },
           { status: 200 }
         );

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -49,12 +49,12 @@ export default function LoginPage() {
 
   const handleGitHubLogin = async () => {
     const supabase = createClient();
+    // Public-only OAuth (Supabase default). See the note in signup/page.tsx:
+    // we intentionally don't request `repo` — read-only private access will
+    // come from a GitHub App, not the all-or-nothing OAuth `repo` scope.
     await supabase.auth.signInWithOAuth({
       provider: "github",
-      options: {
-        redirectTo: `${window.location.origin}/auth/callback`,
-        scopes: "read:user user:email repo",
-      },
+      options: { redirectTo: `${window.location.origin}/auth/callback` },
     });
   };
 

--- a/src/app/auth/profile-setup/page.tsx
+++ b/src/app/auth/profile-setup/page.tsx
@@ -64,30 +64,6 @@ export default function ProfileSetupPage() {
   const [verifiedGithubId, setVerifiedGithubId] = useState<number | null>(null);
   const [connectingGithub, setConnectingGithub] = useState(false);
   const [streakLogged, setStreakLogged] = useState(false);
-  // Set when the user pastes a private repo URL but their OAuth token only
-  // has `public_repo` — onboarding renders a "Reconnect GitHub" button next
-  // to the error so they can re-grant scope without leaving the page.
-  const [needsRepoReconnect, setNeedsRepoReconnect] = useState(false);
-  const [reconnectingGithub, setReconnectingGithub] = useState(false);
-
-  async function handleReconnectGithubForRepoScope() {
-    setReconnectingGithub(true);
-    // Create the client inside the handler (self-contained, matches the
-    // reconnect handlers in dashboard/page.tsx and profile-project-card.tsx)
-    // rather than reaching for the component-scope instance defined later.
-    const supabase = createClient();
-    // Routing back to /auth/profile-setup keeps the user in the onboarding
-    // flow after GitHub redirects them home. The form state will reset, but
-    // the project URL they pasted lives in localStorage if we cared to
-    // restore it — for v1, ask them to paste it again.
-    await supabase.auth.signInWithOAuth({
-      provider: "github",
-      options: {
-        redirectTo: `${window.location.origin}/auth/profile-setup`,
-        scopes: "read:user user:email repo",
-      },
-    });
-  }
 
   // Step 1
   const [profile, setProfile] = useState<ProfileData>({
@@ -435,16 +411,6 @@ export default function ProfileSetupPage() {
 
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
-        // Surface the reconnect path explicitly so a denied private-repo
-        // consent doesn't dead-end the onboarding flow.
-        if (data.code === "needs_repo_scope") {
-          setError(
-            (data.error || "Private repo detected.") +
-              " Reconnect GitHub with private-repo access to continue."
-          );
-          setNeedsRepoReconnect(true);
-          return;
-        }
         throw new Error(data.error || "Failed to save project");
       }
 
@@ -530,15 +496,6 @@ export default function ProfileSetupPage() {
       }}
     >
       {error}
-      {needsRepoReconnect && (
-        <button
-          onClick={handleReconnectGithubForRepoScope}
-          disabled={reconnectingGithub}
-          className="ml-2 underline disabled:opacity-50"
-        >
-          {reconnectingGithub ? "Redirecting..." : "Reconnect GitHub"}
-        </button>
-      )}
     </div>
   ) : null;
 

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -65,15 +65,15 @@ export default function SignUpPage() {
 
   const handleGitHubSignUp = async () => {
     const supabase = createClient();
+    // Public-only OAuth (Supabase default scope). We deliberately do NOT
+    // request the `repo` scope: GitHub OAuth Apps can't grant read-only
+    // private access — `repo` is read+write+admin, which is more than we
+    // need (we only ever read repo metadata) and scares users off. Read-only
+    // private-repo support is coming via a GitHub App with fine-grained
+    // permissions instead.
     await supabase.auth.signInWithOAuth({
       provider: "github",
-      options: {
-        redirectTo: `${window.location.origin}/auth/callback`,
-        // `repo` covers both public + private repos so users can verify a
-        // private codebase. GitHub renders this as "Repositories: Public
-        // and private" on the consent screen.
-        scopes: "read:user user:email repo",
-      },
+      options: { redirectTo: `${window.location.origin}/auth/callback` },
     });
   };
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -521,24 +521,7 @@ export default function DashboardPage() {
   const chatPollRef = useRef<NodeJS.Timeout | null>(null);
   const [badgeCopied, setBadgeCopied] = useState<string | null>(null);
   const [verifyingProjectId, setVerifyingProjectId] = useState<string | null>(null);
-  const [verifyMessage, setVerifyMessage] = useState<{ projectId: string; success: boolean; text: string; needsReconnect?: boolean } | null>(null);
-  const [reconnectingGithub, setReconnectingGithub] = useState(false);
-
-  // Re-runs GitHub OAuth with the `repo` scope so private repos resolve. Used
-  // when the verify endpoint hits a 404 + token-lacks-scope condition, which
-  // is the signature of existing users whose pre-migration token only carries
-  // `public_repo`.
-  const handleReconnectGithub = async () => {
-    setReconnectingGithub(true);
-    const supabase = createClient();
-    await supabase.auth.signInWithOAuth({
-      provider: "github",
-      options: {
-        redirectTo: `${window.location.origin}/dashboard`,
-        scopes: "read:user user:email repo",
-      },
-    });
-  };
+  const [verifyMessage, setVerifyMessage] = useState<{ projectId: string; success: boolean; text: string } | null>(null);
   const [showVerifyGuide, setShowVerifyGuide] = useState(true);
   const [projectImageFile, setProjectImageFile] = useState<File | null>(null);
   const [projectImagePreview, setProjectImagePreview] = useState<string | null>(null);
@@ -606,15 +589,10 @@ export default function DashboardPage() {
         setVerifyMessage({ projectId, success: true, text: data.reason || "Project verified!" });
         await reloadUser();
       } else {
-        // `needs_repo_scope` means GitHub returned 404 while the user's token
-        // doesn't have `repo` — almost always a private repo on a stale
-        // pre-migration session. Surface a one-click reconnect rather than
-        // a generic "verification failed".
         setVerifyMessage({
           projectId,
           success: false,
           text: data.reason || "Verification failed.",
-          needsReconnect: data.code === "needs_repo_scope",
         });
       }
     } catch {
@@ -1616,15 +1594,6 @@ export default function DashboardPage() {
               {verifyMessage && verifyMessage.projectId === project.id && (
                 <div className={`mt-1 px-4 py-1.5 text-[10px] font-bold uppercase ${verifyMessage.success ? "text-green-600" : "text-orange-600"}`}>
                   {verifyMessage.text}
-                  {verifyMessage.needsReconnect && (
-                    <button
-                      onClick={handleReconnectGithub}
-                      disabled={reconnectingGithub}
-                      className="ml-2 underline disabled:opacity-50"
-                    >
-                      {reconnectingGithub ? "Redirecting..." : "Reconnect GitHub"}
-                    </button>
-                  )}
                 </div>
               )}
             </div>

--- a/src/components/profile/profile-project-card.tsx
+++ b/src/components/profile/profile-project-card.tsx
@@ -43,8 +43,7 @@ export function ProfileProjectCard({ project, verified = false, isOwner = false 
   const [undoing, setUndoing] = useState(false);
   const [expanded, setExpanded] = useState(false);
   const [verifying, setVerifying] = useState(false);
-  const [verifyMessage, setVerifyMessage] = useState<{ success: boolean; text: string; needsReconnect?: boolean } | null>(null);
-  const [reconnectingGithub, setReconnectingGithub] = useState(false);
+  const [verifyMessage, setVerifyMessage] = useState<{ success: boolean; text: string } | null>(null);
   const reportRef = useRef<HTMLDivElement>(null);
   const isLongDescription = (project.description?.length ?? 0) > 280;
 
@@ -66,25 +65,12 @@ export function ProfileProjectCard({ project, verified = false, isOwner = false 
         setVerifyMessage({
           success: false,
           text: data.reason || data.error || "Verification failed.",
-          needsReconnect: data.code === "needs_repo_scope",
         });
       }
     } catch {
       setVerifyMessage({ success: false, text: "Verification request failed." });
     }
     setVerifying(false);
-  }
-
-  async function handleReconnectGithub() {
-    setReconnectingGithub(true);
-    const supabase = createClient();
-    await supabase.auth.signInWithOAuth({
-      provider: "github",
-      options: {
-        redirectTo: `${window.location.origin}${window.location.pathname}`,
-        scopes: "read:user user:email repo",
-      },
-    });
   }
 
   useEffect(() => {
@@ -328,15 +314,6 @@ export function ProfileProjectCard({ project, verified = false, isOwner = false 
               role="status"
             >
               {verifyMessage.text}
-              {verifyMessage.needsReconnect && (
-                <button
-                  onClick={handleReconnectGithub}
-                  disabled={reconnectingGithub}
-                  className="ml-2 underline disabled:opacity-50"
-                >
-                  {reconnectingGithub ? "Redirecting..." : "Reconnect GitHub"}
-                </button>
-              )}
             </p>
           )}
         </div>

--- a/src/lib/github-quality.ts
+++ b/src/lib/github-quality.ts
@@ -37,10 +37,11 @@ export interface RepoQualityMetrics {
 }
 
 // Discriminated error codes so callers can branch on what went wrong without
-// brittle string parsing. `needs_repo_scope` is the signal the project-add
-// flow uses to surface the "Reconnect GitHub" CTA — it means the GitHub API
-// returned 404 for a syntactically valid repo URL while the caller's token
-// only carried `public_repo`, which is what existing pre-migration users have.
+// brittle string parsing. `needs_repo_scope` means the GitHub API returned 404
+// for a syntactically valid repo URL while the caller's token only carried
+// public scope — i.e. it's almost certainly a private repo we can't read.
+// Callers map this to a "private repos aren't supported yet" message (we use
+// public-only OAuth; read-only private access is coming via a GitHub App).
 export type RepoAnalysisErrorCode =
   | "not_found"
   | "rate_limited"
@@ -110,12 +111,14 @@ export function parseGithubRepoUrl(
 }
 
 /**
- * Analyze a GitHub repository and return quality metrics.
+ * Analyze a GitHub repository and return quality metrics. Reads only — repo
+ * metadata, languages, contributors, file tree, README, commit count.
  *
- * Pass the caller's GitHub OAuth `token` to access their private repos. The
- * `repo` scope is required for private access; with only `public_repo`, the
- * API returns 404 for private repos and we surface that as `needs_repo_scope`
- * so the caller can prompt for a re-auth.
+ * Pass the caller's GitHub OAuth `token` (public scope) to read public repos
+ * as the user and dodge unauthenticated rate limits. Private repos return 404
+ * under public scope; we surface that as `needs_repo_scope` so callers can
+ * show a "private repos aren't supported yet" message. (Read-only private
+ * access will come from a fine-grained GitHub App, not the OAuth `repo` scope.)
  */
 export async function analyzeRepository(
   owner: string,
@@ -133,17 +136,16 @@ export async function analyzeRepository(
 
     if (!repoRes.ok) {
       if (repoRes.status === 404) {
-        // A 404 from an authenticated request whose token lacks `repo` is the
-        // signature of a private repo the caller could reach if they re-auth.
-        // We can't be certain without a second probe, but it's the only
-        // actionable signal we have and the false-positive case (truly
-        // missing public repo) still surfaces a useful CTA.
+        // A 404 from an authenticated request whose token carries only public
+        // scope is the signature of a private repo we can't read. Flag it as
+        // needs_repo_scope so callers can show the "not supported yet" message
+        // rather than a generic "not found".
         const scopes = parseOAuthScopes(repoRes);
         if (token && scopes && !scopes.includes("repo")) {
           return {
             success: false,
             metrics: null,
-            error: "Private repo — reconnect GitHub to grant private access.",
+            error: "Private repository — not supported yet.",
             errorCode: "needs_repo_scope",
           };
         }


### PR DESCRIPTION
## Why
A prospective signup refused the GitHub consent screen because the `repo` scope grants **read + write + admin** to all public *and* private repos. We only ever **read** repo metadata to compute quality scores — we never write — so that access is more than we need and reads as invasive.

Per GitHub's docs, **OAuth Apps can't grant read-only private access** — `repo` is the only scope that sees private repos and it's all-or-nothing. There's no scope tweak that makes it read-only. The proper solution is a fine-grained **GitHub App** (Contents + Metadata read-only, per-repo, revocable), which is the next piece of work.

## What this does
Reverts the user-facing OAuth-private approach so the consent screen goes back to public-only:
- Remove `scopes: "...repo"` from **signup** + **login** → Supabase default (public) scope.
- Remove the "Reconnect GitHub" CTAs + handlers from **dashboard**, **profile-project-card**, and **profile-setup** (they re-requested `repo`).
- Replace the `needs_repo_scope` "reconnect" messaging with an honest **"private repos aren't supported yet — coming soon"** in the project create + verify routes.

## Kept (inert now, reused by the GitHub App later)
`is_private` column + RLS, public-surface privacy filters, feed anonymization, settings toggle. With all repos public these are no-ops — no need to rip them out and re-add them.

## Verification
- `tsc --noEmit`: clean
- `eslint src`: clean
- `npm test`: 252 passed
- `next build`: ✓ Compiled successfully

## Follow-up
Read-only private-repo support via a fine-grained GitHub App (separate effort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated GitHub authentication to use public-only OAuth scope, removing support for private repository access.
  * Private repositories now return a clear "not yet supported" message instead of prompting reconnection.
  * Removed the "reconnect GitHub" flow from authentication and project verification workflows for improved clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unknownking07/vibe-talent/pull/199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->