### PR TITLE
fix: skeleton loading (leaderboard + feeds) + custom /projects sort arrow

### DIFF
--- a/src/components/feed/network-feed.tsx
+++ b/src/components/feed/network-feed.tsx
@@ -315,11 +315,31 @@ export function NetworkFeed({
   const visibleRows = grouped.slice(0, effectiveLimit);
 
   if (loading) {
+    // Skeleton rows mirroring FeedRow (circular avatar + two text lines)
+    // instead of a bare "Loading feed..." string.
     return (
       <>
         <style>{FEED_STYLES}</style>
-        <div style={{ minHeight: "40vh", display: "flex", alignItems: "center", justifyContent: "center" }}>
-          <div style={{ color: "var(--text-muted, #8A8B94)", fontSize: "0.85rem" }}>Loading feed...</div>
+        <div style={{ display: "flex", flexDirection: "column", paddingTop: 8 }}>
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              style={{
+                display: "grid",
+                gridTemplateColumns: "auto 1fr",
+                gap: "0.875rem",
+                alignItems: "center",
+                padding: "0.875rem 0",
+                borderBottom: "1px solid var(--border-subtle, #2a2a2a)",
+              }}
+            >
+              <div className="skeleton" style={{ width: 44, height: 44, borderRadius: "50%" }} />
+              <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <div className="skeleton" style={{ height: 12, width: "42%" }} />
+                <div className="skeleton" style={{ height: 14, width: "68%" }} />
+              </div>
+            </div>
+          ))}
         </div>
       </>
     );

