### PR TITLE
feat(payments): accept Solana USDC + $VIBE for featured promotions

### DIFF
--- a/src/app/api/solana/quote/route.ts
+++ b/src/app/api/solana/quote/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { CHAIN_CONFIGS, isSolanaChain } from "@/lib/chains-config";
+import {
+  isValidPackageId,
+  expectedTokenAmount,
+  fetchContractPricesCached,
+  fetchVibeUsdCached,
+  type PaymentToken,
+} from "@/lib/promotion-pricing";
+
+// GET /api/solana/quote?package_id=2&token=vibe
+// Returns the exact on-chain amount (base units) the client should transfer,
+// from the SAME price source the verifier uses — so the payment passes
+// verification (within the 60s price cache + 90% slippage floor).
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const pkg = Number(searchParams.get("package_id"));
+    const tok: PaymentToken = searchParams.get("token") === "vibe" ? "vibe" : "usdc";
+
+    if (!Number.isInteger(pkg) || !isValidPackageId(pkg)) {
+      return NextResponse.json({ error: "Invalid package_id" }, { status: 400 });
+    }
+    const solana = CHAIN_CONFIGS.solana;
+    if (!isSolanaChain(solana)) {
+      return NextResponse.json({ error: "Solana not configured" }, { status: 500 });
+    }
+
+    const prices = await fetchContractPricesCached();
+    const usdcPrice = prices[pkg];
+    if (usdcPrice == null) {
+      return NextResponse.json({ error: "Price unavailable" }, { status: 500 });
+    }
+
+    if (tok === "usdc") {
+      return NextResponse.json(
+        {
+          token: "usdc",
+          amount: usdcPrice.toString(),
+          decimals: solana.usdcDecimals,
+          usd: Number(usdcPrice) / 1e6,
+        },
+        { headers: { "Cache-Control": "public, s-maxage=30" } }
+      );
+    }
+
+    let vibeUsd: number;
+    try {
+      vibeUsd = await fetchVibeUsdCached();
+    } catch {
+      return NextResponse.json({ error: "Couldn't price $VIBE right now." }, { status: 503 });
+    }
+    const amount = expectedTokenAmount(usdcPrice, "vibe", vibeUsd, solana.vibeDecimals);
+    return NextResponse.json(
+      {
+        token: "vibe",
+        amount: amount.toString(),
+        decimals: solana.vibeDecimals,
+        vibeUsd,
+        usd: Number(usdcPrice) / 1e6,
+      },
+      { headers: { "Cache-Control": "public, s-maxage=30" } }
+    );
+  } catch {
+    return NextResponse.json({ error: "Quote failed" }, { status: 400 });
+  }
+}

