### PR TITLE
feat(seo): rank for "vibe coders marketplace" across Google + AI search

### DIFF
--- a/src/app/glossary/[slug]/page.tsx
+++ b/src/app/glossary/[slug]/page.tsx
@@ -73,7 +73,7 @@ export default async function GlossaryTermPage({
       name: "VibeTalent Glossary",
       url: `${siteUrl}/glossary`,
     },
-    dateModified: "2026-05-22",
+    dateModified: term.dateModified ?? "2026-05-22",
   };
 
   const related = term.related

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,7 +23,7 @@ const jetbrainsMono = JetBrains_Mono({
 
 export const metadata: Metadata = {
   title: {
-    default: "VibeTalent — Find Vibe Coders Who Actually Ship",
+    default: "Vibe Coders Marketplace — Hire Builders Who Ship | VibeTalent",
     template: "%s | VibeTalent",
   },
   description:

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -32,6 +32,14 @@ const FAQ_ITEMS = [
     a: "Vibe coding is the practice of building software using AI-powered IDEs and coding assistants like Claude Code, Cursor, Bolt, and Windsurf. Rather than following traditional development processes with lengthy planning cycles and sprints, vibe coders focus on staying in flow state, shipping features fast, and committing code every single day. The philosophy prioritizes working software in production over documentation, and consistency over sporadic bursts of activity. Vibe coders leverage AI to handle boilerplate and repetitive tasks, freeing them to focus on architecture decisions, product design, and rapid iteration. The result is developers who ship more, ship faster, and build a verifiable track record of daily output that speaks louder than any resume.",
   },
   {
+    q: "Where can I hire vibe coders?",
+    a: "VibeTalent is a vibe coders marketplace built specifically for hiring developers who ship with AI tools like Claude Code, Cursor, and Bolt. Browse builders ranked by coding streak, shipped-project quality, and vibe score on the Explore page and Leaderboard, or describe your project to VibeFinder Bot and get matched automatically. Hiring is direct and free — open any builder's profile, hit Hire, and message them with no middleman and no platform fees. Unlike general freelance sites such as Upwork or Fiverr, every ranking on VibeTalent is backed by verifiable GitHub activity rather than self-reported resumes.",
+  },
+  {
+    q: "What is the best marketplace to hire vibe coders?",
+    a: "The best vibe coders marketplace depends on what you value. General freelance platforms like Upwork, Fiverr, and Freelancer have the largest talent pools but rank developers on resumes and client reviews that are easy to game. VibeTalent takes the opposite approach: it is a developer-only marketplace where builders are ranked entirely on proof of work — daily GitHub commit streaks, deployed projects with live URLs, repository quality, and peer endorsements. If you want to hire a vibe coder based on what they actually ship rather than how they market themselves, VibeTalent is purpose-built for it, with zero platform fees and AI-powered matching through VibeFinder Bot.",
+  },
+  {
     q: "How does the VibeTalent vibe score work?",
     a: "The vibe score is VibeTalent's core reputation metric — a single number representing how consistently and effectively a developer ships code. It is calculated from four weighted components: coding streak days (40% weight), which measures consecutive days of GitHub commits; project quality scores (30% weight), based on GitHub repo health including stars, forks, commit frequency, and deployment status; GitHub activity (20% weight), covering commits, pull requests, code reviews, and issue participation; and peer endorsements (10% weight), where endorsements from higher-scored developers carry more weight. The score updates daily and is always based on verifiable, public data. It cannot be gamed through fake reviews or purchased followers — only real, consistent shipping moves the needle.",
   },
@@ -135,6 +143,8 @@ export default async function HomePage() {
                 "@id": `${siteUrl}/#organization`,
                 name: "VibeTalent",
                 url: siteUrl,
+                description:
+                  "VibeTalent is the vibe coders marketplace — hire AI-assisted developers ranked by coding streaks, shipped projects, and verifiable proof of work instead of resumes.",
                 logo: {
                   "@type": "ImageObject",
                   url: `${siteUrl}/og-image-v2.jpg`,
@@ -169,7 +179,7 @@ export default async function HomePage() {
               boxShadow: "var(--shadow-brutal-sm)",
             }}
           >
-            <span>The vibecoders marketplace</span>
+            <span>The vibe coders marketplace</span>
           </div>
 
           <h1 className="text-5xl sm:text-7xl font-extrabold tracking-tight uppercase text-[var(--foreground)]">

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,6 +2,7 @@ import type { MetadataRoute } from "next";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { siteUrl } from "@/lib/seo";
 import { GLOSSARY_TERMS } from "@/lib/glossary";
+import { COMPARISONS } from "@/lib/comparisons";
 
 // Regenerate hourly. Google polls sitemaps on its own schedule and the
 // per-user `<lastmod>` below already signals freshness to crawlers — no
@@ -23,9 +24,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${siteUrl}/glossary`, lastModified: new Date("2026-05-22") },
     ...GLOSSARY_TERMS.map((t) => ({
       url: `${siteUrl}/glossary/${t.slug}`,
-      lastModified: new Date("2026-05-22"),
+      lastModified: new Date(t.dateModified ?? "2026-05-22"),
     })),
+    { url: `${siteUrl}/vs`, lastModified: new Date("2026-06-05") },
     { url: `${siteUrl}/vs/upwork`, lastModified: new Date("2026-05-22") },
+    ...COMPARISONS.map((c) => ({
+      url: `${siteUrl}/vs/${c.slug}`,
+      lastModified: new Date(c.dateModified),
+    })),
   ];
 
   try {

--- a/src/app/vs/[slug]/page.tsx
+++ b/src/app/vs/[slug]/page.tsx
@@ -1,0 +1,311 @@
+import type { Metadata } from "next";
+import { jsonLdHtml } from "@/lib/json-ld";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { Check, X, ArrowRight, Flame, Zap, Shield } from "lucide-react";
+import { siteUrl } from "@/lib/seo";
+import { COMPARISONS, getComparison } from "@/lib/comparisons";
+
+export function generateStaticParams() {
+  return COMPARISONS.map((c) => ({ slug: c.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const c = getComparison(slug);
+  if (!c) return { title: "Not found" };
+
+  const url = `${siteUrl}/vs/${c.slug}`;
+  return {
+    title: c.title,
+    description: c.description,
+    alternates: { canonical: url },
+    openGraph: {
+      title: c.title,
+      description: c.description,
+      url,
+      siteName: "VibeTalent",
+      type: "article",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: c.title,
+      description: c.description,
+    },
+  };
+}
+
+export default async function ComparisonPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const c = getComparison(slug);
+  if (!c) notFound();
+
+  const url = `${siteUrl}/vs/${c.slug}`;
+
+  const breadcrumbLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Home", item: siteUrl },
+      { "@type": "ListItem", position: 2, name: "Compare", item: `${siteUrl}/vs` },
+      { "@type": "ListItem", position: 3, name: `VibeTalent vs ${c.name}`, item: url },
+    ],
+  };
+
+  const faqLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    dateModified: c.dateModified,
+    mainEntity: c.faq.map(({ q, a }) => ({
+      "@type": "Question",
+      name: q,
+      acceptedAnswer: { "@type": "Answer", text: a },
+    })),
+  };
+
+  const articleLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: c.title,
+    description: c.description,
+    url,
+    mainEntityOfPage: { "@type": "WebPage", "@id": url },
+    dateModified: c.dateModified,
+    author: { "@type": "Organization", "@id": `${siteUrl}/#organization`, name: "VibeTalent" },
+    publisher: { "@type": "Organization", "@id": `${siteUrl}/#organization`, name: "VibeTalent" },
+    about: [
+      { "@type": "Organization", name: "VibeTalent", url: siteUrl },
+      { "@type": "Organization", name: c.name, url: c.competitorUrl },
+    ],
+  };
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 sm:px-6 py-16">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(breadcrumbLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(articleLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(faqLd) }}
+      />
+
+      <div className="mb-10">
+        <div
+          className="inline-flex items-center gap-2 px-4 py-1.5 text-xs font-bold uppercase tracking-wide text-[var(--foreground)] mb-6"
+          style={{
+            backgroundColor: "var(--bg-surface)",
+            border: "2px solid var(--border-hard)",
+            boxShadow: "var(--shadow-brutal-sm)",
+          }}
+        >
+          <Zap size={14} className="text-[var(--accent)]" />
+          Comparison
+        </div>
+        <h1 className="text-3xl sm:text-5xl font-extrabold uppercase text-[var(--foreground)] leading-tight">
+          VibeTalent <span className="text-[var(--text-muted)]">vs</span>{" "}
+          <span className="text-[var(--accent)]">{c.name}</span>
+        </h1>
+        <p className="mt-3 text-[var(--text-secondary)] font-medium">{c.subtitle}</p>
+      </div>
+
+      {/* Answer block — the TL;DR sits at the top so AI engines pull it into
+          answer boxes and humans can decide in 10 seconds. */}
+      <section
+        className="p-6 sm:p-8 mb-10"
+        style={{
+          backgroundColor: "var(--bg-surface)",
+          border: "2px solid var(--border-hard)",
+          boxShadow: "var(--shadow-brutal)",
+        }}
+      >
+        <h2 className="text-lg font-extrabold uppercase text-[var(--foreground)] mb-4">
+          The short answer
+        </h2>
+        <p className="text-base text-[var(--foreground)] font-medium leading-relaxed">{c.tldr}</p>
+      </section>
+
+      {/* Feature matrix */}
+      <section className="mb-12">
+        <h2 className="text-2xl font-extrabold uppercase text-[var(--foreground)] mb-6">
+          Side-by-side comparison
+        </h2>
+        <div
+          className="overflow-hidden"
+          style={{
+            backgroundColor: "var(--bg-surface)",
+            border: "2px solid var(--border-hard)",
+            boxShadow: "var(--shadow-brutal)",
+          }}
+        >
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr style={{ borderBottom: "2px solid var(--border-hard)" }}>
+                  <th className="text-left p-4 font-extrabold uppercase text-[var(--foreground)]">
+                    Feature
+                  </th>
+                  <th className="text-left p-4 font-extrabold uppercase text-[var(--accent)]">
+                    VibeTalent
+                  </th>
+                  <th className="text-left p-4 font-extrabold uppercase text-[var(--text-muted)]">
+                    {c.name}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {c.rows.map((row, i) => (
+                  <tr
+                    key={row.feature}
+                    style={{
+                      borderBottom:
+                        i === c.rows.length - 1
+                          ? "none"
+                          : "1px solid var(--border-subtle)",
+                    }}
+                  >
+                    <td className="p-4 font-semibold text-[var(--foreground)]">{row.feature}</td>
+                    <td className="p-4 font-medium text-[var(--text-secondary)]">
+                      {typeof row.vt === "boolean" ? (
+                        row.vt ? (
+                          <Check size={18} className="text-[var(--accent)]" />
+                        ) : (
+                          <X size={18} className="text-[var(--text-muted)]" />
+                        )
+                      ) : (
+                        row.vt
+                      )}
+                    </td>
+                    <td className="p-4 font-medium text-[var(--text-secondary)]">
+                      {typeof row.them === "boolean" ? (
+                        row.them ? (
+                          <Check size={18} className="text-[var(--accent)]" />
+                        ) : (
+                          <X size={18} className="text-[var(--text-muted)]" />
+                        )
+                      ) : (
+                        row.them
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid sm:grid-cols-2 gap-6 mb-12">
+        <div
+          className="p-6"
+          style={{
+            backgroundColor: "var(--bg-surface)",
+            border: "2px solid var(--border-hard)",
+            boxShadow: "var(--shadow-brutal)",
+          }}
+        >
+          <div className="flex items-center gap-2 mb-3">
+            <Flame size={20} className="text-[var(--accent)]" />
+            <h2 className="text-lg font-extrabold uppercase text-[var(--foreground)]">
+              When VibeTalent wins
+            </h2>
+          </div>
+          <ul className="space-y-2 text-sm text-[var(--text-secondary)] font-medium">
+            {c.vtWins.map((point) => (
+              <li key={point}>{point}</li>
+            ))}
+          </ul>
+        </div>
+
+        <div
+          className="p-6"
+          style={{
+            backgroundColor: "var(--bg-surface)",
+            border: "2px solid var(--border-hard)",
+            boxShadow: "var(--shadow-brutal)",
+          }}
+        >
+          <div className="flex items-center gap-2 mb-3">
+            <Shield size={20} className="text-[var(--text-muted)]" />
+            <h2 className="text-lg font-extrabold uppercase text-[var(--foreground)]">
+              When {c.name} wins
+            </h2>
+          </div>
+          <ul className="space-y-2 text-sm text-[var(--text-secondary)] font-medium">
+            {c.themWins.map((point) => (
+              <li key={point}>{point}</li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section className="mb-12">
+        <h2 className="text-2xl font-extrabold uppercase text-[var(--foreground)] mb-6">
+          Frequently asked questions
+        </h2>
+        <div className="space-y-3">
+          {c.faq.map(({ q, a }) => (
+            <details
+              key={q}
+              className="group p-5"
+              style={{
+                backgroundColor: "var(--bg-surface)",
+                border: "2px solid var(--border-hard)",
+                boxShadow: "var(--shadow-brutal-sm)",
+              }}
+            >
+              <summary className="cursor-pointer font-extrabold uppercase text-sm text-[var(--foreground)] flex items-center justify-between">
+                {q}
+                <ArrowRight
+                  size={14}
+                  className="text-[var(--accent)] transition-transform group-open:rotate-90"
+                />
+              </summary>
+              <p className="mt-3 text-sm text-[var(--text-secondary)] font-medium leading-relaxed">
+                {a}
+              </p>
+            </details>
+          ))}
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section
+        className="p-8 sm:p-10 text-center"
+        style={{
+          backgroundColor: "var(--bg-inverted)",
+          border: "2px solid var(--border-hard)",
+          boxShadow: "8px 8px 0 var(--accent)",
+        }}
+      >
+        <h2 className="text-2xl sm:text-3xl font-extrabold uppercase text-white mb-3">
+          Hire builders who actually ship
+        </h2>
+        <p className="text-sm text-[var(--text-muted-soft)] font-medium mb-6 max-w-md mx-auto">
+          Browse vibe coders ranked by streak, project quality, and verified GitHub activity.
+        </p>
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <Link href="/explore" className="btn-brutal btn-brutal-accent inline-flex items-center gap-2 justify-center">
+            Explore talent <ArrowRight size={14} />
+          </Link>
+          <Link href="/agent" className="btn-brutal btn-brutal-secondary inline-flex items-center gap-2 justify-center">
+            Try VibeFinder Bot
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/vs/page.tsx
+++ b/src/app/vs/page.tsx
@@ -1,14 +1,25 @@
 import type { Metadata } from "next";
 import { jsonLdHtml } from "@/lib/json-ld";
 import Link from "next/link";
-import { BookOpen, ArrowRight } from "lucide-react";
+import { Zap, ArrowRight } from "lucide-react";
 import { siteUrl } from "@/lib/seo";
-import { GLOSSARY_TERMS } from "@/lib/glossary";
+import { COMPARISONS } from "@/lib/comparisons";
 
-const PAGE_URL = `${siteUrl}/glossary`;
-const PAGE_TITLE = "VibeTalent Glossary — Vibe Coding, Streaks, Scores Explained";
+const PAGE_URL = `${siteUrl}/vs`;
+const PAGE_TITLE = "VibeTalent vs the Alternatives — Compare Hiring Platforms";
 const PAGE_DESCRIPTION =
-  "Plain-English definitions of the core VibeTalent concepts: vibe coding, vibe coders, coding streaks, vibe scores, and the vibe coders marketplace. Built so AI search engines and humans can find the answer in one paragraph.";
+  "How VibeTalent compares to Upwork, Fiverr, Toptal, and Freelancer for hiring developers. VibeTalent ranks vibe coders on verifiable proof of work — coding streaks, shipped projects, and GitHub activity — instead of resumes and reviews.";
+
+// Upwork predates the data-driven /vs/[slug] system and lives as a standalone
+// page; list it here explicitly alongside the data-driven comparisons.
+const ALL_COMPARISONS = [
+  {
+    slug: "upwork",
+    name: "Upwork",
+    tagline: "Proof-of-work hiring vs resumes and client reviews.",
+  },
+  ...COMPARISONS.map((c) => ({ slug: c.slug, name: c.name, tagline: c.tagline })),
+];
 
 export const metadata: Metadata = {
   title: PAGE_TITLE,
@@ -28,27 +39,26 @@ export const metadata: Metadata = {
   },
 };
 
-export default function GlossaryIndexPage() {
+export default function CompareIndexPage() {
   const breadcrumbLd = {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
     itemListElement: [
       { "@type": "ListItem", position: 1, name: "Home", item: siteUrl },
-      { "@type": "ListItem", position: 2, name: "Glossary", item: PAGE_URL },
+      { "@type": "ListItem", position: 2, name: "Compare", item: PAGE_URL },
     ],
   };
 
   const itemListLd = {
     "@context": "https://schema.org",
-    "@type": "DefinedTermSet",
-    name: "VibeTalent Glossary",
+    "@type": "ItemList",
+    name: "VibeTalent platform comparisons",
     url: PAGE_URL,
-    hasDefinedTerm: GLOSSARY_TERMS.map((t) => ({
-      "@type": "DefinedTerm",
-      "@id": `${siteUrl}/glossary/${t.slug}`,
-      name: t.shortLabel,
-      description: t.summary,
-      url: `${siteUrl}/glossary/${t.slug}`,
+    itemListElement: ALL_COMPARISONS.map((c, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: `VibeTalent vs ${c.name}`,
+      url: `${siteUrl}/vs/${c.slug}`,
     })),
   };
 
@@ -72,23 +82,25 @@ export default function GlossaryIndexPage() {
             boxShadow: "var(--shadow-brutal-sm)",
           }}
         >
-          <BookOpen size={14} className="text-[var(--accent)]" />
-          Glossary
+          <Zap size={14} className="text-[var(--accent)]" />
+          Compare
         </div>
         <h1 className="text-3xl sm:text-4xl font-extrabold uppercase text-[var(--foreground)] leading-tight">
-          The vocabulary of <span className="text-[var(--accent)]">vibe coding.</span>
+          VibeTalent <span className="text-[var(--text-muted)]">vs</span>{" "}
+          <span className="text-[var(--accent)]">the alternatives.</span>
         </h1>
         <p className="mt-4 text-[var(--text-secondary)] font-medium leading-relaxed max-w-2xl">
-          Core terms used across VibeTalent — vibe coding, vibe coders, coding streaks, vibe scores,
-          and the vibe coders marketplace — defined in one paragraph each so you can find the answer fast.
+          Every platform below can connect you with developers. Only VibeTalent ranks them on
+          verifiable proof of work — coding streaks, shipped projects, and GitHub activity — instead
+          of resumes, bids, and reviews. Here is how it stacks up.
         </p>
       </div>
 
       <div className="grid sm:grid-cols-2 gap-4">
-        {GLOSSARY_TERMS.map((term) => (
+        {ALL_COMPARISONS.map((c) => (
           <Link
-            key={term.slug}
-            href={`/glossary/${term.slug}`}
+            key={c.slug}
+            href={`/vs/${c.slug}`}
             className="block p-6 transition-all hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-[2px_2px_0_var(--border-hard)]"
             style={{
               backgroundColor: "var(--bg-surface)",
@@ -97,13 +109,13 @@ export default function GlossaryIndexPage() {
             }}
           >
             <h2 className="text-lg font-extrabold uppercase text-[var(--foreground)] mb-2">
-              {term.shortLabel}
+              VibeTalent vs {c.name}
             </h2>
-            <p className="text-sm text-[var(--text-secondary)] font-medium leading-relaxed mb-3 line-clamp-4">
-              {term.summary}
+            <p className="text-sm text-[var(--text-secondary)] font-medium leading-relaxed mb-3">
+              {c.tagline}
             </p>
             <span className="inline-flex items-center gap-1 text-xs font-bold uppercase text-[var(--accent)]">
-              Read definition <ArrowRight size={12} />
+              Read comparison <ArrowRight size={12} />
             </span>
           </Link>
         ))}

--- a/src/lib/comparisons.ts
+++ b/src/lib/comparisons.ts
@@ -1,0 +1,237 @@
+// Data-driven competitor comparison pages. Each entry renders at
+// /vs/[slug] (see src/app/vs/[slug]/page.tsx) with an Article + FAQPage +
+// BreadcrumbList JSON-LD payload, mirroring the glossary's single-topic-page
+// pattern so AI answer engines can cite a focused "VibeTalent vs X" page.
+//
+// NOTE: /vs/upwork is intentionally NOT in this array — it predates this
+// system and lives as a standalone page at src/app/vs/upwork/page.tsx. The
+// static route takes precedence over [slug], so it keeps working untouched.
+// The /vs index and sitemap list it explicitly alongside these entries.
+
+export type ComparisonCell = string | boolean;
+
+export type ComparisonRow = {
+  feature: string;
+  vt: ComparisonCell;
+  them: ComparisonCell;
+};
+
+export type ComparisonFaq = { q: string; a: string };
+
+export type Comparison = {
+  slug: string;
+  /** Competitor display name, e.g. "Fiverr". */
+  name: string;
+  /** Competitor homepage, used in Article `about` schema. */
+  competitorUrl: string;
+  /** One-line card tagline for the /vs index. */
+  tagline: string;
+  title: string;
+  description: string;
+  /** Sub-headline under the H1. */
+  subtitle: string;
+  /** The 60-90 word "short answer" block — what AI engines pull into answers. */
+  tldr: string;
+  rows: ComparisonRow[];
+  vtWins: string[];
+  themWins: string[];
+  faq: ComparisonFaq[];
+  /** ISO date driving Article/FAQ `dateModified` and the sitemap `<lastmod>`. */
+  dateModified: string;
+};
+
+export const COMPARISONS: Comparison[] = [
+  {
+    slug: "fiverr",
+    name: "Fiverr",
+    competitorUrl: "https://www.fiverr.com",
+    tagline: "Proof-of-work hiring vs fixed-price gig packages.",
+    title: "VibeTalent vs Fiverr — Which Is Better for Hiring Developers?",
+    description:
+      "VibeTalent ranks developers on verifiable proof of work — coding streaks, shipped projects, and GitHub activity. Fiverr is a gig marketplace where sellers are ranked by levels and star reviews. Side-by-side comparison, fees, and which fits your hiring needs.",
+    subtitle:
+      "Which platform is better for hiring developers in 2026? A side-by-side breakdown.",
+    tldr: "VibeTalent ranks developers on verifiable proof of work — daily coding streaks, deployed projects, and GitHub activity — while Fiverr sells fixed-price \"gigs\" from sellers ranked by order volume and star reviews that are easy to inflate. Pick VibeTalent if you want to hire a developer based on what they actually ship, especially AI-native builders using Claude Code, Cursor, or Bolt. Pick Fiverr if you need a quick, packaged one-off task across many non-engineering categories and prefer paying a fixed price up front.",
+    rows: [
+      { feature: "Talent type", vt: "AI-native developers", them: "Generalist gig freelancers" },
+      { feature: "Ranking signal", vt: "GitHub streaks + shipped projects", them: "Seller level + star reviews" },
+      { feature: "Verifiable proof of work", vt: true, them: false },
+      { feature: "GitHub commit streak tracking", vt: true, them: false },
+      { feature: "Project quality scoring from repo health", vt: true, them: false },
+      { feature: "AI-powered hire matching", vt: "VibeFinder Bot", them: "Category & gig search" },
+      { feature: "Pricing model", vt: "Direct hire, negotiate freely", them: "Fixed-price gig packages" },
+      { feature: "Service fee for the freelancer", vt: "0%", them: "~20% commission" },
+      { feature: "Crypto payments (USDC)", vt: true, them: false },
+      { feature: "Built-in order protection", vt: false, them: true },
+      { feature: "Non-engineering roles", vt: false, them: true },
+      { feature: "Public daily activity feed", vt: true, them: false },
+    ],
+    vtWins: [
+      "You want to hire AI-native developers using Claude Code, Cursor, or Bolt",
+      "You care more about shipping evidence than star ratings",
+      "You want to pay in USDC with no platform fees",
+      "You need a builder who can prototype and ship in days, not a canned package",
+      "You are tired of inflated gig reviews and want verifiable signal",
+    ],
+    themWins: [
+      "You need non-engineering work (logos, voiceover, video, copy)",
+      "You want a packaged, fixed-price deliverable with clear scope",
+      "You have a small one-off micro-task",
+      "You want built-in order protection and dispute handling",
+      "You want a huge catalog of cheap, fast turnarounds",
+    ],
+    faq: [
+      {
+        q: "What is the main difference between VibeTalent and Fiverr?",
+        a: "Fiverr is a gig marketplace where freelancers sell fixed-price packages and are ranked by seller level, order volume, and star reviews — signals that can be inflated. VibeTalent is a developer-only marketplace where rankings come from verifiable data: GitHub commit streaks, deployed project quality, repo health, and peer endorsements weighted by the endorser's own vibe score. The data refreshes daily and cannot be faked.",
+      },
+      {
+        q: "Is VibeTalent cheaper than Fiverr?",
+        a: "VibeTalent is free for both developers and clients — there is no service fee on hires and no commission on payments. The only paid feature is optional Featured Projects placement, priced in USDC with no platform markup. Fiverr typically takes around a 20% commission from the seller and adds a service fee for the buyer on top of the gig price.",
+      },
+      {
+        q: "Can I hire AI-native developers on Fiverr?",
+        a: "You can find sellers on Fiverr who advertise AI tools in their gig descriptions, but there is no way to verify that they ship working software with those tools daily. VibeTalent was built specifically for vibe coders — developers who use Claude Code, Cursor, Bolt, and Windsurf to ship code every day — and ranks them on the GitHub activity that proves they actually do it.",
+      },
+      {
+        q: "Does Fiverr show GitHub data?",
+        a: "No. Fiverr ranks sellers on gig performance metrics — order volume, on-time delivery, response rate, and buyer reviews — not on code. VibeTalent makes GitHub activity the core ranking signal: coding streak length alone is 40% of a developer's vibe score, with deployed project quality and repo health on top.",
+      },
+      {
+        q: "Is Fiverr or VibeTalent better for a one-off task?",
+        a: "Fiverr is better for a small, well-defined, fixed-price task — especially non-engineering work like a logo, a voiceover, or a short video. VibeTalent is better when you need a developer who can ship a real, working product, whether that is a one-week prototype or an ongoing build, because it surfaces builders proven to ship consistently.",
+      },
+    ],
+    dateModified: "2026-06-05",
+  },
+  {
+    slug: "toptal",
+    name: "Toptal",
+    competitorUrl: "https://www.toptal.com",
+    tagline: "Public, verifiable merit vs a private \"top 3%\" screen.",
+    title: "VibeTalent vs Toptal — Which Is Better for Hiring Developers?",
+    description:
+      "VibeTalent ranks developers on public, verifiable proof of work — coding streaks, shipped projects, and GitHub activity, free to use. Toptal is a premium network that vets the \"top 3%\" behind closed doors. Compare cost, vetting, and which fits your hiring needs.",
+    subtitle:
+      "Which platform is better for hiring developers in 2026? A side-by-side breakdown.",
+    tldr: "VibeTalent and Toptal both promise quality but prove it differently. Toptal screens for the \"top 3%\" through a private vetting process and matches you with senior freelancers at premium, account-managed rates. VibeTalent makes the proof public: every builder is ranked on verifiable GitHub streaks, shipped projects, and repo quality you can inspect yourself — for free. Pick Toptal for hands-off, enterprise-grade staffing. Pick VibeTalent to hire AI-native builders fast, on transparent merit, with no markup and no gatekeeper.",
+    rows: [
+      { feature: "Talent type", vt: "AI-native developers", them: "Vetted senior freelancers" },
+      { feature: "Ranking signal", vt: "Public GitHub streaks + shipped projects", them: "Private \"top 3%\" screen" },
+      { feature: "You can inspect the evidence yourself", vt: true, them: false },
+      { feature: "GitHub commit streak tracking", vt: true, them: false },
+      { feature: "Project quality scoring from repo health", vt: true, them: false },
+      { feature: "AI-powered hire matching", vt: "VibeFinder Bot", them: "Human account matcher" },
+      { feature: "Cost to start", vt: "Free", them: "Premium + deposit" },
+      { feature: "Platform fee for clients", vt: "0%", them: "Premium markup on rates" },
+      { feature: "Crypto payments (USDC)", vt: true, them: false },
+      { feature: "Fully managed matching", vt: false, them: true },
+      { feature: "Enterprise contracts & compliance", vt: false, them: true },
+      { feature: "Public daily activity feed", vt: true, them: false },
+    ],
+    vtWins: [
+      "You want to hire AI-native builders using Claude Code, Cursor, or Bolt",
+      "You want to verify a developer's track record yourself, not trust a private screen",
+      "You want it free, with no premium markup or refundable deposit",
+      "You need a builder who can prototype and ship in days",
+      "You value transparent, merit-based ranking over a curated shortlist",
+    ],
+    themWins: [
+      "You want a fully managed, hands-off hiring process",
+      "You need enterprise contracts, compliance, and invoicing",
+      "You prefer a human matcher to assemble a vetted shortlist",
+      "You have the budget for premium, account-managed rates",
+      "You also need designers, PMs, or finance experts in one network",
+    ],
+    faq: [
+      {
+        q: "What is the main difference between VibeTalent and Toptal?",
+        a: "Toptal vets freelancers privately and markets them as the \"top 3%,\" then matches you through an account manager at premium rates — but you cannot inspect the screen yourself. VibeTalent makes vetting public and verifiable: every developer is ranked on GitHub commit streaks, deployed project quality, and repo health that you can check directly on their profile, for free.",
+      },
+      {
+        q: "Is VibeTalent cheaper than Toptal?",
+        a: "Yes. VibeTalent is free for both clients and developers, with no platform fee on hires. Toptal is a premium service — it does not publish flat rates, typically involves a refundable deposit to start, and bills clients at account-managed rates well above a typical freelance marketplace.",
+      },
+      {
+        q: "Is VibeTalent's talent vetted like Toptal's?",
+        a: "The vetting philosophy is the opposite. Toptal vets candidates behind closed doors and asks you to trust the result. VibeTalent puts the evidence in the open: a builder's coding streak, shipped projects with live URLs, repo quality, and vibe score are all public and update daily. You do the vetting in seconds by looking at real, verifiable work.",
+      },
+      {
+        q: "Can I verify a Toptal developer's track record myself?",
+        a: "Not directly — Toptal's screening is internal, and you mostly see a curated profile and the matcher's recommendation. On VibeTalent, every ranking signal is public GitHub-derived data, so you can audit a builder's commit history, deployed projects, and consistency yourself before you reach out.",
+      },
+      {
+        q: "Is Toptal or VibeTalent better for enterprise hiring?",
+        a: "Toptal is better when you need fully managed staffing with enterprise contracts, compliance, and a human matcher handling the process. VibeTalent is better when you want to hire AI-native builders fast on transparent merit, without a markup or gatekeeper — ideal for startups and teams that value shipping speed and proof of work.",
+      },
+    ],
+    dateModified: "2026-06-05",
+  },
+  {
+    slug: "freelancer",
+    name: "Freelancer",
+    competitorUrl: "https://www.freelancer.com",
+    tagline: "Merit rankings vs competitive bidding wars.",
+    title: "VibeTalent vs Freelancer — Which Is Better for Hiring Developers?",
+    description:
+      "VibeTalent ranks developers on verifiable proof of work — coding streaks, shipped projects, and GitHub activity. Freelancer.com runs on competitive bidding and reviews. Side-by-side comparison, fees, and which fits your hiring needs.",
+    subtitle:
+      "Which platform is better for hiring developers in 2026? A side-by-side breakdown.",
+    tldr: "VibeTalent ranks developers on verifiable proof of work — daily coding streaks, deployed projects, and GitHub activity — while Freelancer.com runs on competitive bidding, where freelancers underbid each other and rankings lean on ratings and reviews that are easy to game. Pick VibeTalent if you want to hire on demonstrated shipping ability, especially AI-native builders using Claude Code, Cursor, or Bolt. Pick Freelancer if you want a huge global pool, contest-style sourcing, and the lowest possible bid for a well-defined task.",
+    rows: [
+      { feature: "Talent type", vt: "AI-native developers", them: "Generalist global freelancers" },
+      { feature: "Ranking signal", vt: "GitHub streaks + shipped projects", them: "Bids + ratings + reviews" },
+      { feature: "Verifiable proof of work", vt: true, them: false },
+      { feature: "GitHub commit streak tracking", vt: true, them: false },
+      { feature: "Project quality scoring from repo health", vt: true, them: false },
+      { feature: "How you source talent", vt: "Browse merit rankings + VibeFinder Bot", them: "Post a project, collect bids" },
+      { feature: "AI-powered hire matching", vt: "VibeFinder Bot", them: false },
+      { feature: "Service fee for the freelancer", vt: "0%", them: "~10% or fixed fee" },
+      { feature: "Crypto payments (USDC)", vt: true, them: false },
+      { feature: "Milestone escrow", vt: false, them: true },
+      { feature: "Contests & non-engineering roles", vt: false, them: true },
+      { feature: "Public daily activity feed", vt: true, them: false },
+    ],
+    vtWins: [
+      "You want to hire AI-native developers using Claude Code, Cursor, or Bolt",
+      "You care about shipping evidence, not who bids the lowest",
+      "You want to skip bidding wars and browse builders ranked on merit",
+      "You want to pay in USDC with no platform fees",
+      "You want verifiable signal instead of gameable reviews",
+    ],
+    themWins: [
+      "You want the lowest possible bid for a clearly scoped task",
+      "You need a very large global talent pool",
+      "You like contest-style sourcing for design or naming work",
+      "You need non-engineering roles alongside development",
+      "You want milestone escrow for fixed-scope projects",
+    ],
+    faq: [
+      {
+        q: "What is the main difference between VibeTalent and Freelancer?",
+        a: "Freelancer.com is a bidding marketplace: you post a project and freelancers compete on price, with rankings driven by ratings, reviews, and completion rate — signals that can be gamed. VibeTalent removes bidding entirely and ranks developers on verifiable data: GitHub commit streaks, deployed project quality, repo health, and peer endorsements that refresh daily and cannot be faked.",
+      },
+      {
+        q: "Is VibeTalent cheaper than Freelancer?",
+        a: "VibeTalent is free for both developers and clients, with no service fee on hires and no commission on payments. Freelancer.com typically charges freelancers around a 10% (or fixed minimum) project fee and adds project and milestone fees for clients on top.",
+      },
+      {
+        q: "Is bidding better than ranking developers on proof of work?",
+        a: "Bidding optimizes for the lowest price, which often means a race to the bottom rather than the best builder. VibeTalent ranks developers on demonstrated ability — coding streaks, shipped projects, and repo quality — so you start from proven builders instead of sorting through bids and hoping the reviews are real.",
+      },
+      {
+        q: "Does Freelancer show GitHub data?",
+        a: "No. Freelancer.com ranks talent on bids, ratings, reviews, and on-platform completion history, not on code. VibeTalent makes GitHub activity the core ranking signal — coding streak length alone is 40% of a developer's vibe score, with deployed project quality and repo health on top.",
+      },
+      {
+        q: "Is Freelancer or VibeTalent better for a one-off project?",
+        a: "Freelancer is better when you want competitive bids on a clearly scoped, often non-engineering task and value milestone escrow. VibeTalent is better when you need a developer who can ship a working product fast — a prototype or an ongoing build — because it surfaces builders proven to ship consistently rather than those who simply bid the lowest.",
+      },
+    ],
+    dateModified: "2026-06-05",
+  },
+];
+
+export function getComparison(slug: string): Comparison | undefined {
+  return COMPARISONS.find((c) => c.slug === slug);
+}

--- a/src/lib/glossary.ts
+++ b/src/lib/glossary.ts
@@ -13,6 +13,10 @@ export type GlossaryTerm = {
   body: string[];
   related: string[];
   metaDescription: string;
+  // Optional ISO date for this term's last meaningful content change. Drives
+  // the DefinedTerm `dateModified` and the sitemap `<lastmod>` so newer terms
+  // signal freshness for crawling/indexing. Falls back to the glossary-wide date.
+  dateModified?: string;
 };
 
 export const GLOSSARY_TERMS: GlossaryTerm[] = [
@@ -27,7 +31,7 @@ export const GLOSSARY_TERMS: GlossaryTerm[] = [
       "The philosophy treats AI coding tools as the new primitive. Claude Code, Cursor, Bolt, and Windsurf handle boilerplate, scaffolding, and repetitive logic, freeing the developer to focus on product decisions, architecture, and rapid iteration. The result is that one motivated vibe coder can ship what previously took a full team — but only if they actually do it every day.",
       "Consistency matters more than raw talent in this model. A vibe coder with a 200-day coding streak is more valuable than one with a polished resume but irregular output, because the streak is verifiable proof of work that cannot be faked. That is why VibeTalent ranks developers on shipping signals — streaks, deployed projects, and repo health — instead of credentials.",
     ],
-    related: ["vibe-coder", "coding-streak", "vibe-score"],
+    related: ["vibe-coder", "vibe-coders-marketplace", "coding-streak", "vibe-score"],
     metaDescription:
       "Vibe coding means building software with AI tools like Claude Code, Cursor, and Bolt — staying in flow, shipping every day, and letting working code be the resume.",
   },
@@ -42,7 +46,7 @@ export const GLOSSARY_TERMS: GlossaryTerm[] = [
       "The most distinctive trait is daily shipping. A vibe coder commits to GitHub every day, deploys updates frequently, and treats their public repos as a living portfolio. This is fundamentally different from a developer with a strong resume but sporadic output — clients can verify a vibe coder's work in seconds by checking their commit history, demo links, and project quality.",
       "VibeTalent surfaces vibe coders by ranking them on verifiable signals: coding streak length, project shipping rate, repo health (stars, forks, deployment status), and peer endorsements from other vibe coders. The leaderboard rewards builders who show up every day, not those who interview well.",
     ],
-    related: ["vibe-coding", "coding-streak", "vibe-score"],
+    related: ["vibe-coding", "vibe-coders-marketplace", "coding-streak", "vibe-score"],
     metaDescription:
       "A vibe coder is a developer who ships code daily using AI tools and proves their skill through coding streaks, deployed projects, and public GitHub activity.",
   },
@@ -75,6 +79,22 @@ export const GLOSSARY_TERMS: GlossaryTerm[] = [
     related: ["coding-streak", "vibe-coder", "vibe-coding"],
     metaDescription:
       "A vibe score is VibeTalent's reputation metric: 40% streak + 30% project quality + 20% GitHub activity + 10% peer endorsements. Updated daily from verifiable data.",
+  },
+  {
+    slug: "vibe-coders-marketplace",
+    title: "What is a vibe coders marketplace?",
+    shortLabel: "Vibe Coders Marketplace",
+    summary:
+      "A vibe coders marketplace is a hiring platform that connects clients with developers who build using AI coding tools — and ranks them by verifiable proof of work instead of resumes. On VibeTalent, builders are surfaced by their coding streak, shipped-project quality, and GitHub activity, so clients can hire vibe coders based on what they actually ship rather than how well they interview.",
+    body: [
+      "A vibe coders marketplace is where clients go to find and hire developers who work in the vibe coding style — shipping software fast with AI assistants like Claude Code, Cursor, Bolt, and Windsurf. The phrase is sometimes written \"vibe coding marketplace,\" but the two can mean different things: some marketplaces sell finished vibe-coded apps and templates, while a vibe coders marketplace like VibeTalent is about hiring the people who build them.",
+      "What separates a vibe coders marketplace from a traditional freelance platform is the ranking signal. Sites like Upwork, Fiverr, and Toptal rank talent on self-reported resumes, client reviews, and interview screens — all of which can be gamed. VibeTalent ranks developers on data that cannot be faked: consecutive-day GitHub commit streaks, the quality and deployment status of shipped projects, broader GitHub activity, and peer endorsements weighted by each endorser's own reputation.",
+      "For clients, that means you can evaluate a builder in seconds — open a profile and see a live streak, real deployed projects, and a transparent vibe score instead of a polished pitch. Hiring is direct and free: no platform fees and no middleman, and VibeFinder Bot can match a project brief to the right builders automatically. For developers, it means your daily shipping becomes a public, compounding reputation that wins work on merit.",
+    ],
+    related: ["vibe-coder", "vibe-coding", "vibe-score"],
+    metaDescription:
+      "A vibe coders marketplace connects clients with AI-native developers ranked by proof of work — coding streaks, shipped projects, and GitHub activity, not resumes.",
+    dateModified: "2026-06-05",
   },
 ];
 


### PR DESCRIPTION
## Goal

Rank vibetalent.work for **"vibe coders marketplace"** / **"vibe coding marketplace"** in Google **and** AI search (ChatGPT, Perplexity, Google AI Overviews).

The site's technical + AEO foundation (robots AI-crawler allowlist, `llms.txt`, FAQ/DefinedTerm schema, sitemap) was already strong. The audit found the gap was **exact-phrase keyword targeting** and a lack of dedicated, citable pages for the target terms. Search intent also splits: *"vibe coding marketplace"* skews toward product marketplaces, while *"vibe coders marketplace / hire vibe coders"* is the talent intent we actually serve — so this PR leans into the talent cluster.

## Changes

**On-page (Critical)**
- Homepage `<title>` now leads with the exact phrase: `Vibe Coders Marketplace — Hire Builders Who Ship | VibeTalent` (previously contained no "marketplace")
- Hero eyebrow `vibecoders` → `vibe coders` (two words, matches how people search)
- `Organization` JSON-LD gains a keyword-bearing `description`

**Content + AEO (High)**
- **New glossary term** `/glossary/vibe-coders-marketplace` with `DefinedTerm` schema — a focused, citable answer page (the pattern already getting us cited by AI). Cross-linked from the `vibe-coder` and `vibe-coding` terms.
- **2 hiring-intent homepage FAQ items** ("Where can I hire vibe coders?", "What's the best marketplace to hire vibe coders?") feeding the existing `FAQPage` schema
- **Competitor comparison pages** `/vs/fiverr`, `/vs/toptal`, `/vs/freelancer` — built data-driven via a new `/vs/[slug]` route + `src/lib/comparisons.ts`, plus a `/vs` hub page. Each has a unique TL;DR, feature matrix, FAQ, and Article/FAQPage schema.

**Plumbing fixes surfaced along the way**
- Sitemap was hardcoded to only `/vs/upwork` → now maps the full comparison set automatically
- Glossary terms now carry per-page `dateModified` (was one shared hardcoded date) for accurate freshness signals
- `/vs` breadcrumb previously pointed to a non-existent page → the new hub resolves it

## Notes / safety
- The existing **`/vs/upwork` page is left completely untouched** — Next's static route takes precedence over `/vs/[slug]`, so there's zero regression risk to the indexed page.
- New comparison pages are data-driven; adding a future competitor is just a `comparisons.ts` entry.
- `FAQPage` here is for **AI/LLM citation + on-page relevance**, not Google rich snippets (those are gov/health-only since Aug 2023).

## Verification
- `npx tsc --noEmit` → exit 0
- `eslint` (changed files) → exit 0
- `npm run build` → success; all 6 new pages confirmed prerendered to HTML

## Post-merge
After deploy, request indexing in Search Console for: `/`, `/glossary/vibe-coders-marketplace`, `/vs`, `/vs/fiverr`, `/vs/toptal`, `/vs/freelancer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)