--- a/src/components/feed/network-feed.tsx
+++ b/src/components/feed/network-feed.tsx
@@ -327,13 +327,14 @@ export function NetworkFeed({
               style={{
                 display: "grid",
                 gridTemplateColumns: "auto 1fr",
-                gap: "0.875rem",
+                gap: "16px",
                 alignItems: "center",
-                padding: "0.875rem 0",
+                padding: "24px 0 24px 16px",
+                borderLeft: "3px solid transparent",
                 borderBottom: "1px solid var(--border-subtle, #2a2a2a)",
               }}
             >
-              <div className="skeleton" style={{ width: 44, height: 44, borderRadius: "50%" }} />
+              <div className="skeleton" style={{ width: 48, height: 48, borderRadius: "50%" }} />
               <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
                 <div className="skeleton" style={{ height: 12, width: "42%" }} />
                 <div className="skeleton" style={{ height: 14, width: "68%" }} />

--- a/src/components/leaderboard/weekly-tab.tsx
+++ b/src/components/leaderboard/weekly-tab.tsx
@@ -1,8 +1,63 @@
+import type { ReactNode } from "react";
 import { ActiveBuilderRow, type ActiveBuilderRowProps } from "./active-builder-row";
 
 interface Props {
   rows: ActiveBuilderRowProps[] | null;
   error: string | null;
+}
+
+/**
+ * Container + header shared by the loading and loaded states, so the skeleton
+ * reserves the exact frame the real list drops into — no layout shift when the
+ * weekly fetch resolves. The "ACTIVE BUILDERS / LAST 7 DAYS" header is static
+ * chrome, so it renders immediately rather than shimmering.
+ */
+function WeeklyShell({ children }: { children: ReactNode }) {
+  return (
+    <div className="bg-[var(--bg-surface)] border-2 border-[var(--border-hard)] rounded overflow-hidden" style={{ boxShadow: "var(--shadow-brutal)" }}>
+      <header className="bg-[var(--bg-inverted)] text-[var(--text-on-inverted)] px-5 py-4 flex justify-between items-center">
+        <h3 className="text-[15px] font-extrabold tracking-wider">ACTIVE BUILDERS</h3>
+        <span className="bg-[var(--accent)] text-white px-3 py-1 text-[12px] font-extrabold rounded-sm">LAST 7 DAYS</span>
+      </header>
+      <div>{children}</div>
+    </div>
+  );
+}
+
+/**
+ * One placeholder row mirroring ActiveBuilderRow's layout — position chip,
+ * avatar, handle + meta, and the three stat columns — so the shimmer lines up
+ * with the real rows on both the mobile stacked shape and the sm+ grid.
+ */
+function SkeletonRow() {
+  return (
+    <div className="px-4 sm:px-5 py-3 sm:py-4 border-b border-[var(--border-subtle)] last:border-b-0">
+      <div
+        className="flex flex-col gap-3 sm:grid sm:items-center sm:gap-4"
+        style={{ gridTemplateColumns: "44px 48px 1fr auto auto auto" }}
+      >
+        {/* Identity — flex on mobile, contents (transparent for grid) on sm+ */}
+        <div className="flex items-center gap-3 min-w-0 sm:contents">
+          <div className="skeleton h-4 w-6 sm:w-7 shrink-0" />
+          <div className="skeleton w-10 h-10 sm:w-12 sm:h-12 rounded-full shrink-0" />
+          <div className="min-w-0 flex-1 sm:flex-none">
+            <div className="skeleton h-4 w-28 mb-1.5" />
+            <div className="skeleton h-3 w-20" />
+          </div>
+        </div>
+
+        {/* Stats — three columns, right-aligned on sm+ to match the real numbers */}
+        <div className="flex justify-between items-start gap-2 pt-2 pl-[52px] sm:pl-0 border-t border-[var(--border-subtle)] sm:border-t-0 sm:pt-0 sm:contents">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="flex flex-col items-start sm:items-end sm:min-w-[70px]">
+              <div className="skeleton h-5 sm:h-6 w-9" />
+              <div className="skeleton h-3 w-14 mt-1.5" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export function WeeklyTab({ rows, error }: Props) {
@@ -14,21 +69,21 @@ export function WeeklyTab({ rows, error }: Props) {
     );
   }
   if (rows == null) {
-    return <div className="text-[13px] text-[var(--text-muted)] p-4">Loading…</div>;
+    return (
+      <WeeklyShell>
+        {Array.from({ length: 6 }).map((_, i) => (
+          <SkeletonRow key={i} />
+        ))}
+      </WeeklyShell>
+    );
   }
   if (rows.length === 0) {
     return <div className="text-[13px] text-[var(--text-muted)] p-4">No active builders in the last 7 days yet.</div>;
   }
 
   return (
-    <div className="bg-[var(--bg-surface)] border-2 border-[var(--border-hard)] rounded overflow-hidden" style={{ boxShadow: "var(--shadow-brutal)" }}>
-      <header className="bg-[var(--bg-inverted)] text-[var(--text-on-inverted)] px-5 py-4 flex justify-between items-center">
-        <h3 className="text-[15px] font-extrabold tracking-wider">ACTIVE BUILDERS</h3>
-        <span className="bg-[var(--accent)] text-white px-3 py-1 text-[12px] font-extrabold rounded-sm">LAST 7 DAYS</span>
-      </header>
-      <div>
-        {rows.map((r) => <ActiveBuilderRow key={r.username} {...r} />)}
-      </div>
-    </div>
+    <WeeklyShell>
+      {rows.map((r) => <ActiveBuilderRow key={r.username} {...r} />)}
+    </WeeklyShell>
   );
 }

--- a/src/components/leaderboard/weekly-tab.tsx
+++ b/src/components/leaderboard/weekly-tab.tsx
@@ -12,9 +12,14 @@ interface Props {
  * weekly fetch resolves. The "ACTIVE BUILDERS / LAST 7 DAYS" header is static
  * chrome, so it renders immediately rather than shimmering.
  */
-function WeeklyShell({ children }: { children: ReactNode }) {
+function WeeklyShell({ children, loading }: { children: ReactNode; loading?: boolean }) {
   return (
-    <div className="bg-[var(--bg-surface)] border-2 border-[var(--border-hard)] rounded overflow-hidden" style={{ boxShadow: "var(--shadow-brutal)" }}>
+    <div
+      className="bg-[var(--bg-surface)] border-2 border-[var(--border-hard)] rounded overflow-hidden"
+      style={{ boxShadow: "var(--shadow-brutal)" }}
+      aria-busy={loading || undefined}
+      aria-label={loading ? "Loading active builders" : undefined}
+    >
       <header className="bg-[var(--bg-inverted)] text-[var(--text-on-inverted)] px-5 py-4 flex justify-between items-center">
         <h3 className="text-[15px] font-extrabold tracking-wider">ACTIVE BUILDERS</h3>
         <span className="bg-[var(--accent)] text-white px-3 py-1 text-[12px] font-extrabold rounded-sm">LAST 7 DAYS</span>
@@ -70,7 +75,7 @@ export function WeeklyTab({ rows, error }: Props) {
   }
   if (rows == null) {
     return (
-      <WeeklyShell>
+      <WeeklyShell loading>
         {Array.from({ length: 6 }).map((_, i) => (
           <SkeletonRow key={i} />
         ))}

--- a/src/components/projects/projects-content.tsx
+++ b/src/components/projects/projects-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo, useCallback } from "react";
-import { Search, SlidersHorizontal } from "lucide-react";
+import { Search, SlidersHorizontal, ChevronDown } from "lucide-react";
 import { ProjectCard } from "@/components/ui/project-card";
 import { Pagination } from "@/components/ui/pagination";
 import type { Project } from "@/lib/types/database";
@@ -101,15 +101,21 @@ export function ProjectsContent({ projects }: { projects: ProjectWithAuthor[] })
           />
         </div>
         <div className="flex gap-3">
-          <select
-            value={sortBy}
-            onChange={e => setSortBy(e.target.value as SortOption)}
-            className="px-4 py-2.5 border-2 border-[var(--border-hard)] bg-[var(--card-bg)] text-[var(--foreground)] font-bold text-sm uppercase cursor-pointer focus:outline-none focus:border-[var(--accent)]"
-          >
-            <option value="newest">Newest</option>
-            <option value="endorsements">Most Endorsed</option>
-            <option value="quality">Highest Quality</option>
-          </select>
+          <div className="relative">
+            <select
+              value={sortBy}
+              onChange={e => setSortBy(e.target.value as SortOption)}
+              className="appearance-none pl-4 pr-10 py-2.5 border-2 border-[var(--border-hard)] bg-[var(--card-bg)] text-[var(--foreground)] font-bold text-sm uppercase cursor-pointer focus:outline-none focus:border-[var(--accent)]"
+            >
+              <option value="newest">Newest</option>
+              <option value="endorsements">Most Endorsed</option>
+              <option value="quality">Highest Quality</option>
+            </select>
+            <ChevronDown
+              size={16}
+              className="absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none text-[var(--text-secondary)]"
+            />
+          </div>
           <button
             onClick={() => setShowFilters(!showFilters)}
             className={`flex items-center gap-2 px-4 py-2.5 border-2 font-bold text-sm uppercase transition-colors ${

--- a/src/components/ui/live-activity-feed.tsx
+++ b/src/components/ui/live-activity-feed.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
+import type { ReactNode, CSSProperties } from "react";
 import Link from "next/link";
 import Image from "next/image";
 
@@ -70,51 +71,27 @@ function actionText(item: GroupedItem): string {
 
 const AVATAR_COLORS = ["#ff4400", "#4a4a4a", "#ffffff", "#ff4400", "#4a4a4a", "#ffffff"];
 
-export function LiveActivityFeed() {
-  const [feed, setFeed] = useState<FeedItem[]>([]);
-  const [loaded, setLoaded] = useState(false);
+const FRAME_STYLE: CSSProperties = {
+  width: "100%",
+  maxWidth: 480,
+  margin: "0 auto",
+  backgroundColor: "var(--bg-surface, #0a0a0a)",
+  border: "2px solid var(--border-hard, #fff)",
+  boxShadow: "6px 6px 0px #000",
+  display: "flex",
+  flexDirection: "column",
+};
 
-  useEffect(() => {
-    function fetchFeed() {
-      fetch("/api/feed?limit=20")
-        .then((r) => r.json())
-        .then((d) => {
-          // Drop any event types this snippet can't render correctly.
-          const items: FeedItem[] = (d.feed || []).filter(
-            (i: FeedItem) => SUPPORTED_LEGACY_TYPES.has(i.type),
-          );
-          setFeed(items);
-          setLoaded(true);
-        })
-        .catch(() => setLoaded(true));
-    }
-    fetchFeed();
-    const interval = setInterval(fetchFeed, 30000);
-    return () => clearInterval(interval);
-  }, []);
-
-  const grouped = useMemo(() => groupFeedItems(feed).slice(0, 6), [feed]);
-
-  if (!loaded) return (
-    <section className="mx-auto max-w-7xl px-4 sm:px-6 py-12">
-      <div style={{ textAlign: "center", padding: "20px", color: "var(--text-muted, #8a8a8a)", fontSize: "0.85rem" }}>Loading activity...</div>
-    </section>
-  );
-  if (grouped.length === 0) return null;
-
-  // v2: white text + green blinking dot
+/**
+ * Card frame + header shared by the loading skeleton and the loaded feed so
+ * the skeleton reserves the exact layout the real rows drop into (no shift
+ * when the fetch resolves). The "Live Activity" header is static chrome, so it
+ * renders immediately rather than shimmering.
+ */
+function FeedShell({ children }: { children: ReactNode }) {
   return (
     <section className="mx-auto max-w-7xl px-4 sm:px-6 py-12">
-      <article style={{
-        width: "100%",
-        maxWidth: 480,
-        margin: "0 auto",
-        backgroundColor: "var(--bg-surface, #0a0a0a)",
-        border: "2px solid var(--border-hard, #fff)",
-        boxShadow: "6px 6px 0px #000",
-        display: "flex",
-        flexDirection: "column",
-      }}>
+      <article style={FRAME_STYLE}>
         <header style={{
           backgroundColor: "var(--accent, #ff4400)",
           color: "var(--text-on-inverted, #0F0F0F)",
@@ -148,68 +125,134 @@ export function LiveActivityFeed() {
         </header>
 
         <div style={{ display: "flex", flexDirection: "column", maxHeight: 500, overflowY: "auto" }}>
-          {grouped.map((item, idx) => {
-            const initials = item.username.slice(0, 2).toUpperCase();
-            const bgColor = AVATAR_COLORS[idx % AVATAR_COLORS.length];
-            const textColor = bgColor === "#ffffff" ? "#000" : bgColor === "#4a4a4a" ? "#fff" : "#000";
-            const name = item.type === "project" ? item.project_title : item.repo_name;
-
-            return (
-              <Link
-                key={item.id}
-                href={`/profile/${item.username}`}
-                style={{
-                  padding: "1rem 1.25rem",
-                  display: "grid",
-                  gridTemplateColumns: "auto 1fr",
-                  gap: "1rem",
-                  borderBottom: idx < grouped.length - 1 ? "1px solid #2a2a2a" : "none",
-                  transition: "background-color 0.15s ease",
-                  textDecoration: "none",
-                  color: "inherit",
-                }}
-              >
-                <div style={{
-                  width: 40, height: 40, backgroundColor: bgColor,
-                  border: "2px solid var(--border-hard, #fff)",
-                  display: "flex", justifyContent: "center", alignItems: "center",
-                  fontWeight: 800, color: textColor, fontSize: "1rem",
-                  textTransform: "uppercase", boxShadow: "2px 2px 0px #000",
-                  overflow: "hidden",
-                  fontFamily: "var(--font-space-grotesk, 'Space Grotesk', sans-serif)",
-                }}>
-                  {item.avatar_url ? (
-                    <Image src={item.avatar_url} alt={item.username} width={40} height={40} style={{ width: "100%", height: "100%", objectFit: "cover" }} />
-                  ) : initials}
-                </div>
-
-                <div style={{ display: "flex", flexDirection: "column", justifyContent: "center", gap: 4 }}>
-                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 8 }}>
-                    <div style={{ fontSize: "0.875rem", lineHeight: 1.2 }}>
-                      <span style={{ fontWeight: 700, color: "var(--foreground, #fff)" }}>@{item.username}</span>{" "}
-                      <span style={{ color: "var(--text-muted, #8a8a8a)" }}>{actionText(item)}</span>
-                    </div>
-                    <span style={{ fontSize: "0.75rem", color: "var(--text-muted, #8a8a8a)", fontVariantNumeric: "tabular-nums", flexShrink: 0 }}>
-                      {relativeTime(item.date)}
-                    </span>
-                  </div>
-                  {name && (
-                    <div style={{
-                      fontSize: "1rem", fontWeight: 800, fontStyle: "italic",
-                      color: "var(--accent, #ff4400)", textTransform: "uppercase",
-                      letterSpacing: "-0.5px", lineHeight: 1.1,
-                      fontFamily: "var(--font-space-grotesk, 'Space Grotesk', sans-serif)",
-                    }}>
-                      {name}
-                    </div>
-                  )}
-                </div>
-              </Link>
-            );
-          })}
+          {children}
         </div>
       </article>
-      {/* blink keyframe defined in globals.css */}
     </section>
+  );
+}
+
+/** One placeholder row mirroring a real feed row (avatar + two text lines). */
+function ActivitySkeletonRow({ last }: { last: boolean }) {
+  return (
+    <div style={{
+      padding: "1rem 1.25rem",
+      display: "grid",
+      gridTemplateColumns: "auto 1fr",
+      gap: "1rem",
+      alignItems: "center",
+      borderBottom: last ? "none" : "1px solid #2a2a2a",
+    }}>
+      <div className="skeleton" style={{ width: 40, height: 40, boxShadow: "2px 2px 0px #000" }} />
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8 }}>
+          <div className="skeleton" style={{ height: 12, width: 120 }} />
+          <div className="skeleton" style={{ height: 10, width: 44 }} />
+        </div>
+        <div className="skeleton" style={{ height: 14, width: "55%" }} />
+      </div>
+    </div>
+  );
+}
+
+export function LiveActivityFeed() {
+  const [feed, setFeed] = useState<FeedItem[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    function fetchFeed() {
+      fetch("/api/feed?limit=20")
+        .then((r) => r.json())
+        .then((d) => {
+          // Drop any event types this snippet can't render correctly.
+          const items: FeedItem[] = (d.feed || []).filter(
+            (i: FeedItem) => SUPPORTED_LEGACY_TYPES.has(i.type),
+          );
+          setFeed(items);
+          setLoaded(true);
+        })
+        .catch(() => setLoaded(true));
+    }
+    fetchFeed();
+    const interval = setInterval(fetchFeed, 30000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const grouped = useMemo(() => groupFeedItems(feed).slice(0, 6), [feed]);
+
+  // Skeleton placeholder rows inside the real frame — no layout shift when the
+  // feed arrives.
+  if (!loaded) return (
+    <FeedShell>
+      {Array.from({ length: 5 }).map((_, i) => (
+        <ActivitySkeletonRow key={i} last={i === 4} />
+      ))}
+    </FeedShell>
+  );
+  if (grouped.length === 0) return null;
+
+  // v2: white text + green blinking dot
+  return (
+    <FeedShell>
+      {grouped.map((item, idx) => {
+        const initials = item.username.slice(0, 2).toUpperCase();
+        const bgColor = AVATAR_COLORS[idx % AVATAR_COLORS.length];
+        const textColor = bgColor === "#ffffff" ? "#000" : bgColor === "#4a4a4a" ? "#fff" : "#000";
+        const name = item.type === "project" ? item.project_title : item.repo_name;
+
+        return (
+          <Link
+            key={item.id}
+            href={`/profile/${item.username}`}
+            style={{
+              padding: "1rem 1.25rem",
+              display: "grid",
+              gridTemplateColumns: "auto 1fr",
+              gap: "1rem",
+              borderBottom: idx < grouped.length - 1 ? "1px solid #2a2a2a" : "none",
+              transition: "background-color 0.15s ease",
+              textDecoration: "none",
+              color: "inherit",
+            }}
+          >
+            <div style={{
+              width: 40, height: 40, backgroundColor: bgColor,
+              border: "2px solid var(--border-hard, #fff)",
+              display: "flex", justifyContent: "center", alignItems: "center",
+              fontWeight: 800, color: textColor, fontSize: "1rem",
+              textTransform: "uppercase", boxShadow: "2px 2px 0px #000",
+              overflow: "hidden",
+              fontFamily: "var(--font-space-grotesk, 'Space Grotesk', sans-serif)",
+            }}>
+              {item.avatar_url ? (
+                <Image src={item.avatar_url} alt={item.username} width={40} height={40} style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+              ) : initials}
+            </div>
+
+            <div style={{ display: "flex", flexDirection: "column", justifyContent: "center", gap: 4 }}>
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 8 }}>
+                <div style={{ fontSize: "0.875rem", lineHeight: 1.2 }}>
+                  <span style={{ fontWeight: 700, color: "var(--foreground, #fff)" }}>@{item.username}</span>{" "}
+                  <span style={{ color: "var(--text-muted, #8a8a8a)" }}>{actionText(item)}</span>
+                </div>
+                <span style={{ fontSize: "0.75rem", color: "var(--text-muted, #8a8a8a)", fontVariantNumeric: "tabular-nums", flexShrink: 0 }}>
+                  {relativeTime(item.date)}
+                </span>
+              </div>
+              {name && (
+                <div style={{
+                  fontSize: "1rem", fontWeight: 800, fontStyle: "italic",
+                  color: "var(--accent, #ff4400)", textTransform: "uppercase",
+                  letterSpacing: "-0.5px", lineHeight: 1.1,
+                  fontFamily: "var(--font-space-grotesk, 'Space Grotesk', sans-serif)",
+                }}>
+                  {name}
+                </div>
+              )}
+            </div>
+          </Link>
+        );
+      })}
+    </FeedShell>
   );
 }

--- a/src/components/ui/live-activity-feed.tsx
+++ b/src/components/ui/live-activity-feed.tsx
@@ -158,6 +158,7 @@ function ActivitySkeletonRow({ last }: { last: boolean }) {
 export function LiveActivityFeed() {
   const [feed, setFeed] = useState<FeedItem[]>([]);
   const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     function fetchFeed() {
@@ -170,8 +171,12 @@ export function LiveActivityFeed() {
           );
           setFeed(items);
           setLoaded(true);
+          setError(null);
         })
-        .catch(() => setLoaded(true));
+        .catch(() => {
+          setError("Couldn't load live activity");
+          setLoaded(true);
+        });
     }
     fetchFeed();
     const interval = setInterval(fetchFeed, 30000);
@@ -187,6 +192,16 @@ export function LiveActivityFeed() {
       {Array.from({ length: 5 }).map((_, i) => (
         <ActivitySkeletonRow key={i} last={i === 4} />
       ))}
+    </FeedShell>
+  );
+  // Failed fetch with nothing cached to show — give explicit feedback rather
+  // than silently rendering an empty section. (Stale items survive a transient
+  // refetch error: the rows path below still wins when `grouped` is non-empty.)
+  if (error && grouped.length === 0) return (
+    <FeedShell>
+      <div style={{ padding: "1.5rem 1.25rem", textAlign: "center", color: "var(--text-muted, #8a8a8a)", fontSize: "0.85rem" }}>
+        Couldn&apos;t load live activity.
+      </div>
     </FeedShell>
   );
   if (grouped.length === 0) return null;


### PR DESCRIPTION
## What
Three small, independent UI polish fixes:
- **Weekly leaderboard** — replace the plain "Loading…" text with skeleton rows in a shared shell (mirrors `ActiveBuilderRow`; no layout shift on load).
- **Activity feeds** (`LiveActivityFeed` + `NetworkFeed`) — skeleton rows instead of "Loading…" text.
- **/projects sort dropdown** — custom `ChevronDown` (the native `<select>` arrow floated off with an awkward gap since the select auto-sized to its widest option).

## Test plan
- ESLint + `tsc` clean.
- Weekly leaderboard skeleton visually verified (desktop + mobile) — matches the real row layout, no shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Network feed now shows six skeleton rows matching feed layout while loading for smoother visual feedback.
  * Weekly leaderboard loading state now displays multiple skeleton rows within a consistent header/container.
  * Activity feed loading replaced with five skeleton placeholders and clearer error display when content fails to load.
  * Sort control now includes a chevron icon for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->