### PR TITLE
fix(security): verify featured-promotion ownership (#8)

### DIFF
--- a/src/app/api/promotions/route.ts
+++ b/src/app/api/promotions/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { validateUUID } from "@/lib/validation";
+
+// Records an ownership authorization for a featured promotion (audit finding #8).
+// The on-chain promote(projectId, ...) call accepts any projectId, so the render
+// path only shows a promotion if its payer was authorized here — and only the
+// project's OWNER (verified from the session) can create that authorization.
+//
+// EVM (Base) only. Solana payments will record promotions through a dedicated
+// /api/solana/verify endpoint in the next phase.
+
+const EVM_ADDRESS = /^0x[0-9a-fA-F]{40}$/;
+const ALLOWED_CHAINS = new Set(["base"]);
+
+export async function POST(req: NextRequest) {
+  try {
+    // 1. Require an authenticated session.
+    const supabase = await createServerSupabaseClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: "You must be signed in." }, { status: 401 });
+    }
+
+    // 2. Validate input.
+    const body = await req.json();
+    const { project_id, wallet_address, tx_ref, chain } = body ?? {};
+
+    if (!project_id || !validateUUID(project_id)) {
+      return NextResponse.json({ error: "Invalid project_id" }, { status: 400 });
+    }
+    if (typeof wallet_address !== "string" || !EVM_ADDRESS.test(wallet_address)) {
+      return NextResponse.json({ error: "Invalid wallet_address" }, { status: 400 });
+    }
+    const chainClean = typeof chain === "string" && chain.length > 0 ? chain : "base";
+    if (!ALLOWED_CHAINS.has(chainClean)) {
+      return NextResponse.json({ error: "Unsupported chain" }, { status: 400 });
+    }
+    const txRef =
+      typeof tx_ref === "string" && tx_ref.length > 0 ? tx_ref.slice(0, 120) : null;
+
+    const sb = createAdminClient();
+
+    // 3. Ownership gate — THE security check. Only the project's owner may
+    //    authorize a promotion of it.
+    const { data: project, error: projErr } = await sb
+      .from("projects")
+      .select("id, user_id")
+      .eq("id", project_id)
+      .single();
+
+    if (projErr || !project) {
+      return NextResponse.json({ error: "Project not found" }, { status: 404 });
+    }
+    if (project.user_id !== user.id) {
+      return NextResponse.json(
+        { error: "You can only promote your own project." },
+        { status: 403 }
+      );
+    }
+
+    // 4. Record the authorization (idempotent on tx_ref).
+    const { error: upsertErr } = await sb
+      .from("featured_promotions")
+      .upsert(
+        {
+          project_id,
+          user_id: user.id,
+          promoter_wallet: wallet_address.toLowerCase(),
+          chain: chainClean,
+          tx_ref: txRef,
+        },
+        { onConflict: "tx_ref" }
+      );
+
+    if (upsertErr) {
+      console.error("Failed to record promotion authorization:", upsertErr);
+      return NextResponse.json({ error: "Failed to record authorization" }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+}

--- a/src/components/ui/featured/feature-your-project-card.tsx
+++ b/src/components/ui/featured/feature-your-project-card.tsx
@@ -304,7 +304,7 @@ const FeatureCardBody = forwardRef<HTMLDivElement, Props>(function FeatureCardBo
     await privyLogout();
   }
 
-  async function handlePromoteEVM(project: UserProject, price: bigint, chainConfig: EVMChainConfig) {
+  async function handlePromoteEVM(project: UserProject, price: bigint, chainConfig: EVMChainConfig): Promise<string> {
     if (!connectedWallet) throw new Error("No EVM wallet connected");
     const provider = (await connectedWallet.getEthereumProvider()) as EthereumProvider;
     const walletAddr = connectedWallet.address.toLowerCase();
@@ -369,6 +369,7 @@ const FeatureCardBody = forwardRef<HTMLDivElement, Props>(function FeatureCardBo
     });
     setStatus({ msg: "Waiting for confirmation...", type: "info" });
     await waitForTx(txHash as string, chainConfig.rpc);
+    return txHash as string;
   }
 
   async function handlePromoteSolana(project: UserProject, price: bigint, chainConfig: SolanaChainConfig) {
@@ -395,6 +396,26 @@ const FeatureCardBody = forwardRef<HTMLDivElement, Props>(function FeatureCardBo
     await confirmSolanaTransaction(chainConfig.rpc, signatureToString(signature));
   }
 
+  // Record the owner->wallet authorization so the featured grid will render this
+  // promotion (audit #8). Best-effort with one retry; the server gate (owner-only)
+  // is what secures it. If it ultimately fails, the promotion is briefly hidden
+  // until re-recorded.
+  async function recordPromotionAuthorization(projectId: string, walletAddress: string, txHash: string) {
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        const res = await fetch("/api/promotions", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ project_id: projectId, wallet_address: walletAddress, tx_ref: txHash, chain: "base" }),
+        });
+        if (res.ok) return;
+      } catch {
+        // retry
+      }
+    }
+    console.error("Failed to record promotion authorization for project", projectId);
+  }
+
   async function handlePromote() {
     const project = projects.find((p) => p.id === selectedProject);
     if (!project) {
@@ -417,8 +438,14 @@ const FeatureCardBody = forwardRef<HTMLDivElement, Props>(function FeatureCardBo
     const price = prices[selectedPkg];
     setBusy(true);
     try {
-      if (isEVM) await handlePromoteEVM(project, price, chainConfig);
-      else if (isSol) await handlePromoteSolana(project, price, chainConfig);
+      if (isEVM) {
+        const txHash = await handlePromoteEVM(project, price, chainConfig);
+        if (connectedWallet) {
+          await recordPromotionAuthorization(project.id, connectedWallet.address, txHash);
+        }
+      } else if (isSol) {
+        await handlePromoteSolana(project, price, chainConfig);
+      }
 
       setStatus({ msg: `"${project.title}" is now featured!`, type: "success" });
       setSelectedProject("");

--- a/src/lib/__tests__/featured-promotions.test.ts
+++ b/src/lib/__tests__/featured-promotions.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { filterAuthorizedPromotions } from "../featured-promotions";
+
+// Minimal shape the filter cares about.
+const mk = (projectId: string, promoter: string) => ({ projectId, promoter });
+
+describe("filterAuthorizedPromotions", () => {
+  it("keeps an authorized promotion", () => {
+    const authorized = new Set(["p1:0xabc"]);
+    expect(filterAuthorizedPromotions([mk("p1", "0xABC")], authorized)).toHaveLength(1);
+  });
+
+  it("drops a hijack — payer not authorized for the project", () => {
+    const authorized = new Set(["p1:0xowner"]);
+    expect(filterAuthorizedPromotions([mk("p1", "0xattacker")], authorized)).toHaveLength(0);
+  });
+
+  it("matches wallet addresses case-insensitively", () => {
+    const authorized = new Set(["p1:0xabc"]);
+    expect(filterAuthorizedPromotions([mk("p1", "0xAbC")], authorized)).toHaveLength(1);
+  });
+
+  it("drops a promotion for an unauthorized / unknown projectId", () => {
+    const authorized = new Set(["p1:0xabc"]);
+    expect(filterAuthorizedPromotions([mk("p2", "0xabc")], authorized)).toHaveLength(0);
+  });
+
+  it("hides everything when there are no authorizations", () => {
+    expect(filterAuthorizedPromotions([mk("p1", "0xabc")], new Set())).toHaveLength(0);
+  });
+
+  it("keeps only the authorized subset from a mixed list", () => {
+    const authorized = new Set(["p1:0xabc", "p3:0xdef"]);
+    const result = filterAuthorizedPromotions(
+      [mk("p1", "0xabc"), mk("p2", "0xbad"), mk("p3", "0xDEF")],
+      authorized
+    );
+    expect(result.map((p) => p.projectId).sort()).toEqual(["p1", "p3"]);
+  });
+});

--- a/src/lib/featured-promotions.ts
+++ b/src/lib/featured-promotions.ts
@@ -164,6 +164,20 @@ export function msUntilNextExpiry(promos: Pick<Promotion, "expiresAt">[]): numbe
   return Math.min(Math.min(...future) - nowMs + 1000, 2_000_000_000);
 }
 
+// Ownership verification for audit finding #8. The on-chain promote(projectId,…)
+// call accepts an arbitrary projectId, so a payer can pay to feature a project
+// they don't own. We render a promotion only if its on-chain payer was
+// authorized by the project's owner (recorded server-side in featured_promotions,
+// keyed by `${project_id}:${promoter_wallet}`). Pure + exported for unit testing.
+export function filterAuthorizedPromotions<T extends { projectId: string; promoter: string }>(
+  promotions: T[],
+  authorizedKeys: Set<string>,
+): T[] {
+  return promotions.filter((p) =>
+    authorizedKeys.has(`${p.projectId}:${(p.promoter || "").toLowerCase()}`),
+  );
+}
+
 // Optional `client` lets callers (e.g. server components running inside
 // `unstable_cache`) pass a cookie-free Supabase client — Next.js disallows
 // reading `cookies()` inside cached scopes, which would happen if we always
@@ -178,10 +192,27 @@ export async function enrichPromotions(
     const supabase = client ?? createClient();
     const projectIds = [...new Set(promotions.map((p) => p.projectId))];
 
+    // Ownership gate (#8): drop any promotion whose on-chain payer wasn't
+    // authorized by the project's owner. featured_promotions isn't in the
+    // generated DB types yet, so the query is cast.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: auths } = await (supabase as any)
+      .from("featured_promotions")
+      .select("project_id, promoter_wallet")
+      .in("project_id", projectIds);
+    const authorizedKeys = new Set(
+      ((auths ?? []) as Array<{ project_id: string; promoter_wallet: string }>).map(
+        (a) => `${a.project_id}:${a.promoter_wallet.toLowerCase()}`,
+      ),
+    );
+    const verified = filterAuthorizedPromotions(promotions, authorizedKeys);
+    if (verified.length === 0) return [];
+
+    const verifiedProjectIds = [...new Set(verified.map((p) => p.projectId))];
     const { data: projects } = await supabase
       .from("projects")
       .select("id, title, description, tech_stack, live_url, github_url, image_url, verified, quality_score, endorsement_count, user_id")
-      .in("id", projectIds);
+      .in("id", verifiedProjectIds);
 
     // Supabase's typed client narrows the row to `never` when the select
     // string can't be resolved against the generated Database type — cast
@@ -204,13 +235,15 @@ export async function enrichPromotions(
       userMap.set(u.id, u);
     }
 
-    return promotions.map((promo) => {
+    return verified.map((promo) => {
       const proj = projectMap.get(promo.projectId) || null;
       const author = proj ? userMap.get(proj.user_id) || null : null;
       return { ...promo, project: proj, author };
     });
   } catch {
-    // Graceful fallback — show basic promotion data
-    return promotions.map((promo) => ({ ...promo, project: null, author: null }));
+    // Fail closed: if we can't verify ownership, render nothing rather than risk
+    // showing an unverified (possibly hijacked) promotion. Promotions are
+    // non-critical UI.
+    return [];
   }
 }

--- a/supabase/migrations/20260530_featured_promotions.sql
+++ b/supabase/migrations/20260530_featured_promotions.sql
@@ -1,0 +1,48 @@
+-- Featured-promotion ownership authorization (audit finding #8).
+--
+-- The on-chain promote(string projectId, ...) call accepts an arbitrary
+-- projectId, so a payer can pay to feature a project they don't own. We record
+-- an authorization when a project's OWNER promotes it (server-enforced), and the
+-- featured grid renders only on-chain promotions that have a matching
+-- authorization. Forward-compatible with the upcoming Solana payments phase
+-- (the chain / tx_ref / package_id / paid_amount / expires_at columns).
+--
+-- Editor-safe: plain statements, no DO/$$ blocks.
+
+create table if not exists public.featured_promotions (
+  id              uuid primary key default gen_random_uuid(),
+  project_id      uuid not null references public.projects(id) on delete cascade,
+  user_id         uuid not null references public.users(id) on delete cascade,
+  promoter_wallet text not null,                  -- lowercased EVM addr / Solana base58
+  chain           text not null default 'base',   -- 'base' | 'solana'
+  tx_ref          text,                           -- EVM tx hash / Solana signature
+  package_id      smallint,                       -- tier (Solana); EVM optional
+  paid_amount     bigint,                         -- USDC base units (Solana)
+  expires_at      timestamptz,                    -- Solana: computed; EVM: null (contract owns expiry)
+  created_at      timestamptz not null default now()
+);
+
+-- Replay protection + ON CONFLICT (tx_ref) upsert target. Plain (non-partial)
+-- unique index: Postgres treats NULLs as distinct, so multiple null tx_refs are
+-- allowed while non-null signatures/hashes stay unique.
+create unique index if not exists featured_promotions_txref_uniq
+  on public.featured_promotions (tx_ref);
+create index if not exists featured_promotions_membership
+  on public.featured_promotions (project_id, promoter_wallet);
+create index if not exists featured_promotions_solana_render
+  on public.featured_promotions (chain, expires_at);
+
+alter table public.featured_promotions enable row level security;
+
+-- Writes are service-role only (the /api/promotions endpoint, after a server-side
+-- owner check) — so an authorization can't be forged via the public anon key.
+grant all on public.featured_promotions to service_role;
+
+-- The render path needs only (project_id, promoter_wallet) — both already public
+-- on-chain. Grant SELECT on just those two columns; no INSERT/UPDATE/DELETE.
+revoke all on public.featured_promotions from anon, authenticated;
+grant select (project_id, promoter_wallet) on public.featured_promotions to anon, authenticated;
+
+drop policy if exists "Promotion authorizations are publicly readable" on public.featured_promotions;
+create policy "Promotion authorizations are publicly readable"
+  on public.featured_promotions for select using (true);


### PR DESCRIPTION
## Audit finding #8 — featured-promotion ownership

The on-chain `promote(string projectId, …)` call (Base) accepts an **arbitrary** `projectId`, and `enrichPromotions` rendered the featured grid attributing each promotion to that project's real owner — with no check that the paying wallet owns it. So anyone could **pay to feature any project** (e.g. a competitor's), shown as the victim's.

Fixed read-side (the contract is deployed and not in this repo).

### How it works now
- **`featured_promotions` table** records an authorization when a project's **owner** promotes it. `POST /api/promotions` is gated by `project.user_id === session.user.id` (403 otherwise). **Service-role writes only**; anon may `SELECT` just `(project_id, promoter_wallet)` — so authorizations can't be forged via the public anon key.
- **`enrichPromotions`** renders only on-chain promotions that have a matching authorization (pure, unit-tested `filterAuthorizedPromotions`). A hijack attempt has no authorization → **hidden**. The error path now **fails closed** (hide rather than show unverified).
- The **promote card** records the authorization right after a successful EVM promote tx (best-effort + one retry).

### Notes
- **Requires applying** `supabase/migrations/20260530_featured_promotions.sql`. Until then the featured grid fails closed (empty) — and there are **0 active promotions** today, so no visible change.
- The table is **forward-compatible** with the upcoming Solana/$VIBE payments phase (`chain`, `tx_ref`, `package_id`, `paid_amount`, `expires_at`).
- On-chain tx verification is intentionally out of scope: a forged authorization with no real on-chain promotion renders nothing.

### Verification
✅ `tsc` · `eslint` · **258 tests** (+6 new) · `next build` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Featured promotion authorization system enabling project owners to authorize promotions for their projects
  * Promotion authorizations validated through on-chain transactions
  * Server-side authorization checks enforced before displaying approved promotions

* **Tests**
  * Added test coverage for authorization filtering and validation logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unknownking07/vibe-talent/pull/202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->