### PR TITLE
fix(security): full-codebase hardening — RLS, reputation lock, stored XSS, review IDOR

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { jsonLdHtml } from "@/lib/json-ld";
 import Link from "next/link";
 import { Flame, Zap, Github, ExternalLink, Code2, Trophy, Users } from "lucide-react";
 import { siteUrl } from "@/lib/seo";
@@ -67,11 +68,11 @@ export default function AboutPage() {
     <div className="mx-auto max-w-4xl px-4 sm:px-6 py-16">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(breadcrumbLd) }}
       />
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(personLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(personLd) }}
       />
 
       {/* Header */}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -3,8 +3,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { createClient } from "@/lib/supabase/client";
 import { Shield, Plus, Trash2, Rocket, Target, BarChart3, Calendar, TrendingUp, Users, Code2, Flame, RefreshCw } from "lucide-react";
-
-const ADMIN_USERS = ["unknownking07", "stuart5915"];
+import { ADMIN_USERNAMES } from "@/lib/admin";
 
 type Initiative = { id: string; title: string; status: "active" | "planned" | "done" | "paused"; owner: string; notes: string; deadline: string };
 type RoadmapItem = { id: string; title: string; priority: "high" | "medium" | "low"; status: "todo" | "in-progress" | "done"; notes: string };
@@ -47,7 +46,7 @@ export default function AdminPage() {
     supabase.auth.getUser().then(({ data: { user: u } }) => {
       if (!u) { setLoading(false); return; }
       const un = u.user_metadata?.user_name || u.user_metadata?.preferred_username || "";
-      if (ADMIN_USERS.includes(un.toLowerCase())) { setUser({ username: un }); setAuthorized(true); }
+      if (ADMIN_USERNAMES.includes(un.toLowerCase())) { setUser({ username: un }); setAuthorized(true); }
       setLoading(false);
     });
   }, []);
@@ -55,7 +54,9 @@ export default function AdminPage() {
   const fetchLiveStats = useCallback(async () => {
     setStatsLoading(true);
     try {
-      const res = await fetch("/api/admin-stats");
+      // Distinct URL + no-store so the admin (full) payload is never served
+      // from the public CDN cache that backs the homepage's stats fetch.
+      const res = await fetch("/api/admin-stats?scope=admin", { cache: "no-store" });
       if (res.ok) { const data = await res.json(); setLiveStats(data); }
     } catch { /* ignore */ }
     setStatsLoading(false);

--- a/src/app/agent/layout.tsx
+++ b/src/app/agent/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { jsonLdHtml } from "@/lib/json-ld";
 import { siteUrl } from "@/lib/seo";
 
 export const metadata: Metadata = {
@@ -57,11 +58,11 @@ export default function AgentLayout({ children }: { children: React.ReactNode })
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(breadcrumbLd) }}
       />
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareAppLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(softwareAppLd) }}
       />
       {children}
     </>

