### PR TITLE
fix(onboarding): save profile via update+insert, not upsert (42501 permission denied)

### DIFF
--- a/src/app/auth/profile-setup/page.tsx
+++ b/src/app/auth/profile-setup/page.tsx
@@ -8,6 +8,10 @@ import { normalizeSocialHandle } from "@/lib/social-handles";
 import { normalizeExternalUrl, normalizeRepoUrl } from "@/lib/url-normalize";
 import { armTourTrigger, TOUR_FLAG_ENABLED } from "@/lib/onboarding";
 import {
+  saveOnboardingProfile,
+  type ProfileWriteClient,
+} from "@/lib/onboarding-profile";
+import {
   Flame,
   Github,
   Globe,
@@ -225,30 +229,37 @@ export default function ProfileSetupPage() {
       setError(displayNameError);
       return;
     }
+    if (!userId) {
+      setError("Your session isn't ready yet — refresh the page and try again.");
+      return;
+    }
 
     setError("");
     setLoading(true);
 
     try {
-      // github_username (and github_id) must be written here because this is
-      // the first INSERT for GitHub-first OAuth signups — users.username is
-      // NOT NULL, so no row exists when /auth/callback runs, and its UPDATE
-      // silently no-ops.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { error: dbError } = await (supabase.from("users") as any).upsert(
+      // Create-or-update the row WITHOUT a PostgREST upsert. An upsert lists the
+      // conflict-target `id` in its DO UPDATE SET clause, which the post-2026-05-29
+      // column-level UPDATE grant denies for existing rows (42501 "permission
+      // denied for table users"). saveOnboardingProfile splits the write so `id`
+      // never lands in a SET clause — see it for the full rationale.
+      //
+      // github_username/github_id are written here because this is the first
+      // write for GitHub-first OAuth signups — users.username is NOT NULL, so no
+      // row exists when /auth/callback runs and its UPDATE silently no-ops.
+      await saveOnboardingProfile(
+        supabase as unknown as ProfileWriteClient,
+        userId,
         {
-          id: userId,
           username: profile.username,
           display_name: profile.display_name.trim() || null,
           bio: profile.bio || null,
           ...(oauthAvatarUrl ? { avatar_url: oauthAvatarUrl } : {}),
           ...(verifiedGithub ? { github_username: verifiedGithub } : {}),
           ...(verifiedGithubId !== null ? { github_id: verifiedGithubId } : {}),
-        },
-        { onConflict: "id" }
+        }
       );
 
-      if (dbError) throw dbError;
       // Ensure baseline vibe score is set for new users (non-fatal)
       try {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/lib/__tests__/onboarding-profile.test.ts
+++ b/src/lib/__tests__/onboarding-profile.test.ts
@@ -30,17 +30,24 @@ interface RecordedUpdate {
  */
 function makeClient(
   updateRows: unknown[] | null,
-  errors: { update?: unknown; insert?: unknown } = {}
+  errors: { update?: unknown; insert?: unknown } = {},
+  // Result for the *retry* UPDATE (2nd+ update call). Defaults to `updateRows`.
+  // Used to model the insert-race: 1st UPDATE sees no row, INSERT loses the
+  // race (23505), retry UPDATE now finds the row a concurrent request created.
+  retryUpdateRows?: unknown[] | null
 ) {
   const calls = {
     update: [] as RecordedUpdate[],
     insert: [] as (OnboardingProfileFields & { id: string })[],
   };
+  let updateCalls = 0;
 
   const client: ProfileWriteClient = {
     from() {
       return {
         update(values: OnboardingProfileFields) {
+          updateCalls += 1;
+          const callIndex = updateCalls;
           const recorded: RecordedUpdate = { values };
           calls.update.push(recorded);
           return {
@@ -48,8 +55,12 @@ function makeClient(
               recorded.id = value;
               return {
                 select() {
+                  const data =
+                    callIndex === 1 || retryUpdateRows === undefined
+                      ? updateRows
+                      : retryUpdateRows;
                   return Promise.resolve({
-                    data: updateRows,
+                    data,
                     error: errors.update ?? null,
                   });
                 },
@@ -129,13 +140,52 @@ describe("saveOnboardingProfile", () => {
     expect(calls.insert).toHaveLength(0);
   });
 
-  it("propagates an INSERT error", async () => {
-    const { client } = makeClient([], {
-      insert: { code: "23505", message: "duplicate key value" },
+  it("propagates a non-unique INSERT error without retrying", async () => {
+    const { client, calls } = makeClient([], {
+      insert: { code: "23502", message: "null value in column violates not-null" },
+    });
+
+    await expect(
+      saveOnboardingProfile(client, "new-user", FIELDS)
+    ).rejects.toMatchObject({ code: "23502" });
+    // Only the initial UPDATE — a non-23505 error is not a race, so no retry.
+    expect(calls.update).toHaveLength(1);
+  });
+
+  it("converges on a concurrent-insert race (23505 on id PK → retry UPDATE finds the row)", async () => {
+    // 1st UPDATE: no row. INSERT loses the race (23505). Retry UPDATE: a
+    // concurrent request created the row, so it now matches → resolve, no throw.
+    const { client, calls } = makeClient(
+      [],
+      { insert: { code: "23505", message: 'duplicate key value violates unique constraint "users_pkey"' } },
+      [{ id: "raced-user" }]
+    );
+
+    await expect(
+      saveOnboardingProfile(client, "raced-user", FIELDS)
+    ).resolves.toBeUndefined();
+
+    expect(calls.insert).toHaveLength(1);
+    // Initial UPDATE + the convergence retry.
+    expect(calls.update).toHaveLength(2);
+    // The retry UPDATE also keeps `id` out of its SET payload.
+    expect("id" in calls.update[1].values).toBe(false);
+  });
+
+  it("re-throws a username-uniqueness collision (23505, retry UPDATE still finds no row)", async () => {
+    // INSERT fails 23505 because the username is taken by ANOTHER user. The
+    // retry UPDATE matches no row (this id still has none) → surface the error
+    // rather than silently sending the user on with no profile.
+    const { client, calls } = makeClient([], {
+      insert: {
+        code: "23505",
+        message: 'duplicate key value violates unique constraint "users_username_key"',
+      },
     });
 
     await expect(
       saveOnboardingProfile(client, "new-user", FIELDS)
     ).rejects.toMatchObject({ code: "23505" });
+    expect(calls.update).toHaveLength(2);
   });
 });

--- a/src/lib/__tests__/onboarding-profile.test.ts
+++ b/src/lib/__tests__/onboarding-profile.test.ts
@@ -34,7 +34,10 @@ function makeClient(
   // Result for the *retry* UPDATE (2nd+ update call). Defaults to `updateRows`.
   // Used to model the insert-race: 1st UPDATE sees no row, INSERT loses the
   // race (23505), retry UPDATE now finds the row a concurrent request created.
-  retryUpdateRows?: unknown[] | null
+  retryUpdateRows?: unknown[] | null,
+  // Error for the *retry* UPDATE only. Lets a test fail the retry without
+  // failing the initial UPDATE. Defaults to `errors.update`.
+  retryUpdateError?: unknown
 ) {
   const calls = {
     update: [] as RecordedUpdate[],
@@ -55,14 +58,16 @@ function makeClient(
               recorded.id = value;
               return {
                 select() {
+                  const isFirst = callIndex === 1;
                   const data =
-                    callIndex === 1 || retryUpdateRows === undefined
+                    isFirst || retryUpdateRows === undefined
                       ? updateRows
                       : retryUpdateRows;
-                  return Promise.resolve({
-                    data,
-                    error: errors.update ?? null,
-                  });
+                  const error =
+                    isFirst || retryUpdateError === undefined
+                      ? errors.update ?? null
+                      : retryUpdateError;
+                  return Promise.resolve({ data, error });
                 },
               };
             },
@@ -186,6 +191,23 @@ describe("saveOnboardingProfile", () => {
     await expect(
       saveOnboardingProfile(client, "new-user", FIELDS)
     ).rejects.toMatchObject({ code: "23505" });
+    expect(calls.update).toHaveLength(2);
+  });
+
+  it("propagates a retry UPDATE error (23505 insert, then retry UPDATE fails)", async () => {
+    // Initial UPDATE: no row. INSERT: 23505. Retry UPDATE: its own failure
+    // (e.g. an RLS denial or network blip) → surface it, don't swallow.
+    const { client, calls } = makeClient(
+      [],
+      { insert: { code: "23505", message: 'duplicate key value violates unique constraint "users_pkey"' } },
+      undefined,
+      { code: "42501", message: "permission denied on retry" }
+    );
+
+    await expect(
+      saveOnboardingProfile(client, "user-1", FIELDS)
+    ).rejects.toMatchObject({ code: "42501" });
+    // Initial UPDATE + the retry UPDATE that failed.
     expect(calls.update).toHaveLength(2);
   });
 });

--- a/src/lib/__tests__/onboarding-profile.test.ts
+++ b/src/lib/__tests__/onboarding-profile.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Regression tests for the onboarding profile write.
+ *
+ * The bug (42501 "permission denied for table users"): profile-setup used a
+ * PostgREST upsert whose compiled `ON CONFLICT (id) DO UPDATE SET id = ...`
+ * needs UPDATE on the `id` column, which the 2026-05-29 hardening migration no
+ * longer grants. These tests pin the fix: an UPDATE that never lists `id` in
+ * its SET payload, with an INSERT fallback only when no row exists yet.
+ *
+ * We don't mock the real supabase client — we pass a hand-rolled fake matching
+ * the narrow ProfileWriteClient surface and assert on the calls it records.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  saveOnboardingProfile,
+  type OnboardingProfileFields,
+  type ProfileWriteClient,
+} from "../onboarding-profile";
+
+interface RecordedUpdate {
+  values: OnboardingProfileFields;
+  id?: string;
+}
+
+/**
+ * Build a fake client that records every update/insert and returns the given
+ * `updateRows` from `.update().eq().select()`. `[]` ⇒ no row matched (new user);
+ * a non-empty array ⇒ the row already existed.
+ */
+function makeClient(
+  updateRows: unknown[] | null,
+  errors: { update?: unknown; insert?: unknown } = {}
+) {
+  const calls = {
+    update: [] as RecordedUpdate[],
+    insert: [] as (OnboardingProfileFields & { id: string })[],
+  };
+
+  const client: ProfileWriteClient = {
+    from() {
+      return {
+        update(values: OnboardingProfileFields) {
+          const recorded: RecordedUpdate = { values };
+          calls.update.push(recorded);
+          return {
+            eq(_column: "id", value: string) {
+              recorded.id = value;
+              return {
+                select() {
+                  return Promise.resolve({
+                    data: updateRows,
+                    error: errors.update ?? null,
+                  });
+                },
+              };
+            },
+          };
+        },
+        insert(values: OnboardingProfileFields & { id: string }) {
+          calls.insert.push(values);
+          return Promise.resolve({ error: errors.insert ?? null });
+        },
+      };
+    },
+  };
+
+  return { client, calls };
+}
+
+const FIELDS: OnboardingProfileFields = {
+  username: "rishad",
+  display_name: "Rishad N",
+  bio: null,
+  avatar_url: "https://example.com/a.png",
+  github_username: "rishad",
+  github_id: 12345,
+};
+
+describe("saveOnboardingProfile", () => {
+  it("updates the existing row and does not insert", async () => {
+    const { client, calls } = makeClient([{ id: "user-1" }]);
+
+    await saveOnboardingProfile(client, "user-1", FIELDS);
+
+    expect(calls.update).toHaveLength(1);
+    expect(calls.insert).toHaveLength(0);
+    expect(calls.update[0].id).toBe("user-1");
+    expect(calls.update[0].values).toMatchObject({ username: "rishad" });
+  });
+
+  it("never lists `id` in the UPDATE SET payload (the 42501 regression)", async () => {
+    const { client, calls } = makeClient([{ id: "user-1" }]);
+
+    await saveOnboardingProfile(client, "user-1", FIELDS);
+
+    // The whole point of the fix: `id` is the WHERE filter, never a SET column.
+    expect("id" in calls.update[0].values).toBe(false);
+    expect(calls.update[0].id).toBe("user-1");
+  });
+
+  it("inserts a new row (id included) when no row matched yet", async () => {
+    const { client, calls } = makeClient([]);
+
+    await saveOnboardingProfile(client, "new-user", FIELDS);
+
+    expect(calls.update).toHaveLength(1);
+    expect(calls.insert).toHaveLength(1);
+    expect(calls.insert[0]).toMatchObject({ id: "new-user", username: "rishad" });
+  });
+
+  it("treats null update data as no-row-matched and falls back to insert", async () => {
+    const { client, calls } = makeClient(null);
+
+    await saveOnboardingProfile(client, "new-user", FIELDS);
+
+    expect(calls.insert).toHaveLength(1);
+    expect(calls.insert[0]).toMatchObject({ id: "new-user" });
+  });
+
+  it("propagates an UPDATE error without attempting an insert", async () => {
+    const { client, calls } = makeClient(null, {
+      update: { code: "42501", message: "permission denied for table users" },
+    });
+
+    await expect(
+      saveOnboardingProfile(client, "user-1", FIELDS)
+    ).rejects.toMatchObject({ code: "42501" });
+    expect(calls.insert).toHaveLength(0);
+  });
+
+  it("propagates an INSERT error", async () => {
+    const { client } = makeClient([], {
+      insert: { code: "23505", message: "duplicate key value" },
+    });
+
+    await expect(
+      saveOnboardingProfile(client, "new-user", FIELDS)
+    ).rejects.toMatchObject({ code: "23505" });
+  });
+});

--- a/src/lib/onboarding-profile.ts
+++ b/src/lib/onboarding-profile.ts
@@ -49,6 +49,13 @@ export interface ProfileWriteClient {
   };
 }
 
+/** Pull the SQLSTATE code off a Postgrest-style error object, if present. */
+function errorCode(error: unknown): string | undefined {
+  return typeof error === "object" && error !== null && "code" in error
+    ? (error as { code?: string }).code
+    : undefined;
+}
+
 /**
  * Create or update the caller's `users` row during onboarding WITHOUT a
  * PostgREST upsert.
@@ -66,10 +73,12 @@ export interface ProfileWriteClient {
  * Splitting the write keeps `id` out of every SET clause:
  *   1. UPDATE the existing row (granted columns only; `id` is just the filter).
  *   2. If no row matched, it's a brand-new signup → INSERT (the `id` column is
- *      fine on an INSERT — no UPDATE grant is consulted).
+ *      fine on an INSERT — no UPDATE grant is consulted). If a concurrent
+ *      request wins the insert first, that's a 23505 on the `id` PK — we
+ *      converge by retrying the UPDATE rather than failing onboarding.
  *
  * Throws the underlying Postgrest error so the caller's existing try/catch can
- * surface it.
+ * surface it (including a genuine username-uniqueness collision).
  */
 export async function saveOnboardingProfile(
   client: ProfileWriteClient,
@@ -92,6 +101,26 @@ export async function saveOnboardingProfile(
     const { error: insertError } = await client
       .from("users")
       .insert({ id, ...fields });
-    if (insertError) throw insertError;
+    if (!insertError) return;
+
+    // A unique violation (23505) here is ambiguous. Either:
+    //   (a) a concurrent request created THIS row between our UPDATE and INSERT
+    //       (conflict on the `id` primary key) → converge by UPDATE-ing it, or
+    //   (b) the chosen username belongs to a different user (conflict on the
+    //       username unique index) → a real error the user must see.
+    // Retrying the UPDATE disambiguates without parsing constraint names: if it
+    // now matches our row the race resolved; if it matches nothing, the row for
+    // this id still doesn't exist, so the conflict was the username — re-throw
+    // so the caller surfaces "Failed to save profile" rather than silently
+    // sending the user onward with no row.
+    if (errorCode(insertError) !== "23505") throw insertError;
+
+    const { data: retried, error: retryError } = await client
+      .from("users")
+      .update(fields)
+      .eq("id", id)
+      .select("id");
+    if (retryError) throw retryError;
+    if (!retried || retried.length === 0) throw insertError;
   }
 }

--- a/src/lib/onboarding-profile.ts
+++ b/src/lib/onboarding-profile.ts
@@ -1,0 +1,97 @@
+/**
+ * Onboarding `users`-row persistence.
+ *
+ * Split out from the profile-setup page so the create-or-update write has a
+ * single implementation and a clean Vitest import target (the page component
+ * itself isn't mounted in tests — see onboarding.test.ts for that rationale).
+ */
+
+/**
+ * Columns a client may write on its own `users` row during onboarding.
+ *
+ * Mirrors the column-level UPDATE grant added in migration
+ * `20260529_security_hardening_rls` — keep the two in lock-step. `id` is
+ * deliberately absent: it's the primary key and the RLS scoping column, never a
+ * client-writable field.
+ */
+export interface OnboardingProfileFields {
+  username: string;
+  display_name: string | null;
+  bio: string | null;
+  avatar_url?: string;
+  github_username?: string;
+  github_id?: number;
+}
+
+/**
+ * Structural slice of the supabase-js client covering only the calls this
+ * helper makes. Typed loosely on purpose — the real client is generic over the
+ * DB schema and the page already reaches it through `as any` because the
+ * generated `Database` types lag the newer profile columns — so tests can pass
+ * a light fake without rebuilding the full query-builder surface.
+ */
+export interface ProfileWriteClient {
+  from(table: "users"): {
+    update(values: OnboardingProfileFields): {
+      eq(
+        column: "id",
+        value: string
+      ): {
+        select(columns: string): PromiseLike<{
+          data: unknown[] | null;
+          error: unknown;
+        }>;
+      };
+    };
+    insert(
+      values: OnboardingProfileFields & { id: string }
+    ): PromiseLike<{ error: unknown }>;
+  };
+}
+
+/**
+ * Create or update the caller's `users` row during onboarding WITHOUT a
+ * PostgREST upsert.
+ *
+ * The obvious `.upsert({ id, ... }, { onConflict: "id" })` is a trap here:
+ * PostgREST compiles it to
+ *   `INSERT ... ON CONFLICT (id) DO UPDATE SET id = EXCLUDED.id, username = ...`
+ * i.e. the conflict-target `id` lands in the UPDATE SET list. Migration
+ * `20260529_security_hardening_rls` revoked table-level UPDATE on `users` and
+ * re-granted column-level UPDATE on only the editable profile columns (not
+ * `id`), so the ON CONFLICT branch — taken whenever the row already exists —
+ * fails with `42501 permission denied for table users`. That's the
+ * "Failed to save profile" an existing user hits on the username step.
+ *
+ * Splitting the write keeps `id` out of every SET clause:
+ *   1. UPDATE the existing row (granted columns only; `id` is just the filter).
+ *   2. If no row matched, it's a brand-new signup → INSERT (the `id` column is
+ *      fine on an INSERT — no UPDATE grant is consulted).
+ *
+ * Throws the underlying Postgrest error so the caller's existing try/catch can
+ * surface it.
+ */
+export async function saveOnboardingProfile(
+  client: ProfileWriteClient,
+  id: string,
+  fields: OnboardingProfileFields
+): Promise<void> {
+  // Existing user → UPDATE only the granted profile columns. `id` stays in the
+  // WHERE filter, never in the SET list. `.select("id")` lets us tell an
+  // updated row apart from "no row matched yet".
+  const { data: updated, error: updateError } = await client
+    .from("users")
+    .update(fields)
+    .eq("id", id)
+    .select("id");
+  if (updateError) throw updateError;
+
+  // No row matched → brand-new signup. Create it. INSERT (not UPDATE) so the
+  // locked-down UPDATE grant on `id` is irrelevant.
+  if (!updated || updated.length === 0) {
+    const { error: insertError } = await client
+      .from("users")
+      .insert({ id, ...fields });
+    if (insertError) throw insertError;
+  }
+}


### PR DESCRIPTION
## The bug

An existing user setting their username on **Set Up Profile → step 1** gets **"Failed to save profile"**. The network call returns Postgres **`42501`**:

```json
{ "code": "42501", "details": null, "hint": null, "message": "permission denied for table users" }
```

## Root cause

Step 1 wrote the row with a PostgREST **upsert**:

```ts
supabase.from("users").upsert({ id, username, ... }, { onConflict: "id" })
```

PostgREST compiles that to:

```sql
INSERT INTO users (id, username, ...) VALUES (...)
ON CONFLICT (id) DO UPDATE SET id = EXCLUDED.id, username = EXCLUDED.username, ...
```

— the conflict-target **`id` is listed in the `DO UPDATE SET` clause**.

Migration `20260529_security_hardening_rls` locked down reputation columns by revoking table-level `UPDATE` on `users` and re-granting **column-level** `UPDATE` on only the 7 editable profile columns (`username, display_name, bio, avatar_url, github_username, github_id, share_private_activity`) — **not `id`**. So whenever the row already exists, the `ON CONFLICT DO UPDATE` branch needs `UPDATE` on `id` and is denied at the **grant** layer.

Key tells that pinpoint this:
- The message is **`permission denied for table users`** (a GRANT failure), *not* `new row violates row-level security policy` (an RLS failure) — both are `42501`, but only the grant layer matches what the migration changed.
- Only **existing** users are affected: brand-new signups hit the `INSERT` branch, which never consults the `UPDATE` grant.
- The **settings** profile-edit path was never affected because it already uses `.update()` (no `id` in the SET clause) on exactly those granted columns.

## The fix

Extract `saveOnboardingProfile()` (`src/lib/onboarding-profile.ts`) and call it from profile-setup. It splits the write so **`id` never appears in a SET clause**:

1. `UPDATE` the existing row — granted columns only; `id` stays in the `WHERE` filter.
2. If no row matched (brand-new signup), `INSERT` it — `id` is fine on an INSERT; no UPDATE grant is consulted.

This works under the locked-down grants, preserves new-signup row creation, and mirrors the already-working settings path. **No migration / DB change** — the security hardening stays exactly as intended.

## Testing

- ✅ New unit tests (`src/lib/__tests__/onboarding-profile.test.ts`, 6 cases) pin the regression: the UPDATE payload never contains `id`; INSERT fallback fires only when no row matched; update/insert errors propagate.
- ✅ `npm run test` — 264/264 pass
- ✅ `npx tsc --noEmit` — clean (`src/`)
- ✅ `eslint src` — clean
- ✅ `next build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents profile saves until the user session is ready and surfaces an explicit session-ready error; improves reliability of Step 1 profile setup.
  * Makes profile persistence more resilient to concurrent save conflicts, reducing intermittent onboarding failures.

* **Tests**
  * Added comprehensive tests covering profile save/update/insert flows and conflict-handling to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->