### PR TITLE
fix(auth): redirect authenticated users away from login/signup pages

### DIFF
--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -20,6 +20,16 @@ export default function SignUpPage() {
   const [success, setSuccess] = useState(false);
   const [consentProvider, setConsentProvider] = useState<"github" | "google" | null>(null);
 
+  // Redirect already-authenticated users to dashboard
+  useEffect(() => {
+    const supabase = createClient();
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (user) {
+        window.location.href = "/dashboard";
+      }
+    });
+  }, []);
+
   // Store referral code in localStorage so it persists through the auth flow
   useEffect(() => {
     if (ref) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -35,6 +35,18 @@ export async function middleware(request: NextRequest) {
     return NextResponse.redirect(redirectUrl);
   }
 
+  // Logged-in users visiting auth pages get bounced to /dashboard immediately,
+  // server-side — no client-side flash of the signup/login form.
+  // Uses the cookie heuristic (fast, no network call). Edge case: an expired
+  // cookie triggers a redirect to /dashboard which the dashboard middleware
+  // then redirects back to /auth/login — two hops, but graceful.
+  const isAuthPage =
+    request.nextUrl.pathname === "/auth/signup" ||
+    request.nextUrl.pathname === "/auth/login";
+  if (isAuthPage && hasSupabaseAuthCookie(request)) {
+    return NextResponse.redirect(new URL("/dashboard", request.url));
+  }
+
   // Anonymous visitors on non-protected routes skip updateSession entirely.
   // updateSession calls supabase.auth.getUser() and writes Set-Cookie, which
   // forces `cache-control: no-store` and bypasses both Vercel ISR and the


### PR DESCRIPTION
## Summary

- **Middleware redirect (server-side)**: Authenticated users visiting `/auth/login` or `/auth/signup` are now bounced to `/dashboard` at the edge — before the page renders, no form flash
- **Signup page guard (client-side fallback)**: Added `getUser()` redirect check to the signup page, matching the existing check on the login page — handles the edge case where a Supabase auth cookie exists but has expired

## Root cause

The signup page lacked the redirect-if-authenticated guard that the login page already had. Combined with the navbar's intentional `initialIsLoggedIn=false` (for Vercel ISR), a logged-in user landing on `/auth/signup` would see the full signup form until the client-side auth check resolved.

## Test plan

- [ ] Logged-in user navigates to `/auth/signup` → redirected immediately to `/dashboard`
- [ ] Logged-in user navigates to `/auth/login` → redirected immediately to `/dashboard`
- [ ] Logged-out user can access both pages normally
- [ ] GitHub OAuth flow still works end-to-end (callback → profile-setup or dashboard)
- [ ] Expired cookie edge case: redirect to `/dashboard` → middleware bounces back to `/auth/login` gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authenticated users are now automatically redirected to the dashboard when attempting to access the signup or login pages, preventing confusion and improving the authentication flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unknownking07/vibe-talent/pull/200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->