--- a/src/app/api/admin-stats/route.ts
+++ b/src/app/api/admin-stats/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { statsLimiter, checkRateLimit, getIP } from "@/lib/rate-limit";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { isAdminUsername } from "@/lib/admin";
 
 export async function GET(request: NextRequest) {
   const { success } = await checkRateLimit(statsLimiter, getIP(request));
@@ -72,25 +74,49 @@ export async function GET(request: NextRequest) {
     const lastWeek = recent.filter(u => new Date(u.created_at) >= twoWeeksAgo && new Date(u.created_at) < weekAgo).length;
     const growthPct = lastWeek > 0 ? Math.round(((thisWeek - lastWeek) / lastWeek) * 100) : thisWeek > 0 ? 100 : 0;
 
-    return NextResponse.json({
-      builders,
-      projects,
-      hires,
-      endorsements,
-      avgStreak,
-      maxStreak,
-      activeStreaks,
-      avgVibeScore,
-      badges,
-      growth: {
-        thisWeek,
-        lastWeek,
-        pct: growthPct,
+    const timestamp = new Date().toISOString();
+
+    // Public surfaces (homepage / network-velocity card) consume only these
+    // aggregate counters, so they stay anonymously cacheable.
+    const publicStats = { builders, projects, hires, endorsements, activeStreaks };
+
+    // The rest — week-over-week growth, badge histogram, score/streak averages
+    // — is internal business-health data and is admin-only. Authorize from the
+    // session, matching the GitHub username the admin page checks. The
+    // client-side gate is cosmetic; the server is the trust boundary.
+    let isAdmin = false;
+    try {
+      const authClient = await createServerSupabaseClient();
+      const { data: { user } } = await authClient.auth.getUser();
+      const ghUsername =
+        (user?.user_metadata?.user_name as string | undefined) ||
+        (user?.user_metadata?.preferred_username as string | undefined) ||
+        "";
+      isAdmin = isAdminUsername(ghUsername);
+    } catch {
+      isAdmin = false;
+    }
+
+    if (!isAdmin) {
+      return NextResponse.json(
+        { ...publicStats, timestamp },
+        { headers: { "Cache-Control": "public, s-maxage=120, stale-while-revalidate=300" } }
+      );
+    }
+
+    return NextResponse.json(
+      {
+        ...publicStats,
+        avgStreak,
+        maxStreak,
+        avgVibeScore,
+        badges,
+        growth: { thisWeek, lastWeek, pct: growthPct },
+        timestamp,
       },
-      timestamp: new Date().toISOString(),
-    }, {
-      headers: { "Cache-Control": "public, s-maxage=120, stale-while-revalidate=300" },
-    });
+      // An admin-only response must never sit in a shared / CDN cache.
+      { headers: { "Cache-Control": "private, no-store" } }
+    );
   } catch (err) {
     console.error("Admin stats error:", err);
     return NextResponse.json({ error: "Failed to fetch stats" }, { status: 500 });

--- a/src/app/api/cron/check-live-urls/route.ts
+++ b/src/app/api/cron/check-live-urls/route.ts
@@ -11,6 +11,12 @@ import { checkLiveUrl } from "@/lib/github-quality";
  */
 export async function GET(req: NextRequest) {
   const cronSecret = process.env.CRON_SECRET;
+  // Fail closed in production: a missing CRON_SECRET must never leave this
+  // route open to anonymous callers — it performs privileged batch mutations.
+  if (!cronSecret && process.env.NODE_ENV === "production") {
+    console.error("CRON_SECRET is not configured");
+    return NextResponse.json({ error: "Cron secret not configured" }, { status: 500 });
+  }
   if (cronSecret) {
     const authHeader = req.headers.get("authorization");
     if (authHeader !== `Bearer ${cronSecret}`) {

--- a/src/app/api/cron/github-sync/route.ts
+++ b/src/app/api/cron/github-sync/route.ts
@@ -36,6 +36,12 @@ function sleep(ms: number): Promise<void> {
 export async function GET(req: NextRequest) {
   // Verify cron secret (skip in development)
   const cronSecret = process.env.CRON_SECRET;
+  // Fail closed in production: a missing CRON_SECRET must never leave this
+  // route open to anonymous callers — it performs privileged batch mutations.
+  if (!cronSecret && process.env.NODE_ENV === "production") {
+    console.error("CRON_SECRET is not configured");
+    return NextResponse.json({ error: "Cron secret not configured" }, { status: 500 });
+  }
   if (cronSecret) {
     const authHeader = req.headers.get("authorization");
     if (authHeader !== `Bearer ${cronSecret}`) {

--- a/src/app/api/cron/quality-rescore/route.ts
+++ b/src/app/api/cron/quality-rescore/route.ts
@@ -24,6 +24,12 @@ function sleep(ms: number): Promise<void> {
  */
 export async function GET(req: NextRequest) {
   const cronSecret = process.env.CRON_SECRET;
+  // Fail closed in production: a missing CRON_SECRET must never leave this
+  // route open to anonymous callers — it performs privileged batch mutations.
+  if (!cronSecret && process.env.NODE_ENV === "production") {
+    console.error("CRON_SECRET is not configured");
+    return NextResponse.json({ error: "Cron secret not configured" }, { status: 500 });
+  }
   if (cronSecret) {
     const authHeader = req.headers.get("authorization");
     if (authHeader !== `Bearer ${cronSecret}`) {

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -46,9 +46,14 @@ export async function GET(req: NextRequest) {
       ? Math.round((trustedReviews.reduce((sum: number, r: { rating: number }) => sum + r.rating, 0) / trustedReviews.length) * 10) / 10
       : 0;
 
-    // Strip trust_score from public response to avoid exposing anti-abuse thresholds
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const publicReviews = reviews.map(({ trust_score: _ts, ...rest }: { trust_score?: number; [key: string]: unknown }) => rest);
+    // Strip trust_score (internal anti-abuse threshold) AND reviewer_email
+    // (PII) from the public response. reviewer_email must never leave the
+    // server — no client needs it, and returning it enabled email harvesting
+    // plus the old email-based delete bypass.
+    const publicReviews = reviews.map(
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      ({ trust_score: _ts, reviewer_email: _re, ...rest }: { trust_score?: number; reviewer_email?: string; [key: string]: unknown }) => rest
+    );
 
     return NextResponse.json({
       reviews: publicReviews,
@@ -63,27 +68,31 @@ export async function GET(req: NextRequest) {
 
 export async function DELETE(req: NextRequest) {
   try {
-    const body = await req.json();
-    const { review_id, reviewer_email } = body;
-
-    if (!review_id || !reviewer_email) {
+    // Authorize by session only. The previous email-based check was bypassable:
+    // reviewer_email was readable from the public GET (and directly via the
+    // anon key), so "prove you own it by sending the email" proved nothing.
+    // Only the authenticated author of a review may delete it.
+    const authClient = await createServerSupabaseClient();
+    const { data: { user } } = await authClient.auth.getUser();
+    if (!user) {
       return NextResponse.json(
-        { error: "review_id and reviewer_email are required" },
-        { status: 400 }
+        { error: "You must be signed in to delete a review." },
+        { status: 401 }
       );
     }
 
-    if (!validateUUID(review_id)) {
+    const body = await req.json();
+    const { review_id } = body;
+
+    if (!review_id || !validateUUID(review_id)) {
       return NextResponse.json({ error: "Invalid review_id" }, { status: 400 });
     }
 
-    const emailClean = String(reviewer_email).trim().toLowerCase();
     const sb = createAdminClient();
 
-    // Verify the review exists and belongs to this email
     const { data: review, error: fetchErr } = await sb
       .from("reviews")
-      .select("id, reviewer_email")
+      .select("id, reviewer_user_id")
       .eq("id", review_id)
       .single();
 
@@ -91,9 +100,11 @@ export async function DELETE(req: NextRequest) {
       return NextResponse.json({ error: "Review not found" }, { status: 404 });
     }
 
-    if (review.reviewer_email !== emailClean) {
+    // Anonymous reviews (reviewer_user_id IS NULL) have no platform identity to
+    // match against the session, so they cannot be deleted through this route.
+    if (review.reviewer_user_id !== user.id) {
       return NextResponse.json(
-        { error: "Email does not match. You can only delete your own review." },
+        { error: "You can only delete your own review." },
         { status: 403 }
       );
     }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -325,12 +325,14 @@ export default function DashboardPage() {
       });
       setLoading(false);
 
-      // Sync streak back to DB if it differs, so profile page shows the same value
+      // Recompute streak/score server-side so the profile page stays in sync.
+      // Routed through the SECURITY DEFINER update_user_streak RPC rather than a
+      // direct column write: reputation columns (streak / vibe_score /
+      // badge_level) are no longer client-writable (see the 20260529 security
+      // migration), and the RPC derives them authoritatively from streak_logs.
       if (actualStreak !== (profile.streak || 0) || actualLongest !== (profile.longest_streak || 0)) {
-        sb.from("users").update({
-          streak: actualStreak,
-          longest_streak: actualLongest,
-        }).eq("id", authUser.id).then(() => {});
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (sb as any).rpc("update_user_streak", { p_user_id: authUser.id }).then(() => {});
       }
 
       // Auto-sync GitHub if configured and hasn't synced recently
@@ -450,13 +452,13 @@ export default function DashboardPage() {
         }
       }
 
-      // Sync DB in background if streak was wrong (non-blocking)
-      // Don't write vibe_score — the DB trigger is the single source of truth
+      // Recompute streak/score server-side if our computed value differs
+      // (non-blocking). Routed through the SECURITY DEFINER update_user_streak
+      // RPC — reputation columns are no longer client-writable (see the
+      // 20260529 security migration); the RPC is the single source of truth.
       if (profile && (actualStreak !== profile.streak || actualLongest !== profile.longest_streak)) {
-        sb.from("users").update({
-          streak: actualStreak,
-          longest_streak: actualLongest,
-        }).eq("id", authUser.id);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (sb as any).rpc("update_user_streak", { p_user_id: authUser.id });
       }
       } catch (err) {
         console.error("Dashboard loadUserData failed:", err);

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -1,4 +1,5 @@
 import { fetchAllUsersCached } from "@/lib/supabase/server-queries";
+import { jsonLdHtml } from "@/lib/json-ld";
 import { ExploreContent } from "@/components/explore/explore-content";
 import { siteUrl, buildBreadcrumbList } from "@/lib/seo";
 import type { Metadata } from "next";
@@ -60,7 +61,7 @@ export default async function ExplorePage() {
     <div className="mx-auto max-w-7xl px-4 sm:px-6 py-12">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(jsonLd) }}
       />
       <div className="mb-8">
         <h1 className="text-3xl font-extrabold uppercase text-[var(--foreground)]">Explore Talent</h1>

--- a/src/app/feed/layout.tsx
+++ b/src/app/feed/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { jsonLdHtml } from "@/lib/json-ld";
 import { siteUrl } from "@/lib/seo";
 
 export const metadata: Metadata = {
@@ -65,11 +66,11 @@ export default function FeedLayout({
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(breadcrumbLd) }}
       />
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(collectionLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(collectionLd) }}
       />
       {children}
     </>

--- a/src/app/glossary/[slug]/page.tsx
+++ b/src/app/glossary/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { jsonLdHtml } from "@/lib/json-ld";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { BookOpen, ArrowLeft, ArrowRight } from "lucide-react";
@@ -83,11 +84,11 @@ export default async function GlossaryTermPage({
     <article className="mx-auto max-w-3xl px-4 sm:px-6 py-16">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(breadcrumbLd) }}
       />
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(definedTermLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(definedTermLd) }}
       />
 
       <Link

--- a/src/app/glossary/page.tsx
+++ b/src/app/glossary/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { jsonLdHtml } from "@/lib/json-ld";
 import Link from "next/link";
 import { BookOpen, ArrowRight } from "lucide-react";
 import { siteUrl } from "@/lib/seo";
@@ -55,11 +56,11 @@ export default function GlossaryIndexPage() {
     <div className="mx-auto max-w-4xl px-4 sm:px-6 py-16">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(breadcrumbLd) }}
       />
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(itemListLd) }}
       />
 
       <div className="mb-12">

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,4 +1,5 @@
 import { fetchAllUsersCached } from "@/lib/supabase/server-queries";
+import { jsonLdHtml } from "@/lib/json-ld";
 import { LeaderboardTabs } from "@/components/leaderboard/leaderboard-tabs";
 import { siteUrl, buildBreadcrumbList } from "@/lib/seo";
 import { Trophy } from "lucide-react";
@@ -61,7 +62,7 @@ export default async function LeaderboardPage() {
     <div className="mx-auto max-w-7xl px-4 sm:px-6 py-12">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(jsonLd) }}
       />
       <div className="text-center mb-10">
         <div

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { LiveActivityFeed } from "@/components/ui/live-activity-feed";
+import { jsonLdHtml } from "@/lib/json-ld";
 import { NetworkFeed } from "@/components/feed/network-feed";
 import { EndGameLadder } from "@/components/homepage/end-game-ladder";
 import { FeaturedCarousel } from "@/components/ui/featured-carousel";
@@ -112,7 +113,7 @@ export default async function HomePage() {
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{
-          __html: JSON.stringify({
+          __html: jsonLdHtml({
             "@context": "https://schema.org",
             "@graph": [
               {
@@ -462,7 +463,7 @@ export default async function HomePage() {
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify({
+            __html: jsonLdHtml({
               "@context": "https://schema.org",
               "@type": "FAQPage",
               dateModified: "2026-05-22",

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { jsonLdHtml } from "@/lib/json-ld";
 import Link from "next/link";
 import { Megaphone, Wallet, Shield, ArrowRight, HelpCircle } from "lucide-react";
 import { siteUrl, buildBreadcrumbList } from "@/lib/seo";
@@ -145,15 +146,15 @@ export default async function PricingPage() {
     <div className="mx-auto max-w-4xl px-4 sm:px-6 py-16">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(breadcrumbLd) }}
       />
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(productLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(productLd) }}
       />
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(faqLd) }}
       />
 
       {/* Header */}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { jsonLdHtml } from "@/lib/json-ld";
 import { siteUrl, buildBreadcrumbList } from "@/lib/seo";
 
 export const metadata: Metadata = {
@@ -20,7 +21,7 @@ export default function PrivacyPolicyPage() {
     <div className="mx-auto max-w-3xl px-4 sm:px-6 py-16">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(breadcrumbLd) }}
       />
       <h1 className="text-3xl font-extrabold uppercase text-[var(--foreground)] mb-8">Privacy Policy</h1>
       <p className="text-sm text-[var(--text-muted)] mb-8">Last updated: April 1, 2026</p>

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -1,4 +1,5 @@
 import { fetchUserByUsernameCached, fetchStreakLogsCached, fetchPrivateProjectsForOwner } from "@/lib/supabase/server-queries";
+import { jsonLdHtml } from "@/lib/json-ld";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { ProfileSidebar } from "@/components/profile/profile-sidebar";
@@ -201,11 +202,11 @@ export default async function ProfilePage({
       {!isOwner && <ProfileViewTracker viewedUserId={user.id} />}
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(breadcrumbLd) }}
       />
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(jsonLd) }}
       />
       <div className="w-full max-w-[1200px] grid grid-cols-1 lg:grid-cols-[320px_1fr] gap-6 items-start">
         {/* Sidebar column — primary profile sidebar + reviewer reputation block */}

--- a/src/app/profile/[username]/projects/page.tsx
+++ b/src/app/profile/[username]/projects/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { jsonLdHtml } from "@/lib/json-ld";
 import type { Metadata } from "next";
 import { ArrowLeft } from "lucide-react";
 import { fetchUserByUsernameCached, fetchPrivateProjectsForOwner } from "@/lib/supabase/server-queries";
@@ -125,7 +126,7 @@ export default async function UserProjectsPage({
     <div className="mx-auto max-w-7xl px-4 sm:px-6 py-8 sm:py-12">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(breadcrumbLd) }}
       />
 
       <Link

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,4 +1,5 @@
 import { fetchAllProjectsCached } from "@/lib/supabase/server-queries";
+import { jsonLdHtml } from "@/lib/json-ld";
 import { ProjectsContent } from "@/components/projects/projects-content";
 import { siteUrl, buildBreadcrumbList } from "@/lib/seo";
 import type { Metadata } from "next";
@@ -46,7 +47,7 @@ export default async function ProjectsPage() {
     <div className="mx-auto max-w-7xl px-4 sm:px-6 py-12">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(jsonLd) }}
       />
       <div className="mb-8">
         <h1 className="text-3xl font-extrabold uppercase text-[var(--foreground)]">All Projects</h1>

--- a/src/app/roadmap/page.tsx
+++ b/src/app/roadmap/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { jsonLdHtml } from "@/lib/json-ld";
 import Link from "next/link";
 import Image from "next/image";
 import {
@@ -241,15 +242,15 @@ export default function RoadmapPage() {
     <div className="mx-auto max-w-4xl px-4 sm:px-6 py-16">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(breadcrumbLd) }}
       />
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(itemListLd) }}
       />
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(faqLd) }}
       />
 
       {/* Header */}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { jsonLdHtml } from "@/lib/json-ld";
 import { siteUrl, buildBreadcrumbList } from "@/lib/seo";
 
 export const metadata: Metadata = {
@@ -20,7 +21,7 @@ export default function TermsOfServicePage() {
     <div className="mx-auto max-w-3xl px-4 sm:px-6 py-16">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(breadcrumbLd) }}
       />
       <h1 className="text-3xl font-extrabold uppercase text-[var(--foreground)] mb-8">Terms of Service</h1>
       <p className="text-sm text-[var(--text-muted)] mb-8">Last updated: April 1, 2026</p>

--- a/src/app/vs/upwork/page.tsx
+++ b/src/app/vs/upwork/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { jsonLdHtml } from "@/lib/json-ld";
 import Link from "next/link";
 import { Check, X, ArrowRight, Flame, Zap, Shield } from "lucide-react";
 import { siteUrl } from "@/lib/seo";
@@ -113,15 +114,15 @@ export default function VsUpworkPage() {
     <div className="mx-auto max-w-4xl px-4 sm:px-6 py-16">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(breadcrumbLd) }}
       />
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(articleLd) }}
       />
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(faqLd) }}
       />
 
       <div className="mb-10">

--- a/src/components/profile/reviews-section.tsx
+++ b/src/components/profile/reviews-section.tsx
@@ -98,10 +98,10 @@ export default function ReviewsSection({ builderId, isOwner = false }: ReviewsSe
   const [submitError, setSubmitError] = useState("");
   const [submitSuccess, setSubmitSuccess] = useState(false);
   const [deleteId, setDeleteId] = useState<string | null>(null);
-  const [deleteEmail, setDeleteEmail] = useState("");
   const [deleteError, setDeleteError] = useState("");
   const [deleting, setDeleting] = useState(false);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
 
   // Auto-fetch logged-in user's name and email
   useEffect(() => {
@@ -110,6 +110,7 @@ export default function ReviewsSection({ builderId, isOwner = false }: ReviewsSe
       const { data: { user } } = await supabase.auth.getUser();
       if (user) {
         setIsLoggedIn(true);
+        setCurrentUserId(user.id);
         setFormEmail(user.email || "");
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const { data: profile } = await (supabase as any)
@@ -195,27 +196,22 @@ export default function ReviewsSection({ builderId, isOwner = false }: ReviewsSe
   };
 
   const handleDeleteReview = async () => {
-    if (!deleteId || !deleteEmail.trim()) {
-      setDeleteError("Please enter your email to confirm deletion.");
-      return;
-    }
+    if (!deleteId) return;
 
     setDeleteError("");
     setDeleting(true);
 
     try {
+      // The server authorizes deletion from the session — only the review's
+      // authenticated author may delete it — so we send no client identity.
       const res = await fetch("/api/reviews", {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          review_id: deleteId,
-          reviewer_email: deleteEmail.trim(),
-        }),
+        body: JSON.stringify({ review_id: deleteId }),
       });
 
       if (res.ok) {
         setDeleteId(null);
-        setDeleteEmail("");
 
         // Reload reviews
         const reviewsRes = await fetch(`/api/reviews?builder_id=${builderId}`);
@@ -274,7 +270,7 @@ export default function ReviewsSection({ builderId, isOwner = false }: ReviewsSe
               ({reviews.length})
             </span>
           )}
-          {!isOwner && !showForm && !(isLoggedIn && reviews.some((r) => r.reviewer_email === formEmail)) && (
+          {!isOwner && !showForm && !(currentUserId !== null && reviews.some((r) => r.reviewer_user_id === currentUserId)) && (
             <button
               onClick={() => setShowForm(true)}
               className="btn-brutal text-xs py-1.5 px-3"
@@ -424,9 +420,9 @@ export default function ReviewsSection({ builderId, isOwner = false }: ReviewsSe
                   <span className="text-[var(--text-muted-soft)] text-xs font-mono">
                     {timeAgo(review.created_at)}
                   </span>
-                  {isLoggedIn && formEmail === review.reviewer_email && (
+                  {currentUserId !== null && currentUserId === review.reviewer_user_id && (
                     <button
-                      onClick={() => { setDeleteId(review.id); setDeleteEmail(""); setDeleteError(""); }}
+                      onClick={() => { setDeleteId(review.id); setDeleteError(""); }}
                       className="text-[var(--text-muted-soft)] hover:text-red-500 transition-colors"
                       title="Delete your review"
                     >
@@ -446,15 +442,8 @@ export default function ReviewsSection({ builderId, isOwner = false }: ReviewsSe
                   style={{ backgroundColor: "var(--status-error-bg)", border: "2px solid var(--border-hard)" }}
                 >
                   <p className="text-xs font-bold text-[var(--foreground)]">
-                    Enter the email you used when writing this review to confirm deletion:
+                    Delete this review? This can&apos;t be undone.
                   </p>
-                  <input
-                    type="email"
-                    value={deleteEmail}
-                    onChange={(e) => setDeleteEmail(e.target.value)}
-                    placeholder="your@email.com"
-                    className="input-brutal w-full text-sm"
-                  />
                   {deleteError && (
                     <p className="text-xs font-bold text-red-600">{deleteError}</p>
                   )}

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -1,0 +1,9 @@
+// Admin allowlist, kept in one server-importable place so API routes can
+// authorize against the session. The client-side admin page imports this too,
+// but a client check is only cosmetic — the server is the trust boundary, so
+// every privileged endpoint must re-check with isAdminUsername() server-side.
+export const ADMIN_USERNAMES = ["unknownking07", "stuart5915"];
+
+export function isAdminUsername(username: string | null | undefined): boolean {
+  return !!username && ADMIN_USERNAMES.includes(username.toLowerCase());
+}

--- a/src/lib/chains-config.ts
+++ b/src/lib/chains-config.ts
@@ -59,7 +59,17 @@ export const CHAIN_CONFIGS: Record<string, ChainConfig> = {
   // },
 };
 
-export const SUPPORTED_CHAINS = Object.keys(CHAIN_CONFIGS);
+// Solana is intentionally excluded from the selectable chains. Its payment
+// flow is an unverified, unrecorded wallet-to-wallet USDC transfer, and the
+// featured grid is read solely from the Base contract — so a Solana payment
+// would take the user's money and grant no promotion. Keeping it out of
+// SUPPORTED_CHAINS removes it from the picker, which is the only place
+// `selectedChain` can be set, so the broken Solana path can never run.
+// Re-add it ONLY once a server-side flow verifies the transaction
+// (success + recipient + USDC mint + amount + signature uniqueness) and
+// records the grant. The `solana` entry in CHAIN_CONFIGS is retained for
+// that future work.
+export const SUPPORTED_CHAINS = Object.keys(CHAIN_CONFIGS).filter((k) => k !== "solana");
 export const DEFAULT_CHAIN = "base";
 
 export function getChainConfig(chainKey: string): ChainConfig {

--- a/src/lib/json-ld.ts
+++ b/src/lib/json-ld.ts
@@ -1,0 +1,20 @@
+/**
+ * Safely serialize a JSON-LD object for embedding in a
+ * `<script type="application/ld+json" dangerouslySetInnerHTML>` tag.
+ *
+ * `JSON.stringify` does NOT escape the HTML-significant characters `<`, `>`
+ * and `&`, so any user-controlled value in the object (e.g. a profile bio or
+ * project title) containing the literal `</script>` could close the script
+ * element and inject attacker-supplied markup — a stored XSS. Escaping those
+ * characters to their `\uXXXX` forms keeps the JSON byte-for-byte equivalent
+ * when parsed, while making script-context breakout impossible.
+ *
+ * Always use this instead of `JSON.stringify` when feeding
+ * `dangerouslySetInnerHTML` for structured-data scripts.
+ */
+export function jsonLdHtml(data: unknown): string {
+  return JSON.stringify(data)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026");
+}

--- a/supabase/migrations/20260529_security_hardening_rls.sql
+++ b/supabase/migrations/20260529_security_hardening_rls.sql
@@ -1,0 +1,92 @@
+-- Security hardening pass (2026-05-29)
+--
+-- Closes a set of RLS / access-control gaps found in a full-codebase audit.
+-- Root cause: several SELECT policies were left at `USING (true)` while the
+-- anon key ships in the browser bundle, so "private" tables were readable by
+-- anyone with the public key. There is no FORCE RLS / REVOKE baseline, so an
+-- RLS policy is the ONLY gate on each table.
+--
+-- Written without DO/dollar-quote blocks so it runs cleanly in the Supabase
+-- SQL editor (which splits on `;`). Idempotent — safe to re-run. Assumes the
+-- email_log and feed_events tables already exist (they do in the live DB;
+-- ALTER ... IF EXISTS no-ops otherwise).
+
+
+-- ============================================================
+-- #1 hire_messages — private hire conversations were world-readable.
+-- Scope SELECT to the owning builder. The client (token-holder) view is
+-- served through the service-role API route, which bypasses RLS.
+-- ============================================================
+DROP POLICY IF EXISTS "Anyone can read hire messages" ON public.hire_messages;
+DROP POLICY IF EXISTS "Builders read own hire messages" ON public.hire_messages;
+CREATE POLICY "Builders read own hire messages"
+  ON public.hire_messages FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.hire_requests hr
+      WHERE hr.id = hire_messages.hire_request_id
+        AND hr.builder_id = auth.uid()
+    )
+  );
+
+
+-- ============================================================
+-- #3 users — reputation columns (vibe_score / streak / badge_level) were
+-- client-writable via the anon key. Make the recompute function run as its
+-- definer so it can still write those columns, then revoke blanket UPDATE and
+-- re-grant ONLY the profile columns clients may edit. update_user_streak
+-- already pins search_path, so SECURITY DEFINER is safe here.
+-- ============================================================
+ALTER FUNCTION public.update_user_streak(UUID) SECURITY DEFINER;
+
+REVOKE UPDATE ON public.users FROM anon, authenticated;
+
+GRANT UPDATE (
+  username,
+  display_name,
+  bio,
+  avatar_url,
+  github_username,
+  github_id,
+  share_private_activity
+) ON public.users TO authenticated;
+
+
+-- ============================================================
+-- #4 reviews — reviewer_email (PII) was world-readable via the anon key.
+-- Revoke blanket SELECT and re-grant every column EXCEPT reviewer_email.
+-- trust_score stays granted (the public feed reads it via the anon key).
+-- The reviews API reads reviewer_email via the service-role client.
+-- ============================================================
+REVOKE SELECT ON public.reviews FROM anon, authenticated;
+
+GRANT SELECT (
+  id,
+  builder_id,
+  reviewer_name,
+  hire_request_id,
+  rating,
+  comment,
+  trust_score,
+  created_at,
+  reviewer_user_id
+) ON public.reviews TO anon, authenticated;
+
+
+-- ============================================================
+-- #7 email_log — created without RLS. Enable RLS with no policy so only the
+-- service role (crons) can read/write it.
+-- ============================================================
+ALTER TABLE IF EXISTS public.email_log ENABLE ROW LEVEL SECURITY;
+
+
+-- ============================================================
+-- #10 feed_events — no RLS anywhere. Enable RLS and expose only non-private
+-- rows to anon; private/anonymized rows are surfaced solely through the
+-- service-role API path.
+-- ============================================================
+ALTER TABLE IF EXISTS public.feed_events ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "Public feed events are readable" ON public.feed_events;
+CREATE POLICY "Public feed events are readable"
+  ON public.feed_events FOR SELECT
+  USING (COALESCE(is_private, false) = false);


### PR DESCRIPTION
## Security hardening — full-codebase audit fixes

Fixes **10 of 11** findings from a full-codebase security audit (1 deferred, see below). The RLS migration is **already applied to production** and verified by replaying the attacks with the public anon key.

### 🔴 High
- **hire_messages world-readable** — private client↔builder conversations were dumpable with the public anon key (`SELECT` was `USING(true)`). Now scoped to the owning builder.
- **Reputation forgery** — `users` UPDATE had no column restriction, so any authenticated user could set their own `vibe_score`/`badge_level`/`streak` via a direct supabase-js call. Now column-locked; reputation is written only by `update_user_streak` (SECURITY DEFINER) + service-role crons. Dashboard streak sync rerouted to the RPC.
- **Stored XSS** — profile JSON-LD used `JSON.stringify` into `dangerouslySetInnerHTML`; a bio containing `</script>` executed for every visitor (CSP is `unsafe-inline`). New `jsonLdHtml()` escaper applied to all ~29 structured-data sites.
- **reviewer_email (PII) leak + IDOR delete** — email was returned by the API and readable via the anon key, and any unauthenticated caller could delete any review by supplying that (public) email. Email now hidden (column grant + API strip); DELETE is session-authorized.

### 🟠 Medium / 🟡 Low
- `/api/admin-stats` — sensitive metrics gated behind a server-side admin check.
- `email_log` / `feed_events` — RLS enabled.
- 3 cron routes — fail closed in production when `CRON_SECRET` is unset.
- Solana promotion payments — disabled (took USDC, verified/recorded nothing, granted no promotion).

### 🟡 Deferred
- **Featured-promotion ownership** (`promote(projectId)` accepts any project id) — needs wallet-address linkage or contract-level enforcement; not safely fixable in-repo. Displayed author/title come from the real project row (no defacement) and the attacker must pay. Tracked separately.

### Verification
- ✅ Migration applied to prod + anon-key attack replay (email harvest / hire-message dump / email_log read all blocked; public reads intact)
- ✅ Profile-edit smoke test (confirms the `users` GRANT is complete)
- ✅ `tsc`, `eslint`, **252 tests**, `next build` all green

Migration: `supabase/migrations/20260529_security_hardening_rls.sql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Review deletion now requires user authentication.
  * Enhanced authorization controls for admin operations and sensitive features.

* **Changes**
  * Solana payment option removed from available blockchain payment methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unknownking07/vibe-talent/pull/201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->