--- a/src/app/api/solana/quote/route.ts
+++ b/src/app/api/solana/quote/route.ts
@@ -16,17 +16,29 @@ export async function GET(req: NextRequest) {
   try {
     const { searchParams } = new URL(req.url);
     const pkg = Number(searchParams.get("package_id"));
-    const tok: PaymentToken = searchParams.get("token") === "vibe" ? "vibe" : "usdc";
+    const tokenParam = searchParams.get("token");
 
     if (!Number.isInteger(pkg) || !isValidPackageId(pkg)) {
       return NextResponse.json({ error: "Invalid package_id" }, { status: 400 });
     }
+    if (tokenParam !== "usdc" && tokenParam !== "vibe") {
+      return NextResponse.json({ error: "Invalid token" }, { status: 400 });
+    }
+    const tok: PaymentToken = tokenParam;
     const solana = CHAIN_CONFIGS.solana;
     if (!isSolanaChain(solana)) {
       return NextResponse.json({ error: "Solana not configured" }, { status: 500 });
     }
 
-    const prices = await fetchContractPricesCached();
+    let prices: bigint[];
+    try {
+      prices = await fetchContractPricesCached();
+    } catch {
+      return NextResponse.json(
+        { error: "Pricing unavailable right now. Please retry." },
+        { status: 503 }
+      );
+    }
     const usdcPrice = prices[pkg];
     if (usdcPrice == null) {
       return NextResponse.json({ error: "Price unavailable" }, { status: 500 });

--- a/src/app/api/solana/verify/route.ts
+++ b/src/app/api/solana/verify/route.ts
@@ -46,7 +46,10 @@ export async function POST(req: NextRequest) {
     if (!Number.isInteger(pkg) || !isValidPackageId(pkg)) {
       return NextResponse.json({ error: "Invalid package_id" }, { status: 400 });
     }
-    const tok: PaymentToken = token === "vibe" ? "vibe" : "usdc";
+    if (token !== "usdc" && token !== "vibe") {
+      return NextResponse.json({ error: "Invalid token" }, { status: 400 });
+    }
+    const tok: PaymentToken = token;
 
     const solana = CHAIN_CONFIGS.solana;
     if (!isSolanaChain(solana)) {
@@ -97,7 +100,17 @@ export async function POST(req: NextRequest) {
         ],
       }),
     });
+    if (!txRes.ok) {
+      return NextResponse.json(
+        { error: "Couldn't reach the Solana network. Please retry." },
+        { status: 503 }
+      );
+    }
     const txJson = await txRes.json();
+    if (txJson?.error) {
+      // JSON-RPC error from the node — a provider failure, not a missing tx.
+      return NextResponse.json({ error: "Solana RPC error. Please retry." }, { status: 503 });
+    }
     const tx = txJson?.result;
     if (!tx) {
       return NextResponse.json(
@@ -119,7 +132,15 @@ export async function POST(req: NextRequest) {
     }
 
     // 7. Expected amount for the package.
-    const prices = await fetchContractPricesCached();
+    let prices: bigint[];
+    try {
+      prices = await fetchContractPricesCached();
+    } catch {
+      return NextResponse.json(
+        { error: "Pricing unavailable right now. Please retry." },
+        { status: 503 }
+      );
+    }
     const usdcPrice = prices[pkg];
     if (usdcPrice == null) {
       return NextResponse.json({ error: "Price unavailable" }, { status: 500 });

--- a/src/app/api/solana/verify/route.ts
+++ b/src/app/api/solana/verify/route.ts
@@ -1,0 +1,185 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { validateUUID } from "@/lib/validation";
+import { CHAIN_CONFIGS, isSolanaChain } from "@/lib/chains-config";
+import {
+  isValidPackageId,
+  expiresAtFor,
+  expectedTokenAmount,
+  passesSlippage,
+  pickReceivedDelta,
+  extractMemos,
+  fetchContractPricesCached,
+  fetchVibeUsdCached,
+  type PaymentToken,
+} from "@/lib/promotion-pricing";
+
+// Verifies a Solana USDC/$VIBE payment and records the featured promotion.
+// Unlike Base (where the contract binds the payment to a projectId), a Solana
+// transfer is bare — so the payer must stamp the project_id into the tx MEMO,
+// which we require here. Combined with the owner gate + replay check, that
+// binds each payment to one project and one submitter.
+
+const SIGNATURE_RE = /^[1-9A-HJ-NP-Za-km-z]{64,100}$/;
+
+export async function POST(req: NextRequest) {
+  try {
+    // 1. Auth
+    const authClient = await createServerSupabaseClient();
+    const { data: { user } } = await authClient.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: "You must be signed in." }, { status: 401 });
+    }
+
+    // 2. Validate input
+    const body = await req.json();
+    const { project_id, signature, package_id, token } = body ?? {};
+
+    if (!project_id || !validateUUID(project_id)) {
+      return NextResponse.json({ error: "Invalid project_id" }, { status: 400 });
+    }
+    if (typeof signature !== "string" || !SIGNATURE_RE.test(signature)) {
+      return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
+    }
+    const pkg = Number(package_id);
+    if (!Number.isInteger(pkg) || !isValidPackageId(pkg)) {
+      return NextResponse.json({ error: "Invalid package_id" }, { status: 400 });
+    }
+    const tok: PaymentToken = token === "vibe" ? "vibe" : "usdc";
+
+    const solana = CHAIN_CONFIGS.solana;
+    if (!isSolanaChain(solana)) {
+      return NextResponse.json({ error: "Solana not configured" }, { status: 500 });
+    }
+
+    const sb = createAdminClient();
+
+    // 3. Owner gate — only the project's owner may promote it.
+    const { data: project, error: projErr } = await sb
+      .from("projects")
+      .select("id, user_id")
+      .eq("id", project_id)
+      .single();
+    if (projErr || !project) {
+      return NextResponse.json({ error: "Project not found" }, { status: 404 });
+    }
+    if (project.user_id !== user.id) {
+      return NextResponse.json(
+        { error: "You can only promote your own project." },
+        { status: 403 }
+      );
+    }
+
+    // 4. Replay — a signature can only ever be used once.
+    const { data: existing } = await sb
+      .from("featured_promotions")
+      .select("id")
+      .eq("tx_ref", signature)
+      .maybeSingle();
+    if (existing) {
+      return NextResponse.json({ error: "This transaction was already used." }, { status: 409 });
+    }
+
+    // 5. Fetch the finalized transaction.
+    const txRes = await fetch(solana.rpc, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "getTransaction",
+        params: [
+          signature,
+          // 'confirmed' (not 'finalized') so verification works seconds after the
+          // wallet returns; confirmed-depth reorgs are vanishingly rare on Solana.
+          { commitment: "confirmed", maxSupportedTransactionVersion: 0, encoding: "jsonParsed" },
+        ],
+      }),
+    });
+    const txJson = await txRes.json();
+    const tx = txJson?.result;
+    if (!tx) {
+      return NextResponse.json(
+        { error: "Transaction not found or not confirmed yet." },
+        { status: 404 }
+      );
+    }
+    if (tx.meta?.err) {
+      return NextResponse.json({ error: "That transaction failed on-chain." }, { status: 400 });
+    }
+
+    // 6. Memo binding — the payer must have stamped this project_id into the tx.
+    const memos = extractMemos(tx.transaction?.message?.instructions ?? []);
+    if (!memos.includes(project_id)) {
+      return NextResponse.json(
+        { error: "Payment is not bound to this project." },
+        { status: 400 }
+      );
+    }
+
+    // 7. Expected amount for the package.
+    const prices = await fetchContractPricesCached();
+    const usdcPrice = prices[pkg];
+    if (usdcPrice == null) {
+      return NextResponse.json({ error: "Price unavailable" }, { status: 500 });
+    }
+
+    const mint = tok === "vibe" ? solana.vibeMint : solana.usdcMint;
+    let expected: bigint;
+    if (tok === "vibe") {
+      let vibeUsd: number;
+      try {
+        vibeUsd = await fetchVibeUsdCached();
+      } catch {
+        return NextResponse.json(
+          { error: "Couldn't price $VIBE right now — try USDC or retry." },
+          { status: 503 }
+        );
+      }
+      expected = expectedTokenAmount(usdcPrice, "vibe", vibeUsd, solana.vibeDecimals);
+    } else {
+      expected = expectedTokenAmount(usdcPrice, "usdc", 0);
+    }
+
+    // 8. Amount via balance delta to the receiving wallet (proves mint + dest + amount).
+    const received = pickReceivedDelta(
+      tx.meta?.preTokenBalances ?? [],
+      tx.meta?.postTokenBalances ?? [],
+      solana.receivingWallet,
+      mint
+    );
+    if (!passesSlippage(received, expected)) {
+      return NextResponse.json(
+        { error: "Payment amount is too low for this package." },
+        { status: 400 }
+      );
+    }
+
+    // 9. Record (idempotent on tx_ref). promoter_wallet = fee payer.
+    const keys = tx.transaction?.message?.accountKeys ?? [];
+    const sender = (keys[0]?.pubkey ?? keys[0] ?? "").toString();
+
+    const { error: insErr } = await sb.from("featured_promotions").upsert(
+      {
+        project_id,
+        user_id: user.id,
+        promoter_wallet: sender,
+        chain: "solana",
+        tx_ref: signature,
+        package_id: pkg,
+        paid_amount: received.toString(),
+        expires_at: expiresAtFor(pkg, Date.now()),
+      },
+      { onConflict: "tx_ref" }
+    );
+    if (insErr) {
+      console.error("Failed to record Solana promotion:", insErr);
+      return NextResponse.json({ error: "Failed to record promotion." }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+}

--- a/src/components/ui/featured/feature-your-project-card.tsx
+++ b/src/components/ui/featured/feature-your-project-card.tsx
@@ -426,7 +426,8 @@ const FeatureCardBody = forwardRef<HTMLDivElement, Props>(function FeatureCardBo
         verified = true;
         break;
       }
-      if (res.status !== 404) {
+      // Retry transient states: 404 (tx not visible yet) and 503 (RPC hiccup).
+      if (res.status !== 404 && res.status !== 503) {
         const e = await res.json().catch(() => ({}));
         throw new Error(e.error || "Payment verification failed.");
       }
@@ -513,6 +514,41 @@ const FeatureCardBody = forwardRef<HTMLDivElement, Props>(function FeatureCardBo
   // If admin reorders packages someday, this assumption breaks.
   const fromPerDay = `$${(Number(prices[0]) / 1e6).toFixed(2)}`;
 
+  // Solana token (USDC / $VIBE) picker. Rendered in BOTH the idle and the
+  // expanded payment stages so the choice is always visible when paying.
+  // Only relevant to the Solana lane.
+  const solanaTokenToggle = isSol ? (
+    <div className="mb-4">
+      <label className="block text-[10px] font-bold uppercase tracking-wider text-[var(--text-muted)] mb-1.5">
+        Token
+      </label>
+      <div className="grid grid-cols-2 gap-2">
+        {(["usdc", "vibe"] as const).map((t) => {
+          const active = selectedToken === t;
+          return (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setSelectedToken(t)}
+              className="px-3 py-2 text-xs font-extrabold uppercase transition-all"
+              style={{
+                border: `2px solid ${active ? "var(--accent)" : "var(--border-hard)"}`,
+                backgroundColor: active
+                  ? "color-mix(in srgb, var(--accent) 14%, var(--bg-surface))"
+                  : "var(--bg-surface)",
+                color: "var(--foreground)",
+                boxShadow: active ? "var(--shadow-brutal-xs)" : "none",
+              }}
+              aria-pressed={active}
+            >
+              {t === "usdc" ? "USDC" : "$VIBE"}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  ) : null;
+
   return (
     <div
       ref={ref}
@@ -571,32 +607,7 @@ const FeatureCardBody = forwardRef<HTMLDivElement, Props>(function FeatureCardBo
               })}
             </div>
 
-            {isSol && (
-              <div className="grid grid-cols-2 gap-2 mb-4">
-                {(["usdc", "vibe"] as const).map((t) => {
-                  const active = selectedToken === t;
-                  return (
-                    <button
-                      key={t}
-                      type="button"
-                      onClick={() => setSelectedToken(t)}
-                      className="px-3 py-2 text-xs font-extrabold uppercase transition-all"
-                      style={{
-                        border: `2px solid ${active ? "var(--accent)" : "var(--border-hard)"}`,
-                        backgroundColor: active
-                          ? "color-mix(in srgb, var(--accent) 14%, var(--bg-surface))"
-                          : "var(--bg-surface)",
-                        color: "var(--foreground)",
-                        boxShadow: active ? "var(--shadow-brutal-xs)" : "none",
-                      }}
-                      aria-pressed={active}
-                    >
-                      {t === "usdc" ? "USDC" : "$VIBE"}
-                    </button>
-                  );
-                })}
-              </div>
-            )}
+            {solanaTokenToggle}
 
             <div className="flex-1" />
 
@@ -676,6 +687,8 @@ const FeatureCardBody = forwardRef<HTMLDivElement, Props>(function FeatureCardBo
                 </select>
               )}
             </div>
+
+            {solanaTokenToggle}
 
             <div className="mb-3">
               <label className="block text-[10px] font-bold uppercase tracking-wider text-[var(--text-muted)] mb-1.5">

--- a/src/components/ui/featured/feature-your-project-card.tsx
+++ b/src/components/ui/featured/feature-your-project-card.tsx
@@ -21,7 +21,7 @@ import {
   type EVMChainConfig,
   type SolanaChainConfig,
 } from "@/lib/chains-config";
-import { buildSolanaUSDCTransfer, confirmSolanaTransaction, signatureToString } from "@/lib/solana-payment";
+import { buildSolanaTokenTransfer, signatureToString } from "@/lib/solana-payment";
 import { ChainDot, type ChainKey } from "./chain-dot";
 
 const BASE_CONFIG = CHAIN_CONFIGS.base;
@@ -243,6 +243,7 @@ const FeatureCardBody = forwardRef<HTMLDivElement, Props>(function FeatureCardBo
   const [status, setStatus] = useState<{ msg: string; type: "info" | "error" | "success" } | null>(null);
   const [busy, setBusy] = useState(false);
   const [selectedChain, setSelectedChain] = useState<ChainKey>(DEFAULT_CHAIN as ChainKey);
+  const [selectedToken, setSelectedToken] = useState<"usdc" | "vibe">("usdc");
 
   useEffect(() => {
     fetchPrices().then(setPrices);
@@ -372,28 +373,67 @@ const FeatureCardBody = forwardRef<HTMLDivElement, Props>(function FeatureCardBo
     return txHash as string;
   }
 
-  async function handlePromoteSolana(project: UserProject, price: bigint, chainConfig: SolanaChainConfig) {
+  async function handlePromoteSolana(project: UserProject, chainConfig: SolanaChainConfig) {
     if (!connectedSolanaWallet) throw new Error("No Solana wallet connected");
-    setStatus({ msg: `Building USDC transfer on Solana...`, type: "info" });
-    void project;
+    const token = selectedToken;
+    const label = token === "vibe" ? "$VIBE" : "USDC";
 
-    const serializedTx = await buildSolanaUSDCTransfer({
+    // Ask the server for the exact amount to send — same price source the
+    // verifier uses, so the payment clears verification.
+    const quoteRes = await fetch(`/api/solana/quote?package_id=${selectedPkg}&token=${token}`);
+    if (!quoteRes.ok) {
+      const e = await quoteRes.json().catch(() => ({}));
+      throw new Error(e.error || "Couldn't get a Solana quote. Try again.");
+    }
+    const quote = await quoteRes.json();
+    const amount = BigInt(quote.amount as string);
+    const mint = token === "vibe" ? chainConfig.vibeMint : chainConfig.usdcMint;
+
+    setStatus({ msg: `Building ${label} transfer on Solana...`, type: "info" });
+    const serializedTx = await buildSolanaTokenTransfer({
       senderAddress: connectedSolanaWallet.address,
       rpcUrl: chainConfig.rpc,
-      usdcMint: chainConfig.usdcMint,
+      mint,
       receivingWallet: chainConfig.receivingWallet,
-      amount: price,
+      amount,
+      memo: project.id, // binds the payment to this project for server verification
     });
 
-    setStatus({ msg: `Sending $${(Number(price) / 1e6).toFixed(2)} USDC on Solana...`, type: "info" });
+    setStatus({ msg: `Sending ${label} on Solana...`, type: "info" });
     const { signature } = await privySignAndSend({
       transaction: serializedTx,
       wallet: connectedSolanaWallet,
       chain: "solana:mainnet",
     });
+    const sig = signatureToString(signature);
 
-    setStatus({ msg: `Confirming transaction...`, type: "info" });
-    await confirmSolanaTransaction(chainConfig.rpc, signatureToString(signature));
+    // Verify + record server-side. Retry on 404 while the tx propagates.
+    setStatus({ msg: "Verifying payment...", type: "info" });
+    let verified = false;
+    for (let attempt = 0; attempt < 6; attempt++) {
+      if (attempt > 0) await new Promise((r) => setTimeout(r, 2500));
+      const res = await fetch("/api/solana/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          project_id: project.id,
+          signature: sig,
+          package_id: selectedPkg,
+          token,
+        }),
+      });
+      if (res.ok) {
+        verified = true;
+        break;
+      }
+      if (res.status !== 404) {
+        const e = await res.json().catch(() => ({}));
+        throw new Error(e.error || "Payment verification failed.");
+      }
+    }
+    if (!verified) {
+      throw new Error("Payment sent but not confirmed yet — it'll appear once the network finalizes it.");
+    }
   }
 
   // Record the owner->wallet authorization so the featured grid will render this
@@ -444,7 +484,7 @@ const FeatureCardBody = forwardRef<HTMLDivElement, Props>(function FeatureCardBo
           await recordPromotionAuthorization(project.id, connectedWallet.address, txHash);
         }
       } else if (isSol) {
-        await handlePromoteSolana(project, price, chainConfig);
+        await handlePromoteSolana(project, chainConfig);
       }
 
       setStatus({ msg: `"${project.title}" is now featured!`, type: "success" });
@@ -494,7 +534,7 @@ const FeatureCardBody = forwardRef<HTMLDivElement, Props>(function FeatureCardBo
             {/* Idle stage */}
             <div className="flex items-center justify-between mb-2">
               <label className="text-[10px] font-bold uppercase tracking-wider text-[var(--text-muted)]">
-                Pay with USDC on
+                Pay on
               </label>
               <span
                 className="font-mono text-[10px] font-bold px-2 py-0.5"
@@ -530,6 +570,33 @@ const FeatureCardBody = forwardRef<HTMLDivElement, Props>(function FeatureCardBo
                 );
               })}
             </div>
+
+            {isSol && (
+              <div className="grid grid-cols-2 gap-2 mb-4">
+                {(["usdc", "vibe"] as const).map((t) => {
+                  const active = selectedToken === t;
+                  return (
+                    <button
+                      key={t}
+                      type="button"
+                      onClick={() => setSelectedToken(t)}
+                      className="px-3 py-2 text-xs font-extrabold uppercase transition-all"
+                      style={{
+                        border: `2px solid ${active ? "var(--accent)" : "var(--border-hard)"}`,
+                        backgroundColor: active
+                          ? "color-mix(in srgb, var(--accent) 14%, var(--bg-surface))"
+                          : "var(--bg-surface)",
+                        color: "var(--foreground)",
+                        boxShadow: active ? "var(--shadow-brutal-xs)" : "none",
+                      }}
+                      aria-pressed={active}
+                    >
+                      {t === "usdc" ? "USDC" : "$VIBE"}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
 
             <div className="flex-1" />
 

--- a/src/lib/__tests__/promotion-pricing.test.ts
+++ b/src/lib/__tests__/promotion-pricing.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import {
+  expectedTokenAmount,
+  passesSlippage,
+  expiresAtFor,
+  isValidPackageId,
+  pickReceivedDelta,
+  extractMemos,
+} from "../promotion-pricing";
+
+describe("expectedTokenAmount", () => {
+  it("returns the USDC base units unchanged for USDC", () => {
+    expect(expectedTokenAmount(BigInt(10_000_000), "usdc", 0)).toBe(BigInt(10_000_000));
+  });
+
+  it("converts USD to $VIBE base units via the price", () => {
+    // $5 at $0.000005/token = 1,000,000 $VIBE = 1e15 base units (9 decimals)
+    expect(expectedTokenAmount(BigInt(5_000_000), "vibe", 0.000005)).toBe(
+      BigInt(1_000_000_000_000_000)
+    );
+  });
+
+  it("throws when the $VIBE price is missing or non-positive", () => {
+    expect(() => expectedTokenAmount(BigInt(5_000_000), "vibe", 0)).toThrow();
+    expect(() => expectedTokenAmount(BigInt(5_000_000), "vibe", -1)).toThrow();
+  });
+});
+
+describe("passesSlippage", () => {
+  it("accepts payment exactly at the 90% floor", () => {
+    expect(passesSlippage(BigInt(900), BigInt(1000))).toBe(true);
+  });
+  it("accepts overpayment", () => {
+    expect(passesSlippage(BigInt(1500), BigInt(1000))).toBe(true);
+  });
+  it("rejects payment below the floor", () => {
+    expect(passesSlippage(BigInt(899), BigInt(1000))).toBe(false);
+  });
+  it("respects a custom floor", () => {
+    expect(passesSlippage(BigInt(949), BigInt(1000), 9500)).toBe(false);
+    expect(passesSlippage(BigInt(950), BigInt(1000), 9500)).toBe(true);
+  });
+});
+
+describe("expiresAtFor", () => {
+  const now = 1_700_000_000_000;
+  it("computes a future expiry for timed packages", () => {
+    expect(new Date(expiresAtFor(2, now)!).getTime() - now).toBe(7 * 86_400_000);
+    expect(new Date(expiresAtFor(3, now)!).getTime() - now).toBe(30 * 86_400_000);
+  });
+  it("returns null (lifetime) for the Annual package", () => {
+    expect(expiresAtFor(4, now)).toBeNull();
+  });
+});
+
+describe("isValidPackageId", () => {
+  it("accepts 0..4 and rejects others", () => {
+    expect([0, 1, 2, 3, 4].every(isValidPackageId)).toBe(true);
+    expect(isValidPackageId(5)).toBe(false);
+    expect(isValidPackageId(-1)).toBe(false);
+  });
+});
+
+describe("pickReceivedDelta", () => {
+  const R = "ReceivingOwner";
+  const M = "MintAddr";
+  const bal = (owner: string, mint: string, amount: string) => ({
+    owner,
+    mint,
+    uiTokenAmount: { amount },
+  });
+
+  it("computes the net delta for the receiving owner + mint", () => {
+    expect(pickReceivedDelta([bal(R, M, "100")], [bal(R, M, "600")], R, M)).toBe(BigInt(500));
+  });
+
+  it("treats a freshly-created ATA (no pre entry) as 0", () => {
+    expect(pickReceivedDelta([], [bal(R, M, "500")], R, M)).toBe(BigInt(500));
+  });
+
+  it("ignores other owners and other mints", () => {
+    const pre = [bal(R, M, "0")];
+    const post = [bal(R, M, "500"), bal("someoneElse", M, "999"), bal(R, "OtherMint", "999")];
+    expect(pickReceivedDelta(pre, post, R, M)).toBe(BigInt(500));
+  });
+});
+
+describe("extractMemos", () => {
+  const memo = (text: string) => ({
+    program: "spl-memo",
+    programId: "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr",
+    parsed: text,
+  });
+
+  it("returns memo text from spl-memo instructions", () => {
+    expect(extractMemos([memo("proj-123"), { program: "system", parsed: {} }])).toEqual([
+      "proj-123",
+    ]);
+  });
+
+  it("ignores non-memo instructions and empty memos", () => {
+    expect(extractMemos([{ program: "spl-token", parsed: {} }, memo("")])).toEqual([]);
+  });
+
+  it("handles an empty instruction list", () => {
+    expect(extractMemos([])).toEqual([]);
+  });
+});

--- a/src/lib/chains-config.ts
+++ b/src/lib/chains-config.ts
@@ -19,6 +19,8 @@ export type SolanaChainConfig = {
   receivingWallet: string;
   usdcMint: string;
   usdcDecimals: number;
+  vibeMint: string;
+  vibeDecimals: number;
   explorerUrl: string;
 };
 
@@ -43,6 +45,9 @@ export const CHAIN_CONFIGS: Record<string, ChainConfig> = {
     receivingWallet: "DYp2cUmgoBEYPxN9xPwiqKZoi5WR4SRAWJnLD1d5QAdT",
     usdcMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
     usdcDecimals: 6,
+    // $VIBE (Bags-launched, "VIBE TALENT"). Priced via GeckoTerminal — not on Jupiter.
+    vibeMint: "FfDYT3WqimMw7itMxw4kYJ26GPG78RfpZmepQCFpBAGS",
+    vibeDecimals: 9,
     explorerUrl: "https://solscan.io/tx/",
   },
   // Future EVM chains — add contract addresses once deployed:
@@ -59,17 +64,12 @@ export const CHAIN_CONFIGS: Record<string, ChainConfig> = {
   // },
 };
 
-// Solana is intentionally excluded from the selectable chains. Its payment
-// flow is an unverified, unrecorded wallet-to-wallet USDC transfer, and the
-// featured grid is read solely from the Base contract — so a Solana payment
-// would take the user's money and grant no promotion. Keeping it out of
-// SUPPORTED_CHAINS removes it from the picker, which is the only place
-// `selectedChain` can be set, so the broken Solana path can never run.
-// Re-add it ONLY once a server-side flow verifies the transaction
-// (success + recipient + USDC mint + amount + signature uniqueness) and
-// records the grant. The `solana` entry in CHAIN_CONFIGS is retained for
-// that future work.
-export const SUPPORTED_CHAINS = Object.keys(CHAIN_CONFIGS).filter((k) => k !== "solana");
+// Solana payments are verified server-side before a promotion is granted:
+// POST /api/solana/verify checks the on-chain transfer (success, correct mint,
+// destination = receivingWallet, amount ≥ slippage floor, signature uniqueness)
+// and records the promotion in featured_promotions. Both USDC and $VIBE are
+// accepted on Solana. See docs/superpowers/specs/2026-05-30-solana-vibe-payments.
+export const SUPPORTED_CHAINS = Object.keys(CHAIN_CONFIGS);
 export const DEFAULT_CHAIN = "base";
 
 export function getChainConfig(chainKey: string): ChainConfig {

--- a/src/lib/featured-promotions.ts
+++ b/src/lib/featured-promotions.ts
@@ -183,67 +183,102 @@ export function filterAuthorizedPromotions<T extends { projectId: string; promot
 // reading `cookies()` inside cached scopes, which would happen if we always
 // instantiated the request-bound browser/SSR client here.
 type PromotionsClient = ReturnType<typeof createClient>;
+type SolanaPromoRow = {
+  project_id: string;
+  promoter_wallet: string;
+  package_id: number | null;
+  expires_at: string | null;
+  created_at: string;
+};
+
 export async function enrichPromotions(
   promotions: Promotion[],
   client?: PromotionsClient,
 ): Promise<EnrichedPromotion[]> {
-  if (promotions.length === 0) return [];
   try {
     const supabase = client ?? createClient();
-    const projectIds = [...new Set(promotions.map((p) => p.projectId))];
 
-    // Ownership gate (#8): drop any promotion whose on-chain payer wasn't
-    // authorized by the project's owner. featured_promotions isn't in the
-    // generated DB types yet, so the query is cast.
+    // EVM (Base) ownership gate (#8): keep only on-chain promotions whose payer
+    // was authorized by the project's owner. featured_promotions isn't in the
+    // generated DB types yet, so these queries are cast.
+    let verifiedEvm: Promotion[] = [];
+    if (promotions.length > 0) {
+      const evmProjectIds = [...new Set(promotions.map((p) => p.projectId))];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data: auths } = await (supabase as any)
+        .from("featured_promotions")
+        .select("project_id, promoter_wallet")
+        .in("project_id", evmProjectIds);
+      const authorizedKeys = new Set(
+        ((auths ?? []) as Array<{ project_id: string; promoter_wallet: string }>).map(
+          (a) => `${a.project_id}:${a.promoter_wallet.toLowerCase()}`,
+        ),
+      );
+      verifiedEvm = filterAuthorizedPromotions(promotions, authorizedKeys);
+    }
+
+    // Solana promotions: featured_promotions IS the registry (no contract).
+    // Render rows that are still active (lifetime = null expiry, else future).
+    const nowIso = new Date().toISOString();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { data: auths } = await (supabase as any)
+    const { data: solData } = await (supabase as any)
       .from("featured_promotions")
-      .select("project_id, promoter_wallet")
-      .in("project_id", projectIds);
-    const authorizedKeys = new Set(
-      ((auths ?? []) as Array<{ project_id: string; promoter_wallet: string }>).map(
-        (a) => `${a.project_id}:${a.promoter_wallet.toLowerCase()}`,
-      ),
-    );
-    const verified = filterAuthorizedPromotions(promotions, authorizedKeys);
-    if (verified.length === 0) return [];
+      .select("project_id, promoter_wallet, package_id, expires_at, created_at")
+      .eq("chain", "solana")
+      .or(`expires_at.is.null,expires_at.gt.${nowIso}`)
+      .order("created_at", { ascending: false });
+    const solana = (solData ?? []) as SolanaPromoRow[];
 
-    const verifiedProjectIds = [...new Set(verified.map((p) => p.projectId))];
+    if (verifiedEvm.length === 0 && solana.length === 0) return [];
+
+    // Resolve project + author for everything we'll render, in one pair of queries.
+    const allProjectIds = [
+      ...new Set([...verifiedEvm.map((p) => p.projectId), ...solana.map((s) => s.project_id)]),
+    ];
     const { data: projects } = await supabase
       .from("projects")
       .select("id, title, description, tech_stack, live_url, github_url, image_url, verified, quality_score, endorsement_count, user_id")
-      .in("id", verifiedProjectIds);
-
-    // Supabase's typed client narrows the row to `never` when the select
-    // string can't be resolved against the generated Database type — cast
-    // to the projection we actually requested.
+      .in("id", allProjectIds);
     const projectRows = (projects ?? []) as Array<EnrichedProject & { user_id: string }>;
     const projectMap = new Map<string, EnrichedProject & { user_id: string }>();
-    for (const p of projectRows) {
-      projectMap.set(p.id, p);
-    }
+    for (const p of projectRows) projectMap.set(p.id, p);
 
     const userIds = [...new Set(projectRows.map((p) => p.user_id))];
     const { data: users } = await supabase
       .from("users")
       .select("id, username, display_name, avatar_url, vibe_score, streak, badge_level")
       .in("id", userIds);
-
     const userRows = (users ?? []) as Array<EnrichedAuthor & { id: string }>;
     const userMap = new Map<string, EnrichedAuthor>();
-    for (const u of userRows) {
-      userMap.set(u.id, u);
-    }
+    for (const u of userRows) userMap.set(u.id, u);
 
-    return verified.map((promo) => {
+    const evmEnriched: EnrichedPromotion[] = verifiedEvm.map((promo) => {
       const proj = projectMap.get(promo.projectId) || null;
       const author = proj ? userMap.get(proj.user_id) || null : null;
       return { ...promo, project: proj, author };
     });
+
+    const solEnriched: EnrichedPromotion[] = solana.map((row, i) => {
+      const proj = projectMap.get(row.project_id) || null;
+      const author = proj ? userMap.get(proj.user_id) || null : null;
+      return {
+        // Solana rows have no on-chain id; synthesize a stable, collision-free one.
+        id: 1_000_000_000 + i,
+        promoter: row.promoter_wallet,
+        projectId: row.project_id,
+        projectName: proj?.title ?? "",
+        // EnrichedPromotion.expiresAt is Unix seconds; 0 = lifetime (matches EVM).
+        expiresAt: row.expires_at ? Math.floor(new Date(row.expires_at).getTime() / 1000) : 0,
+        paidAmount: 0,
+        project: proj,
+        author,
+      };
+    });
+
+    return [...evmEnriched, ...solEnriched];
   } catch {
-    // Fail closed: if we can't verify ownership, render nothing rather than risk
-    // showing an unverified (possibly hijacked) promotion. Promotions are
-    // non-critical UI.
+    // Fail closed: if we can't verify, render nothing rather than risk showing an
+    // unverified (possibly hijacked) promotion. Promotions are non-critical UI.
     return [];
   }
 }

--- a/src/lib/promotion-pricing.ts
+++ b/src/lib/promotion-pricing.ts
@@ -104,45 +104,40 @@ export function extractMemos(instructions: ParsedInstruction[]): string[] {
 
 // ── Cached network fetchers (server-side only) ──
 
-const FALLBACK_PRICES_USDC: bigint[] = [
-  BigInt(2_000_000), // 0 Day    $2
-  BigInt(5_000_000), // 1 3-day  $5 (hidden)
-  BigInt(10_000_000), // 2 Week   $10
-  BigInt(29_000_000), // 3 Month  $29
-  BigInt(199_000_000), // 4 Annual $199
-];
-
 let pricesCache: { at: number; prices: bigint[] } | null = null;
 
-/** Package prices (USDC base units) from the Base contract's getPrices(), cached 60s. */
+/**
+ * Package prices (USDC base units) from the Base contract's getPrices(), cached
+ * 60s. THROWS on RPC / decoding failure — this is a payment path, so it fails
+ * closed rather than quoting/granting against stale fallback prices that could
+ * undercharge if the admin has changed on-chain prices since. Callers should
+ * surface a 503.
+ */
 export async function fetchContractPricesCached(): Promise<bigint[]> {
   const now = Date.now();
   if (pricesCache && now - pricesCache.at < 60_000) return pricesCache.prices;
   const base = CHAIN_CONFIGS.base;
-  if (!isEVMChain(base)) return FALLBACK_PRICES_USDC;
-  try {
-    const res = await fetch(base.rpc, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: 1,
-        method: "eth_call",
-        params: [{ to: base.contractAddr, data: "0xbd9a548b" }, "latest"],
-      }),
-    });
-    const json = await res.json();
-    const result: unknown = json?.result;
-    if (typeof result !== "string") return FALLBACK_PRICES_USDC;
-    const data = result.startsWith("0x") ? result.slice(2) : result;
-    if (data.length < 5 * 64) return FALLBACK_PRICES_USDC;
-    const prices: bigint[] = [];
-    for (let i = 0; i < 5; i++) prices.push(BigInt("0x" + data.slice(i * 64, i * 64 + 64)));
-    pricesCache = { at: now, prices };
-    return prices;
-  } catch {
-    return FALLBACK_PRICES_USDC;
-  }
+  if (!isEVMChain(base)) throw new Error("Base chain is not configured");
+  const res = await fetch(base.rpc, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "eth_call",
+      params: [{ to: base.contractAddr, data: "0xbd9a548b" }, "latest"],
+    }),
+  });
+  if (!res.ok) throw new Error("Base RPC request failed");
+  const json = await res.json();
+  const result: unknown = json?.result;
+  if (typeof result !== "string") throw new Error("Invalid getPrices() response");
+  const data = result.startsWith("0x") ? result.slice(2) : result;
+  if (data.length < 5 * 64) throw new Error("Truncated getPrices() response");
+  const prices: bigint[] = [];
+  for (let i = 0; i < 5; i++) prices.push(BigInt("0x" + data.slice(i * 64, i * 64 + 64)));
+  pricesCache = { at: now, prices };
+  return prices;
 }
 
 let vibeCache: { at: number; price: number } | null = null;

--- a/src/lib/promotion-pricing.ts
+++ b/src/lib/promotion-pricing.ts
@@ -1,0 +1,167 @@
+// Pricing + verification helpers for Solana / $VIBE featured-promotion payments.
+//
+// Pure helpers (expectedTokenAmount, passesSlippage, expiresAtFor,
+// pickReceivedDelta) are unit-tested. The cached fetchers do network I/O
+// (Base contract getPrices, GeckoTerminal $VIBE price) and run server-side only.
+
+import { CHAIN_CONFIGS, isEVMChain, isSolanaChain } from "@/lib/chains-config";
+
+export type PaymentToken = "usdc" | "vibe";
+
+// Contract package_id → active duration. 4 (Annual) is treated as lifetime by
+// the contract, so its promotion never expires (expires_at = null).
+const PACKAGE_DURATION_DAYS: Record<number, number | null> = {
+  0: 1, // Day
+  1: 3, // 3-day (hidden)
+  2: 7, // Week
+  3: 30, // Month
+  4: null, // Annual = Lifetime
+};
+
+export function isValidPackageId(packageId: number): boolean {
+  return Object.prototype.hasOwnProperty.call(PACKAGE_DURATION_DAYS, packageId);
+}
+
+/** ISO expiry for a package, or null for lifetime. Caller must pass a valid id. */
+export function expiresAtFor(packageId: number, nowMs: number): string | null {
+  const days = PACKAGE_DURATION_DAYS[packageId];
+  if (days == null) return null;
+  return new Date(nowMs + days * 86_400_000).toISOString();
+}
+
+/**
+ * Expected on-chain amount (base units) for a package price.
+ * @param usdcBaseUnits package price from the contract (USDC, 6 decimals).
+ * @param token         'usdc' (Solana USDC, 6dp) or 'vibe' (9dp).
+ * @param vibeUsd       $VIBE price in USD (required for 'vibe').
+ */
+export function expectedTokenAmount(
+  usdcBaseUnits: bigint,
+  token: PaymentToken,
+  vibeUsd: number,
+  vibeDecimals = 9,
+): bigint {
+  if (token === "usdc") return usdcBaseUnits;
+  if (!(vibeUsd > 0)) throw new Error("Invalid $VIBE price");
+  const usdValue = Number(usdcBaseUnits) / 1e6; // dollars
+  const vibeTokens = usdValue / vibeUsd; // whole $VIBE
+  // Precision note: result can exceed Number.MAX_SAFE_INTEGER, but the error is
+  // < 1 part in 1e15 — utterly negligible against the 90% slippage floor.
+  return BigInt(Math.round(vibeTokens * 10 ** vibeDecimals));
+}
+
+/** Did the buyer pay at least `floorBps`/10000 of the expected amount? */
+export function passesSlippage(paid: bigint, expected: bigint, floorBps = 9000): boolean {
+  return paid * BigInt(10000) >= expected * BigInt(floorBps);
+}
+
+type TokenBalance = {
+  owner?: string | null;
+  mint: string;
+  uiTokenAmount?: { amount?: string | null } | null;
+};
+
+/**
+ * Net base-unit delta received by `receivingOwner` for `mint`, from a parsed
+ * transaction's pre/post token balances. Handles the ATA-created-this-tx case
+ * (no pre entry → counted as 0). Proves mint + destination + amount in one shot.
+ */
+export function pickReceivedDelta(
+  pre: TokenBalance[],
+  post: TokenBalance[],
+  receivingOwner: string,
+  mint: string,
+): bigint {
+  const sum = (arr: TokenBalance[]) =>
+    (arr || [])
+      .filter((b) => b.owner === receivingOwner && b.mint === mint)
+      .reduce((acc, b) => acc + BigInt(b.uiTokenAmount?.amount || "0"), BigInt(0));
+  return sum(post) - sum(pre);
+}
+
+const MEMO_PROGRAM_IDS = new Set([
+  "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr", // memo v2
+  "Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo", // memo v1
+]);
+
+type ParsedInstruction = { program?: string; programId?: string; parsed?: unknown };
+
+/**
+ * Memo strings from a parsed transaction's top-level instructions. Used to bind
+ * a Solana payment to a specific project: the payer stamps the project_id into
+ * the memo inside their signed tx, so it can't be forged onto someone else's
+ * payment (prevents claiming another user's transfer for your own project).
+ */
+export function extractMemos(instructions: ParsedInstruction[]): string[] {
+  return (instructions || [])
+    .filter(
+      (ix) =>
+        ix.program === "spl-memo" || (ix.programId != null && MEMO_PROGRAM_IDS.has(ix.programId)),
+    )
+    .map((ix) => (typeof ix.parsed === "string" ? ix.parsed : ""))
+    .filter((m) => m.length > 0);
+}
+
+// ── Cached network fetchers (server-side only) ──
+
+const FALLBACK_PRICES_USDC: bigint[] = [
+  BigInt(2_000_000), // 0 Day    $2
+  BigInt(5_000_000), // 1 3-day  $5 (hidden)
+  BigInt(10_000_000), // 2 Week   $10
+  BigInt(29_000_000), // 3 Month  $29
+  BigInt(199_000_000), // 4 Annual $199
+];
+
+let pricesCache: { at: number; prices: bigint[] } | null = null;
+
+/** Package prices (USDC base units) from the Base contract's getPrices(), cached 60s. */
+export async function fetchContractPricesCached(): Promise<bigint[]> {
+  const now = Date.now();
+  if (pricesCache && now - pricesCache.at < 60_000) return pricesCache.prices;
+  const base = CHAIN_CONFIGS.base;
+  if (!isEVMChain(base)) return FALLBACK_PRICES_USDC;
+  try {
+    const res = await fetch(base.rpc, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "eth_call",
+        params: [{ to: base.contractAddr, data: "0xbd9a548b" }, "latest"],
+      }),
+    });
+    const json = await res.json();
+    const result: unknown = json?.result;
+    if (typeof result !== "string") return FALLBACK_PRICES_USDC;
+    const data = result.startsWith("0x") ? result.slice(2) : result;
+    if (data.length < 5 * 64) return FALLBACK_PRICES_USDC;
+    const prices: bigint[] = [];
+    for (let i = 0; i < 5; i++) prices.push(BigInt("0x" + data.slice(i * 64, i * 64 + 64)));
+    pricesCache = { at: now, prices };
+    return prices;
+  } catch {
+    return FALLBACK_PRICES_USDC;
+  }
+}
+
+let vibeCache: { at: number; price: number } | null = null;
+
+/** $VIBE price in USD via GeckoTerminal, cached 60s. Throws if unavailable. */
+export async function fetchVibeUsdCached(): Promise<number> {
+  const now = Date.now();
+  if (vibeCache && now - vibeCache.at < 60_000) return vibeCache.price;
+  const solana = CHAIN_CONFIGS.solana;
+  const mint = isSolanaChain(solana) ? solana.vibeMint : "";
+  const res = await fetch(
+    `https://api.geckoterminal.com/api/v2/simple/networks/solana/token_price/${mint}`,
+    { headers: { Accept: "application/json" } },
+  );
+  if (!res.ok) throw new Error("GeckoTerminal request failed");
+  const json = await res.json();
+  const priceStr: unknown = json?.data?.attributes?.token_prices?.[mint];
+  const price = Number(priceStr);
+  if (!(price > 0)) throw new Error("Could not resolve $VIBE price");
+  vibeCache = { at: now, price };
+  return price;
+}

--- a/src/lib/solana-payment.ts
+++ b/src/lib/solana-payment.ts
@@ -1,7 +1,9 @@
+import { Buffer } from "buffer";
 import {
   Connection,
   PublicKey,
   Transaction,
+  TransactionInstruction,
 } from "@solana/web3.js";
 import {
   getAssociatedTokenAddress,
@@ -10,48 +12,57 @@ import {
   getAccount,
 } from "@solana/spl-token";
 
+const MEMO_PROGRAM_ID = new PublicKey("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr");
+
 /**
- * Build a Solana USDC transfer transaction (serialized as Uint8Array).
- * Handles associated token account creation if the receiver doesn't have one yet.
- * Returns the serialized transaction ready for wallet signing.
+ * Build a Solana SPL-token transfer (USDC or $VIBE), serialized for signing.
+ * Creates the receiver's associated token account if needed, and attaches an
+ * optional memo. The memo binds the payment to a specific project so the server
+ * can verify it belongs to the submitting owner (see /api/solana/verify).
  */
-export async function buildSolanaUSDCTransfer({
+export async function buildSolanaTokenTransfer({
   senderAddress,
   rpcUrl,
-  usdcMint,
+  mint: mintAddress,
   receivingWallet,
   amount,
+  memo,
 }: {
   senderAddress: string;
   rpcUrl: string;
-  usdcMint: string;
+  mint: string;
   receivingWallet: string;
   amount: bigint;
+  memo?: string;
 }): Promise<Uint8Array> {
   const connection = new Connection(rpcUrl, "confirmed");
-  const mint = new PublicKey(usdcMint);
+  const mint = new PublicKey(mintAddress);
   const sender = new PublicKey(senderAddress);
   const receiver = new PublicKey(receivingWallet);
 
-  // Get associated token accounts
   const senderAta = await getAssociatedTokenAddress(mint, sender);
   const receiverAta = await getAssociatedTokenAddress(mint, receiver);
 
   const tx = new Transaction();
 
-  // Check if receiver ATA exists, create if not
+  // Create the receiver's associated token account if it doesn't exist yet.
   try {
     await getAccount(connection, receiverAta);
   } catch {
-    tx.add(
-      createAssociatedTokenAccountInstruction(sender, receiverAta, receiver, mint)
-    );
+    tx.add(createAssociatedTokenAccountInstruction(sender, receiverAta, receiver, mint));
   }
 
-  // Add transfer instruction
-  tx.add(
-    createTransferInstruction(senderAta, receiverAta, sender, amount)
-  );
+  tx.add(createTransferInstruction(senderAta, receiverAta, sender, amount));
+
+  if (memo) {
+    tx.add(
+      new TransactionInstruction({
+        keys: [],
+        programId: MEMO_PROGRAM_ID,
+        data: Buffer.from(memo, "utf8"),
+      })
+    );
+  }
 
   const { blockhash } = await connection.getLatestBlockhash();
   tx.recentBlockhash = blockhash;

--- a/src/lib/solana-payment.ts
+++ b/src/lib/solana-payment.ts
@@ -10,6 +10,7 @@ import {
   createTransferInstruction,
   createAssociatedTokenAccountInstruction,
   getAccount,
+  TokenAccountNotFoundError,
 } from "@solana/spl-token";
 
 const MEMO_PROGRAM_ID = new PublicKey("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr");
@@ -45,11 +46,18 @@ export async function buildSolanaTokenTransfer({
 
   const tx = new Transaction();
 
-  // Create the receiver's associated token account if it doesn't exist yet.
+  // Create the receiver's associated token account only if it's genuinely
+  // missing. Other failures (RPC error, invalid owner/size) must propagate —
+  // blindly adding a create instruction would make the tx fail when the ATA
+  // already exists.
   try {
     await getAccount(connection, receiverAta);
-  } catch {
-    tx.add(createAssociatedTokenAccountInstruction(sender, receiverAta, receiver, mint));
+  } catch (e) {
+    if (e instanceof TokenAccountNotFoundError) {
+      tx.add(createAssociatedTokenAccountInstruction(sender, receiverAta, receiver, mint));
+    } else {
+      throw e;
+    }
   }
 
   tx.add(createTransferInstruction(senderAta, receiverAta, sender, amount));

--- a/supabase/migrations/20260530_featured_promotions_solana_grant.sql
+++ b/supabase/migrations/20260530_featured_promotions_solana_grant.sql
@@ -1,0 +1,11 @@
+-- Solana / $VIBE payments phase.
+--
+-- The featured grid now renders Solana promotions DIRECTLY from
+-- featured_promotions (not just as EVM authorizations), so the anon SELECT
+-- grant must include the columns the render reads. Additive + editor-safe.
+-- (Table, RLS, replay index, and the base grant shipped in
+-- 20260530_featured_promotions.sql.) user_id / tx_ref / paid_amount stay
+-- service-role only.
+
+grant select (project_id, promoter_wallet, chain, package_id, expires_at, created_at)
+  on public.featured_promotions to anon, authenticated;


### PR DESCRIPTION
## Solana + $VIBE payments for Featured Promotions

Re-enables the Solana lane (disabled in #9) behind **real server-side verification**, and adds the project's own **$VIBE** token as a payment option. ⚠️ **Do not merge until tested with a real wallet** (per request).

### How it works
- **`POST /api/solana/verify`** — owner gate (`project.user_id === session`) + replay check + on-chain verification: tx succeeded · correct mint · destination = receiving wallet · **amount ≥ 90%** of expected (via the receiving wallet's token-balance delta, which proves mint+dest+amount in one check) → records the promotion in `featured_promotions` (`chain='solana'`).
- **🔒 Memo binding (security):** a bare Solana transfer isn't bound to a project. So the payer stamps `project_id` into the tx **memo**, and the server requires it. Without this, an attacker could grab a victim's payment signature off-chain and submit it for *their own* project before the victim does (front-running the verify). The memo is inside the signed tx → unforgeable onto someone else's payment. *(This wasn't in the original spec — I caught it while implementing.)*
- **`POST /api/solana/quote`** — returns the exact amount to send, from the same price source the verifier uses (USDC, or $VIBE via GeckoTerminal, cached 60s).
- **`enrichPromotions`** now renders a **union**: EVM (contract ∩ #8 authorizations) + Solana (`featured_promotions` rows, unexpired). Still fails closed.
- **Card**: Solana back in the picker, **USDC / $VIBE toggle**, memo'd transfer, verify-with-retry (polls while the tx propagates; uses `confirmed` commitment).

### Verification
✅ `tsc` · `eslint` · **274 tests** (+16 new: amount/slippage/expiry/balance-delta/memo helpers) · `next build`. *Compile + unit level only — the actual on-chain flow needs a real wallet.*

### Before merge
1. Apply `supabase/migrations/20260530_featured_promotions_solana_grant.sql` (widens the anon SELECT grant for the render). **Also requires the #8 migration** `20260530_featured_promotions.sql` to be applied first.
2. **Test the real flow**: connect a Solana wallet → pay a small package in USDC, confirm the promotion appears → repeat in $VIBE.
3. Sanity-check the $VIBE amount shown vs GeckoTerminal.

### Notes / follow-ups
- 90% slippage floor + GeckoTerminal-only pricing (no fallback) as agreed — tunable.
- Public Solana RPC (`api.mainnet-beta.solana.com`) is used for verification; a dedicated RPC (Helius) would be more reliable at volume.
- Streak-restore via $VIBE is the next, separate build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Solana support for featured project promotions, selectable in the chain picker
  * Pay on Solana with USDC or VIBE, with a client token picker and on-server payment quotes
  * Client verifies Solana payments and retries verification until confirmed
* **Tests**
  * Added unit tests for promotion pricing, slippage, expiry, memo extraction, and balance delta logic
* **Chores**
  * DB read grant added so Solana promotions can be surfaced in the featured grid
<!-- end of auto-generated comment: release notes by coderabbit.ai -->