### PR TITLE
fix(seo): dedupe brand titles, noindex thin routes, claim two-word brand

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -5,7 +5,7 @@ import { Flame, Zap, Github, ExternalLink, Code2, Trophy, Users } from "lucide-r
 import { siteUrl } from "@/lib/seo";
 
 export const metadata: Metadata = {
-  title: "About VibeTalent — Built by @abhiontwt",
+  title: { absolute: "About VibeTalent — Built by @abhiontwt" },
   description:
     "VibeTalent is a developer talent marketplace built on proof of work — coding streaks, shipped projects, and vibe scores. Built by Abhinav, a crypto-native builder and AI maximalist.",
   alternates: { canonical: `${siteUrl}/about` },

--- a/src/app/feedback/layout.tsx
+++ b/src/app/feedback/layout.tsx
@@ -1,11 +1,12 @@
 import type { Metadata } from "next";
 
 // Churn/exit survey reached via /feedback?u=<username> — a utility form, not a
-// content page. Keep it out of search results (the page itself is a client
-// component and can't export metadata, so the noindex lives here).
+// content page. noindex keeps it out of search; follow lets any links still
+// pass equity (the page is a client component and can't export metadata, so
+// the robots policy lives here).
 export const metadata: Metadata = {
   title: "Feedback",
-  robots: { index: false, follow: false },
+  robots: { index: false, follow: true },
 };
 
 export default function FeedbackLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/feedback/layout.tsx
+++ b/src/app/feedback/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+// Churn/exit survey reached via /feedback?u=<username> — a utility form, not a
+// content page. Keep it out of search results (the page itself is a client
+// component and can't export metadata, so the noindex lives here).
+export const metadata: Metadata = {
+  title: "Feedback",
+  robots: { index: false, follow: false },
+};
+
+export default function FeedbackLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -142,6 +142,7 @@ export default async function HomePage() {
                 "@type": "WebSite",
                 "@id": `${siteUrl}/#website`,
                 name: "VibeTalent",
+                alternateName: "Vibe Talent",
                 url: siteUrl,
                 description:
                   "The marketplace for vibe coders who ship consistently. Find developers based on streaks, shipped projects, and vibe scores.",
@@ -156,6 +157,7 @@ export default async function HomePage() {
                 "@type": "Organization",
                 "@id": `${siteUrl}/#organization`,
                 name: "VibeTalent",
+                alternateName: "Vibe Talent",
                 url: siteUrl,
                 description:
                   "VibeTalent is the vibe coders marketplace — hire AI-assisted developers ranked by coding streaks, shipped projects, and verifiable proof of work instead of resumes.",

--- a/src/app/profile/[username]/achievements/page.tsx
+++ b/src/app/profile/[username]/achievements/page.tsx
@@ -34,6 +34,7 @@ export async function generateMetadata({
       title,
       description,
       url: `${siteUrl}/profile/${encodedUsername}/achievements`,
+      siteName: "VibeTalent",
       type: "profile",
     },
     twitter: {

--- a/src/app/profile/[username]/achievements/page.tsx
+++ b/src/app/profile/[username]/achievements/page.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata({
     return { title: "Achievements" };
   }
 
-  const title = `@${user.username}'s Achievements — VibeTalent`;
+  const title = `@${user.username}'s Achievements`;
   const description = `Badges earned by @${user.username} on VibeTalent — streaks, projects, endorsements, and more.`;
   const encodedUsername = encodeURIComponent(user.username);
 

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -32,7 +32,7 @@ export async function generateMetadata({
     return { title: "Builder Not Found" };
   }
 
-  const title = `@${user.username} — VibeTalent`;
+  const title = `@${user.username} — Vibe Coder`;
   const description = user.bio
     ? `${user.bio.slice(0, 150)} | ${user.streak}-day streak, ${(user.projects ?? []).length} projects`
     : `${user.streak}-day streak, ${(user.projects ?? []).length} projects on VibeTalent`;
@@ -47,6 +47,7 @@ export async function generateMetadata({
       title,
       description,
       url: `${siteUrl}/profile/${username}`,
+      siteName: "VibeTalent",
       type: "profile",
       images: [
         {

--- a/src/app/profile/[username]/projects/page.tsx
+++ b/src/app/profile/[username]/projects/page.tsx
@@ -30,7 +30,7 @@ export async function generateMetadata({
   }
 
   const projectCount = (user.projects ?? []).length;
-  const title = `@${user.username}'s projects — VibeTalent`;
+  const title = `@${user.username}'s Projects`;
   const description = `All ${projectCount} project${projectCount === 1 ? "" : "s"} shipped by @${user.username} on VibeTalent.`;
 
   return {

--- a/src/app/profile/[username]/projects/page.tsx
+++ b/src/app/profile/[username]/projects/page.tsx
@@ -43,6 +43,7 @@ export async function generateMetadata({
       title,
       description,
       url: `${siteUrl}/profile/${username}/projects`,
+      siteName: "VibeTalent",
       type: "profile",
       images: [
         {

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -5,7 +5,7 @@ import { siteUrl, buildBreadcrumbList } from "@/lib/seo";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "All Projects — Shipped by Vibe Coders | VibeTalent",
+  title: "All Projects — Shipped by Vibe Coders",
   description:
     "Browse all projects shipped by vibe coders. Filter by tech stack, quality score, and more to discover what builders are shipping.",
   alternates: {

--- a/src/app/roadmap/page.tsx
+++ b/src/app/roadmap/page.tsx
@@ -20,7 +20,7 @@ import {
 import { siteUrl } from "@/lib/seo";
 
 export const metadata: Metadata = {
-  title: "Roadmap — VibeTalent 2026 | $VIBE Utility, Multichain USDC, Squad Hiring",
+  title: { absolute: "VibeTalent Roadmap 2026 — $VIBE, Multichain USDC & Squad Hiring" },
   description:
     "The VibeTalent public roadmap for 2026. $VIBE is live on Solana (CA: FfDYT3WqimMw7itMxw4kYJ26GPG78RfpZmepQCFpBAGS). USDC payments already live on Base and Solana. Q2: $VIBE utility (streak protect, project featuring). Q3: stake-to-vouch profiles + Ethereum USDC. Q4: try-before-you-hire, squad hiring, retainers, auto-generated portfolios, shipping radar, and GitHub PR badges.",
   keywords: [

--- a/src/app/share/[username]/custom/page.tsx
+++ b/src/app/share/[username]/custom/page.tsx
@@ -15,10 +15,13 @@ export async function generateMetadata({ params, searchParams }: { params: Promi
   const { range } = await searchParams;
   const r = normalizeRange(range);
   const og = `${siteUrl}/api/og/receipt/custom/${username}?range=${r}`;
+  const cardTitle = `@${username} on VibeTalent`;
+  const description = `@${username}'s builder receipt — vibe score, streak, and shipped projects, verified on VibeTalent.`;
   return {
-    title: `@${username} on VibeTalent`,
-    openGraph: { images: [{ url: og, width: 1200, height: 630 }] },
-    twitter:   { card: "summary_large_image", images: [og] },
+    title: `@${username}`,
+    description,
+    openGraph: { title: cardTitle, description, images: [{ url: og, width: 1200, height: 630 }] },
+    twitter:   { card: "summary_large_image", title: cardTitle, description, images: [og] },
   };
 }
 

--- a/src/app/share/[username]/shipped/[slug]/page.tsx
+++ b/src/app/share/[username]/shipped/[slug]/page.tsx
@@ -6,10 +6,13 @@ import type { Metadata } from "next";
 export async function generateMetadata({ params }: { params: Promise<{ username: string; slug: string }> }): Promise<Metadata> {
   const { username, slug } = await params;
   const og = `${siteUrl}/api/og/receipt/shipped/${username}?slug=${slug}`;
+  const cardTitle = `@${username} shipped ${slug}`;
+  const description = `@${username} shipped ${slug} — built and verified on VibeTalent.`;
   return {
-    title: `@${username} shipped ${slug}`,
-    openGraph: { images: [{ url: og, width: 1200, height: 630 }] },
-    twitter:   { card: "summary_large_image", images: [og] },
+    title: cardTitle,
+    description,
+    openGraph: { title: cardTitle, description, images: [{ url: og, width: 1200, height: 630 }] },
+    twitter:   { card: "summary_large_image", title: cardTitle, description, images: [og] },
   };
 }
 

--- a/src/app/share/[username]/weekly/[week]/page.tsx
+++ b/src/app/share/[username]/weekly/[week]/page.tsx
@@ -6,10 +6,13 @@ import type { Metadata } from "next";
 export async function generateMetadata({ params }: { params: Promise<{ username: string; week: string }> }): Promise<Metadata> {
   const { username, week } = await params;
   const og = `${siteUrl}/api/og/receipt/weekly/${username}?w=${week}`;
+  const cardTitle = `@${username}'s weekly receipt`;
+  const description = `@${username}'s shipping receipt for the week of ${week} — streak, commits, and projects on VibeTalent.`;
   return {
-    title: `@${username}'s weekly receipt`,
-    openGraph: { images: [{ url: og, width: 1200, height: 630 }] },
-    twitter:   { card: "summary_large_image", images: [og] },
+    title: cardTitle,
+    description,
+    openGraph: { title: cardTitle, description, images: [{ url: og, width: 1200, height: 630 }] },
+    twitter:   { card: "summary_large_image", title: cardTitle, description, images: [og] },
   };
 }
 

--- a/src/app/share/achievement/[username]/[id]/page.tsx
+++ b/src/app/share/achievement/[username]/[id]/page.tsx
@@ -16,15 +16,15 @@ export async function generateMetadata({ params }: PageParams): Promise<Metadata
   const { username, id } = await params;
   const user = await fetchUserByUsernameCached(username);
 
-  if (!user) return { title: "Achievement — VibeTalent" };
+  if (!user) return { title: "Achievement" };
 
   const counters = await fetchAchievementCounters(user);
   const achievements = computeAchievements(counters);
   const a = achievements.find((x) => x.id === id);
-  if (!a) return { title: "Achievement — VibeTalent" };
+  if (!a) return { title: "Achievement" };
 
   const verb = a.earned ? "unlocked" : "is progressing toward";
-  const title = `@${user.username} ${verb} "${a.title}" — VibeTalent`;
+  const title = `@${user.username} ${verb} "${a.title}"`;
   const description = `${a.description} See @${user.username}'s achievements on VibeTalent.`;
   const encodedUser = encodeURIComponent(user.username);
   const encodedId = encodeURIComponent(a.id);
@@ -41,6 +41,7 @@ export async function generateMetadata({ params }: PageParams): Promise<Metadata
       title,
       description,
       url: shareUrl,
+      siteName: "VibeTalent",
       type: "article",
       images: [{ url: ogUrl, width: 1200, height: 630, alt: a.title }],
     },

--- a/src/app/share/layout.tsx
+++ b/src/app/share/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+
+// Share routes (/share/...) are social-unfurl targets — they exist to render
+// OG/Twitter cards when a builder shares an achievement, weekly recap, shipped
+// project, or custom card. Their content mirrors the canonical profile/project
+// pages, so letting Google index them creates thin duplicates and dilutes
+// crawl budget. noindex keeps them out of search; `follow` lets link equity
+// flow back to the real profiles. OG/Twitter tags still render for the cards —
+// crawlers read those regardless of the robots directive.
+export const metadata: Metadata = {
+  robots: { index: false, follow: true },
+};
+
+export default function ShareLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 
-// Canonical site URL — always use www; Vercel redirects non-www with 307 which breaks social media crawlers
+// Canonical site URL — always use www. Vercel 308-redirects the bare apex to www (vercel.json),
+// so www is the stable canonical Google indexes and social crawlers unfurl.
 export const siteUrl = "https://www.vibetalent.work";
 const siteName = "VibeTalent";
 


### PR DESCRIPTION
## What & why

The root `title.template` (`%s | VibeTalent`) was doubling the brand on every page that *also* hard-coded it — e.g. all ~165 profile pages rendered `@user — VibeTalent | VibeTalent`. This PR fixes that and tightens index hygiene.

Found via a Google Search Console audit: indexing / sitemap / structured-data are healthy, but the own-name query **"vibe talent"** (two words) sits at **~position 22 with 373 impressions / 90d** while "vibetalent" (one word) ranks ~6.

## Changes
- **Dedupe document titles** — drop the redundant brand from profile (×3 routes), `projects`, `about`, `roadmap`, and share titles; use `title: { absolute }` where the brand sits mid-string.
- **`og:site_name`** added to profile + share cards so social previews keep the brand once it's removed from the title.
- **noindex thin routes** — `/feedback` (churn survey) and `/share/*` (social-unfurl duplicates; `noindex, follow`) via layout `robots`. Keeps the index focused on real pages; OG cards still render for sharing.
- **Share receipt cards** (custom / shipped / weekly) get real titles + descriptions.
- **`alternateName: "Vibe Talent"`** on the homepage Organization + WebSite JSON-LD to claim the two-word brand query.
- Correct the stale 307 → 308 redirect note in `lib/seo.ts`.

## Verification
- `tsc --noEmit` ✅ · `eslint` ✅ (clean against `main`)
- Rendered `<title>` / OG / robots tags verified on a local dev server: profile, projects, about, roadmap, share receipts, feedback.

## Notes
- Cherry-picked off `main`, so SEO can ship independently of the `feat/featured-promotions` work.
- The `/wall` title fix from the same set is **excluded here** — `/wall` doesn't exist on `main` yet (it's introduced by the feature branch), so that fix ships with the feature.
- Separate manual step (not code): remove the stale **non-www** sitemap submission in GSC (`https://vibetalent.work/sitemap.xml`) — redundant with the www sitemap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dedicated layouts for share and feedback pages with custom search engine indexing controls

* **Improvements**
  * Updated page titles and descriptions across profile, projects, and roadmap pages to enhance search engine visibility and social media sharing previews
  * Refined product branding and metadata consistency across pages for better discoverability
  * Enhanced schema markup with alternate product naming for improved search recognition

<!-- end of auto-generated comment: release notes by coderabbit.ai -->