### PR TITLE
fix(profile): Fix share card name overflow & bio pill bleed

### DIFF
--- a/src/app/api/share-card/[username]/route.tsx
+++ b/src/app/api/share-card/[username]/route.tsx
@@ -25,8 +25,18 @@ export async function GET(
   const initial = user.username.slice(0, 1).toUpperCase();
   const avatarSrc = user.avatar_url;
   const bio = user.bio
-    ? (user.bio.length > 30 ? user.bio.slice(0, 30) + "..." : user.bio)
+    ? (user.bio.length > 22 ? user.bio.slice(0, 22) + "..." : user.bio)
     : "vibecoder";
+  const displayName = user.display_name || `@${user.username}`;
+  // Dynamic font size: available width ~390px, uppercase system-ui ~0.62× fontSize + 4px letter-spacing per char
+  // Names >12 chars: subtract 50px for verified badge (36px icon + 14px gap)
+  const NAME_AVAILABLE_PX = displayName.length > 12 ? 340 : 390;
+  const CHAR_WIDTH_RATIO = 0.62;
+  const LETTER_SPACING_PX = 4;
+  const nameFontSize = Math.max(
+    16,
+    Math.min(42, Math.floor((NAME_AVAILABLE_PX / displayName.length - LETTER_SPACING_PX) / CHAR_WIDTH_RATIO))
+  );
   const streakStr = String(user.streak).padStart(2, "0");
   const longestStr = String(user.longest_streak).padStart(2, "0");
   const projectsStr = String((user.projects ?? []).length).padStart(2, "0");
@@ -225,19 +235,20 @@ export async function GET(
               </div>
 
               {/* Name + badge */}
-              <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+              <div style={{ display: "flex", flexDirection: "column", gap: 8, flex: 1, minWidth: 0, overflow: "hidden" }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 14, minWidth: 0 }}>
                   <span
                     style={{
-                      fontSize: 42,
+                      fontSize: nameFontSize,
                       fontWeight: 300,
                       color: TEXT,
                       textTransform: "uppercase",
                       letterSpacing: "4px",
                       lineHeight: 1,
+                      whiteSpace: "nowrap",
                     }}
                   >
-                    {user.display_name || `@${user.username}`}
+                    {displayName}
                   </span>
                   {user.github_username && (
                     <svg
@@ -279,6 +290,8 @@ export async function GET(
                     borderRadius: 999,
                     letterSpacing: "3px",
                     textTransform: "uppercase",
+                    maxWidth: "100%",
+                    overflow: "hidden",
                   }}
                 >
                   {bio}

--- a/src/app/api/share-card/[username]/route.tsx
+++ b/src/app/api/share-card/[username]/route.tsx
@@ -28,15 +28,8 @@ export async function GET(
     ? (user.bio.length > 22 ? user.bio.slice(0, 22) + "..." : user.bio)
     : "vibecoder";
   const displayName = user.display_name || `@${user.username}`;
-  // Dynamic font size: available width ~390px, uppercase system-ui ~0.62× fontSize + 4px letter-spacing per char
-  // Names >12 chars: subtract 50px for verified badge (36px icon + 14px gap)
-  const NAME_AVAILABLE_PX = displayName.length > 12 ? 340 : 390;
-  const CHAR_WIDTH_RATIO = 0.62;
-  const LETTER_SPACING_PX = 4;
-  const nameFontSize = Math.max(
-    16,
-    Math.min(42, Math.floor((NAME_AVAILABLE_PX / displayName.length - LETTER_SPACING_PX) / CHAR_WIDTH_RATIO))
-  );
+  const hasBadge = Boolean(user.github_username);
+  const nameFontSize = fitNameFontSize(displayName, hasBadge);
   const streakStr = String(user.streak).padStart(2, "0");
   const longestStr = String(user.longest_streak).padStart(2, "0");
   const projectsStr = String((user.projects ?? []).length).padStart(2, "0");
@@ -236,7 +229,7 @@ export async function GET(
 
               {/* Name + badge */}
               <div style={{ display: "flex", flexDirection: "column", gap: 8, flex: 1, minWidth: 0, overflow: "hidden" }}>
-                <div style={{ display: "flex", alignItems: "center", gap: 14, minWidth: 0 }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 14, minWidth: 0, overflow: "hidden" }}>
                   <span
                     style={{
                       fontSize: nameFontSize,
@@ -246,6 +239,7 @@ export async function GET(
                       letterSpacing: "4px",
                       lineHeight: 1,
                       whiteSpace: "nowrap",
+                      overflow: "hidden",
                     }}
                   >
                     {displayName}
@@ -419,4 +413,12 @@ export async function GET(
     ),
     { width: 1200, height: 630 }
   );
+}
+
+/** Estimate a clamped font size so the name fits within the profile card. */
+function fitNameFontSize(name: string, hasBadge: boolean): number {
+  const available = hasBadge ? 340 : 390; // 50px reserved for badge (36px icon + 14px gap)
+  const charWidth = 0.62; // uppercase system-ui glyph ratio
+  const spacing = 4; // letter-spacing per char
+  return Math.max(16, Math.min(42, Math.floor((available / name.length - spacing) / charWidth)));
 }


### PR DESCRIPTION
### Changes Made


1. Dynamic name font scaling
Name font size is now computed server-side instead of fixed at 42px. Formula estimates character width using uppercase system-ui glyph ratio (~0.62×) + 4px letter-spacing, clamped between 16–42px. Prevents long names from overflowing the card.

2. Verified badge space reservation
When name exceeds 12 characters, available width budget shrinks by 50px (36px badge + 14px gap) before font size is calculated. Ensures the name never collides with the verified badge.

3. Name container flex fix
Name+badge wrapper gains flex: 1, minWidth: 0, and overflow: hidden. Without flex: 1, Satori didn't shrink the box — it grew past the avatar's remaining space. minWidth: 0 allows flex shrinking below content size.

4. Bio pill overflow fix
Bio pill gets maxWidth: "100%" and overflow: hidden so it can't bleed outside the name column. Truncation threshold also tightened from 30 → 22 chars to keep the pill compact inside the fixed-height (160px) profile card.

Before 
<img width="1200" height="630" alt="fahmin-vibetalent-card" src="https://github.com/user-attachments/assets/1987e66a-db60-4f1f-9f14-451fdb812129" />

After
<img width="1200" height="630" alt="fam-vibetalent-card (1)" src="https://github.com/user-attachments/assets/d96e8e6e-df85-4f18-afb0-35d3c58395ec" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic font sizing for profile names on shared cards to better fit available space
  * Fallback display name when no bio is present

* **Bug Fixes**
  * Truncate bios more consistently to reduce overflow
  * Improved overflow and max-width handling to prevent layout breakage on long profile information
<!-- end of auto-generated comment: release notes by coderabbit.ai -->