### PR TITLE
fix(username): clear "taken" errors + live availability everywhere (no more silent failures)

### DIFF
--- a/src/app/auth/profile-setup/page.tsx
+++ b/src/app/auth/profile-setup/page.tsx
@@ -11,6 +11,8 @@ import {
   saveOnboardingProfile,
   type ProfileWriteClient,
 } from "@/lib/onboarding-profile";
+import { isUsernameTakenError, validateUsername } from "@/lib/username";
+import { useUsernameAvailability } from "@/lib/use-username-availability";
 import {
   Flame,
   Github,
@@ -127,7 +129,7 @@ export default function ProfileSetupPage() {
       const { data: userRow } = await (supabase.from("users") as any)
         .select("display_name, github_username, github_id")
         .eq("id", user.id)
-        .single();
+        .maybeSingle();
       if (userRow?.display_name) {
         setProfile((p) => ({ ...p, display_name: userRow.display_name }));
       }
@@ -187,7 +189,7 @@ export default function ProfileSetupPage() {
         const { data } = await (supabase.from("social_links") as any)
           .select("*")
           .eq("user_id", user.id)
-          .single();
+          .maybeSingle();
         if (data) {
           setSocials({
             github: data.github || "",
@@ -205,12 +207,8 @@ export default function ProfileSetupPage() {
 
   const supabase = createClient();
 
-  const validateUsername = (value: string) => {
-    if (value.length < 3) return "Username must be at least 3 characters";
-    if (!/^[a-z0-9_]+$/.test(value))
-      return "Only lowercase letters, numbers, and underscores allowed";
-    return null;
-  };
+  // Live, debounced availability for the username field (shared with settings).
+  const usernameAvailability = useUsernameAvailability(profile.username);
 
   /* ── Step handlers ───────────────────────────────────────── */
 
@@ -269,9 +267,11 @@ export default function ProfileSetupPage() {
       }
       setStep(2);
     } catch (err: unknown) {
-      const message =
-        err instanceof Error ? err.message : "Failed to save profile";
-      setError(message);
+      if (isUsernameTakenError(err)) {
+        setError(`@${profile.username} is already taken — please choose another.`);
+      } else {
+        setError(err instanceof Error ? err.message : "Failed to save profile");
+      }
     } finally {
       setLoading(false);
     }
@@ -554,6 +554,25 @@ export default function ProfileSetupPage() {
         <p className="text-[10px] text-[var(--text-secondary)] mt-1">
           Min 3 chars. Lowercase letters, numbers, and underscores only.
         </p>
+        {(usernameAvailability.status === "checking" ||
+          usernameAvailability.status === "available" ||
+          usernameAvailability.status === "taken") && (
+          <p
+            className="text-[10px] font-bold mt-1"
+            style={{
+              color:
+                usernameAvailability.status === "available"
+                  ? "var(--status-success-text)"
+                  : usernameAvailability.status === "taken"
+                  ? "var(--status-error-text)"
+                  : "var(--text-secondary)",
+            }}
+          >
+            {usernameAvailability.status === "checking" && "Checking availability…"}
+            {usernameAvailability.status === "available" && "✓ Available"}
+            {usernameAvailability.status === "taken" && usernameAvailability.message}
+          </p>
+        )}
       </div>
 
       <div>
@@ -1001,7 +1020,7 @@ export default function ProfileSetupPage() {
                     .from("users")
                     .select("id, referral_count")
                     .eq("username", refCode)
-                    .single();
+                    .maybeSingle();
                   if (referrer) {
                     // Create referral record
                     await sb.from("referrals").insert({

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -190,9 +190,9 @@ export default function DashboardPage() {
       try {
       // Fetch profile + projects + socials + streaks + inbox ALL in parallel (single round trip)
       const results = await Promise.allSettled([
-        sb.from("users").select("*").eq("id", authUser.id).single(),
+        sb.from("users").select("*").eq("id", authUser.id).maybeSingle(),
         sb.from("projects").select("*").eq("user_id", authUser.id).order("created_at", { ascending: false }),
-        sb.from("social_links").select("*").eq("user_id", authUser.id).single(),
+        sb.from("social_links").select("*").eq("user_id", authUser.id).maybeSingle(),
         fetchStreakLogs(authUser.id),
         sb.from("hire_requests").select("*").eq("builder_id", authUser.id).order("created_at", { ascending: false }),
       ]);
@@ -560,11 +560,11 @@ export default function DashboardPage() {
     if (!authUser) return;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sb = supabase as any;
-    const { data: profile } = await sb.from("users").select("id, username, bio, avatar_url, vibe_score, streak, longest_streak, badge_level, referral_count, created_at").eq("id", authUser.id).single();
+    const { data: profile } = await sb.from("users").select("id, username, bio, avatar_url, vibe_score, streak, longest_streak, badge_level, referral_count, created_at").eq("id", authUser.id).maybeSingle();
     if (!profile) return;
     const [{ data: projects }, { data: socials }, streakData] = await Promise.all([
       sb.from("projects").select("id, user_id, title, description, tech_stack, live_url, github_url, image_url, build_time, tags, verified, created_at").eq("user_id", authUser.id).order("created_at", { ascending: false }),
-      sb.from("social_links").select("id, user_id, twitter, telegram, github, website, farcaster").eq("user_id", authUser.id).single(),
+      sb.from("social_links").select("id, user_id, twitter, telegram, github, website, farcaster").eq("user_id", authUser.id).maybeSingle(),
       fetchStreakLogs(authUser.id),
     ]);
     setUser({ ...profile, projects: projects || [], social_links: socials || null });

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -11,6 +11,8 @@ import { normalizeExternalUrl } from "@/lib/url-normalize";
 import type { UserWithSocials } from "@/lib/types/database";
 import { EmailPreferences } from "@/components/dashboard/email-preferences";
 import { PrivacyPreferences } from "@/components/dashboard/privacy-preferences";
+import { isUsernameTakenError, validateUsername } from "@/lib/username";
+import { useUsernameAvailability } from "@/lib/use-username-availability";
 import {
   Save,
   Camera,
@@ -50,6 +52,13 @@ export default function SettingsPage() {
   const [highlightName, setHighlightName] = useState(false);
   const displayNameRef = useRef<HTMLInputElement>(null);
 
+  // Live, debounced availability for the username field. The user's own current
+  // handle reads as `idle` (unchanged), never a redundant "taken".
+  const usernameAvailability = useUsernameAvailability(profileForm.username, {
+    currentUsername: user?.username ?? null,
+    currentUserId: user?.id ?? null,
+  });
+
   useEffect(() => {
     let cancelled = false;
     let loaded = false;
@@ -63,9 +72,9 @@ export default function SettingsPage() {
 
       try {
         const results = await Promise.allSettled([
-          sb.from("users").select("*").eq("id", authUser.id).single(),
+          sb.from("users").select("*").eq("id", authUser.id).maybeSingle(),
           sb.from("projects").select("*").eq("user_id", authUser.id).order("created_at", { ascending: false }),
-          sb.from("social_links").select("*").eq("user_id", authUser.id).single(),
+          sb.from("social_links").select("*").eq("user_id", authUser.id).maybeSingle(),
         ]);
 
         const profile = results[0].status === "fulfilled" ? results[0].value?.data : null;
@@ -222,6 +231,11 @@ export default function SettingsPage() {
       alert("Username contains inappropriate language");
       return;
     }
+    const usernameError = validateUsername(profileForm.username.trim());
+    if (usernameError) {
+      alert(usernameError);
+      return;
+    }
     const twitterResult = normalizeSocialHandle(profileForm.twitter, "twitter");
     if (!twitterResult.ok) {
       alert(twitterResult.error);
@@ -278,7 +292,7 @@ export default function SettingsPage() {
     // initial signup: the OAuth callback sets it, but earlier flows could
     // leave it null while the GitHub identity was already attached, which
     // kept the blue verified badge from rendering.
-    await sb
+    const { error: usersError } = await sb
       .from("users")
       .update({
         username: profileForm.username.trim(),
@@ -287,6 +301,17 @@ export default function SettingsPage() {
         github_username: verifiedGithub,
       })
       .eq("id", user.id);
+    if (usersError) {
+      // Surface a clear, recoverable message instead of silently failing and
+      // then optimistically rendering the new handle as if it had saved.
+      alert(
+        isUsernameTakenError(usersError)
+          ? `@${profileForm.username.trim()} is already taken — please choose another.`
+          : `Couldn't save your profile: ${usersError.message ?? "please try again."}`
+      );
+      setSaving(false);
+      return;
+    }
 
     await sb.from("social_links").upsert({
       user_id: user.id,
@@ -417,9 +442,33 @@ export default function SettingsPage() {
             <input
               type="text"
               value={profileForm.username}
-              onChange={(e) => setProfileForm({ ...profileForm, username: e.target.value })}
+              onChange={(e) =>
+                setProfileForm({
+                  ...profileForm,
+                  username: e.target.value.toLowerCase().replace(/[^a-z0-9_]/g, ""),
+                })
+              }
               className="input-brutal"
             />
+            {(usernameAvailability.status === "checking" ||
+              usernameAvailability.status === "available" ||
+              usernameAvailability.status === "taken") && (
+              <p
+                className="text-[10px] font-bold mt-1"
+                style={{
+                  color:
+                    usernameAvailability.status === "available"
+                      ? "var(--status-success-text)"
+                      : usernameAvailability.status === "taken"
+                      ? "var(--status-error-text)"
+                      : "var(--text-muted)",
+                }}
+              >
+                {usernameAvailability.status === "checking" && "Checking availability…"}
+                {usernameAvailability.status === "available" && "✓ Available"}
+                {usernameAvailability.status === "taken" && usernameAvailability.message}
+              </p>
+            )}
           </div>
           <div>
             <label className="text-xs font-bold uppercase tracking-wide text-[var(--text-muted)] mb-1.5 flex items-center gap-2">

--- a/src/lib/__tests__/username.test.ts
+++ b/src/lib/__tests__/username.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateUsername,
+  isUsernameTakenError,
+  checkUsernameAvailable,
+  type UsernameLookupClient,
+} from "../username";
+
+describe("validateUsername", () => {
+  it("accepts valid lowercase handles", () => {
+    expect(validateUsername("rishad")).toBeNull();
+    expect(validateUsername("vibe_coder_99")).toBeNull();
+  });
+
+  it("rejects too-short handles", () => {
+    expect(validateUsername("ab")).toMatch(/at least 3/i);
+  });
+
+  it("rejects uppercase, spaces, and symbols", () => {
+    expect(validateUsername("Rishad")).toMatch(/lowercase/i);
+    expect(validateUsername("ris had")).toMatch(/lowercase/i);
+    expect(validateUsername("ris-had")).toMatch(/lowercase/i);
+  });
+});
+
+describe("isUsernameTakenError", () => {
+  it("is true for 23505 on the username constraint", () => {
+    expect(
+      isUsernameTakenError({
+        code: "23505",
+        message: 'duplicate key value violates unique constraint "users_username_key"',
+      })
+    ).toBe(true);
+  });
+
+  it("is false for 23505 on the github_id index (not a username clash)", () => {
+    expect(
+      isUsernameTakenError({
+        code: "23505",
+        message: 'duplicate key value violates unique constraint "idx_users_github_id_unique"',
+      })
+    ).toBe(false);
+  });
+
+  it("is false for non-unique errors and non-error values", () => {
+    expect(isUsernameTakenError({ code: "42501", message: "permission denied" })).toBe(false);
+    expect(isUsernameTakenError({ code: "23502", message: "null value" })).toBe(false);
+    expect(isUsernameTakenError(null)).toBe(false);
+    expect(isUsernameTakenError("23505")).toBe(false);
+    expect(isUsernameTakenError(undefined)).toBe(false);
+  });
+});
+
+function lookupClient(row: { id: string } | null, error: unknown = null): UsernameLookupClient {
+  return {
+    from() {
+      return {
+        select() {
+          return {
+            eq() {
+              return {
+                maybeSingle() {
+                  return Promise.resolve({ data: row, error });
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe("checkUsernameAvailable", () => {
+  it("is available when no row exists", async () => {
+    const res = await checkUsernameAvailable(lookupClient(null), "freename");
+    expect(res).toEqual({ available: true, error: null });
+  });
+
+  it("is taken when a row owned by someone else exists", async () => {
+    const res = await checkUsernameAvailable(lookupClient({ id: "other-user" }), "taken", "me");
+    expect(res.available).toBe(false);
+  });
+
+  it("is available when the existing row is the caller's own (settings, unchanged handle)", async () => {
+    const res = await checkUsernameAvailable(lookupClient({ id: "me" }), "myname", "me");
+    expect(res.available).toBe(true);
+  });
+
+  it("treats an existing row as taken when no currentUserId is given (onboarding)", async () => {
+    const res = await checkUsernameAvailable(lookupClient({ id: "anyone" }), "taken");
+    expect(res.available).toBe(false);
+  });
+
+  it("surfaces a lookup error as not-available without throwing", async () => {
+    const res = await checkUsernameAvailable(lookupClient(null, { code: "500" }), "x");
+    expect(res.available).toBe(false);
+    expect(res.error).toMatchObject({ code: "500" });
+  });
+});

--- a/src/lib/use-username-availability.ts
+++ b/src/lib/use-username-availability.ts
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import {
+  checkUsernameAvailable,
+  validateUsername,
+  type UsernameLookupClient,
+} from "@/lib/username";
+
+export type UsernameStatus =
+  | "idle" // empty, or unchanged from the current handle
+  | "invalid" // fails the format rule
+  | "checking" // availability lookup in flight
+  | "available"
+  | "taken"
+  | "error"; // lookup failed — don't hard-block; the on-submit constraint decides
+
+export interface UsernameAvailability {
+  status: UsernameStatus;
+  message: string | null;
+}
+
+/**
+ * Debounced live username availability for the profile-setup and settings
+ * fields. Validates format first, then queries `users` for a clash.
+ *
+ * The synchronous statuses (idle / invalid / checking) are DERIVED during
+ * render — only the async lookup result is stored in state, and that `setState`
+ * runs inside the debounced callback, never synchronously in the effect (which
+ * would cascade renders). Stale lookups are dropped via a request token tagged
+ * onto the result, and failures degrade to `error` (never throw) so a flaky
+ * check never blocks a legitimate submit — the unique constraint stays the
+ * authoritative, race-proof gate.
+ *
+ * `currentUsername` (settings): the user's existing handle — unchanged input is
+ * `idle`, never a redundant "taken". `currentUserId`: treats their own row as
+ * available if the query happens to return it.
+ */
+export function useUsernameAvailability(
+  username: string,
+  opts: { currentUsername?: string | null; currentUserId?: string | null } = {}
+): UsernameAvailability {
+  const { currentUsername, currentUserId } = opts;
+
+  const value = username.trim();
+  const unchanged = !value || (currentUsername != null && value === currentUsername);
+  const formatError = unchanged ? null : validateUsername(value);
+  const checkable = !unchanged && !formatError;
+
+  // Only the async lookup result lives in state, tagged with the value it was
+  // computed for so a stale result is ignored when deriving the status below.
+  const [result, setResult] = useState<{
+    value: string;
+    available: boolean | null;
+    errored: boolean;
+  }>({ value: "", available: null, errored: false });
+  const reqId = useRef(0);
+
+  useEffect(() => {
+    if (!checkable) return;
+    const id = ++reqId.current;
+    const timer = setTimeout(async () => {
+      try {
+        const client = createClient() as unknown as UsernameLookupClient;
+        const { available, error } = await checkUsernameAvailable(
+          client,
+          value,
+          currentUserId ?? undefined
+        );
+        if (id !== reqId.current) return; // a newer keystroke superseded this one
+        setResult(
+          error
+            ? { value, available: null, errored: true }
+            : { value, available, errored: false }
+        );
+      } catch {
+        if (id !== reqId.current) return;
+        setResult({ value, available: null, errored: true });
+      }
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [value, checkable, currentUserId]);
+
+  if (unchanged) return { status: "idle", message: null };
+  if (formatError) return { status: "invalid", message: formatError };
+  if (result.value !== value) return { status: "checking", message: "Checking availability…" };
+  if (result.errored) return { status: "error", message: null };
+  return result.available
+    ? { status: "available", message: "Available" }
+    : { status: "taken", message: `@${value} is already taken — try another.` };
+}

--- a/src/lib/username.ts
+++ b/src/lib/username.ts
@@ -1,0 +1,86 @@
+/**
+ * Username validation, availability, and error-classification helpers.
+ *
+ * Centralised so onboarding (profile-setup) and settings agree on the rules and
+ * both turn a unique-violation into the same clear, recoverable message instead
+ * of a vague "Failed to save profile" (or, in settings, a silent failure).
+ */
+
+/** Format rule shared by every place a username is set. Returns an error
+ * string, or null when valid. Mirrors the input filter on the username fields
+ * (lowercase letters, numbers, underscores; min 3 chars). */
+export function validateUsername(value: string): string | null {
+  if (value.length < 3) return "Username must be at least 3 characters";
+  if (!/^[a-z0-9_]+$/.test(value)) {
+    return "Only lowercase letters, numbers, and underscores allowed";
+  }
+  return null;
+}
+
+/**
+ * True when `err` is a Postgres unique-violation (23505) on the username
+ * constraint — i.e. the handle is already taken. Gated on the SQLSTATE first,
+ * then the constraint/column name so it never mistakes the `github_id` unique
+ * index (which carries 23505 too) for a username clash.
+ */
+export function isUsernameTakenError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const code = "code" in err ? (err as { code?: unknown }).code : undefined;
+  if (code !== "23505") return false;
+  const message = "message" in err ? String((err as { message?: unknown }).message ?? "") : "";
+  const details = "details" in err ? String((err as { details?: unknown }).details ?? "") : "";
+  return /users_username_key|username/i.test(`${message} ${details}`);
+}
+
+/**
+ * Minimal structural slice of the supabase-js client for the availability
+ * lookup. Typed loosely on purpose (the real client is generic over the DB
+ * schema and pages reach it via `as any`) so tests can pass a light fake.
+ */
+export interface UsernameLookupClient {
+  from(table: "users"): {
+    select(columns: string): {
+      eq(
+        column: "username",
+        value: string
+      ): {
+        maybeSingle(): PromiseLike<{
+          data: { id: string } | null;
+          error: unknown;
+        }>;
+      };
+    };
+  };
+}
+
+export interface UsernameAvailabilityResult {
+  available: boolean;
+  /** The lookup failed (network/RLS). Callers should not hard-block on this —
+   * the unique constraint is still the source of truth on submit. */
+  error: unknown;
+}
+
+/**
+ * Check whether `username` is free. `currentUserId` (optional) treats the
+ * caller's own existing row as "available" so editing settings without changing
+ * the handle never reads as taken.
+ *
+ * On a lookup error, returns `{ available: false, error }` — the caller decides
+ * whether to surface it or fall through to the on-submit unique-constraint
+ * check (which is authoritative and race-proof).
+ */
+export async function checkUsernameAvailable(
+  client: UsernameLookupClient,
+  username: string,
+  currentUserId?: string
+): Promise<UsernameAvailabilityResult> {
+  const { data, error } = await client
+    .from("users")
+    .select("id")
+    .eq("username", username)
+    .maybeSingle();
+  if (error) return { available: false, error };
+  if (!data) return { available: true, error: null };
+  // A row exists: free only if it's the caller's own row.
+  return { available: currentUserId != null && data.id === currentUserId, error: null };
+}


### PR DESCRIPTION
## Context: this fixes it for *everyone*, not one user

Follow-up to #204 (the `42501` onboarding fix). A user reported he still couldn't save his profile — errors `23505 users_username_key` + `PGRST116 "0 rows"`. To rule out the scary theory (corrupted user DB / duplicate identities), I ran a **read-only audit of all 221 auth users + 163 profiles**:

| Check | Result |
|---|---|
| Duplicate auth accounts (same email) | **0** |
| Orphaned profiles (`users.id` not a live auth user) | **0** |
| Same person via 2 logins (matched by `github_id`) | **0** |

**No DB corruption.** So the remaining "can't save my profile" reports are a plain **username collision, surfaced terribly** — and that affects anyone who picks a taken handle.

## The bugs (all user-facing UX, no DB change)
1. **profile-setup** showed a generic **"Failed to save profile"** on a `23505`, with no hint to pick another name.
2. **settings was worse** — it never captured the update error and then **optimistically rendered the new handle**, so a taken username *silently failed while the UI claimed success* (reverts on reload).
3. The expected **"no profile yet"** lookup used `.single()`, emitting a `PGRST116` / `406` that *looks* like a DB fault in devtools (this is the error the reporter saw).

## The fix — applied everywhere a username is set
- **`src/lib/username.ts`** (unit-tested): `validateUsername`, `isUsernameTakenError` (`23505` on `users_username_key` — never the `github_id` index), `checkUsernameAvailable`.
- **`useUsernameAvailability`** hook: debounced **live "Available / taken / checking"** indicator, shared by profile-setup and settings. Synchronous statuses are *derived during render*; `setState` runs only inside the async callback (no cascading-render anti-pattern).
- **profile-setup + settings:** clear **"@name is already taken — choose another"** on submit. Settings now **captures the error and no longer optimistically updates on failure**, and enforces the same format rule + lowercases input.
- Own-profile / own-social_links / referrer lookups → **`.maybeSingle()`** so the expected missing-row case stops throwing `PGRST116`.

## Testing
- `src/lib/__tests__/username.test.ts` — 11 cases (validation, taken-error classification incl. the github_id false-positive guard, availability incl. settings "own handle" case).
- `npm run test` → **294 pass** · `npx tsc --noEmit` clean · `eslint src` clean · `next build` succeeds.

## Not in scope
No identity/auth changes (the audit showed they're not needed). Schema-level `users.id` ↔ `auth.users` binding remains a separate, larger consideration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)