### PR TITLE
fix(agent): VibeFinder Bot suggests real builders, not placeholders

### DIFF
--- a/src/app/agent/chat/page.tsx
+++ b/src/app/agent/chat/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { fetchUsers } from "@/lib/supabase/queries";
 import { matchUsers } from "@/lib/agent-scoring";
+import { getBadgeInfo } from "@/lib/streak";
 import type { UserWithSocials } from "@/lib/types/database";
 import { ChatMessage } from "@/components/agent/chat-message";
 import { ChatInput } from "@/components/agent/chat-input";
@@ -129,10 +130,23 @@ export default function AgentChatPage() {
       case "evaluate":
         addMessage("user", "I want to evaluate a builder");
         simulateThinking(() => {
-          addMessage(
-            "agent",
-            "Sure! You can evaluate any builder on the platform. Head to their profile and click the \"VibeFinder Evaluate\" button, or visit /agent/evaluate/[username].\n\nWho would you like to evaluate? Here are some popular builders:\n\n• @indie_hacker (Diamond, 380-day streak)\n• @web3_builder (Gold, 210-day streak)\n• @vibemaster (Silver, 127-day streak)"
-          );
+          const intro =
+            'Sure! You can evaluate any builder on the platform. Head to their profile and click the "VibeFinder Evaluate" button, or visit /agent/evaluate/[username].';
+          // Suggest REAL top builders from live platform data — never invent users.
+          const topBuilders = [...allUsers]
+            .sort((a, b) => b.vibe_score - a.vibe_score || b.longest_streak - a.longest_streak)
+            .slice(0, 3);
+          if (topBuilders.length === 0) {
+            addMessage("agent", `${intro}\n\nWho would you like to evaluate? Just send me their @username.`);
+          } else {
+            const list = topBuilders
+              .map((u) => {
+                const tier = u.badge_level !== "none" ? `${getBadgeInfo(u.badge_level).label}, ` : "";
+                return `• @${u.username} (${tier}${u.longest_streak}-day streak)`;
+              })
+              .join("\n");
+            addMessage("agent", `${intro}\n\nWho would you like to evaluate? Here are some of the top builders right now:\n\n${list}`);
+          }
           setStage("results");
         });
         break;
@@ -144,7 +158,7 @@ export default function AgentChatPage() {
         });
         break;
     }
-  }, [addMessage, simulateThinking]);
+  }, [allUsers, addMessage, simulateThinking]);
 
   const showQuickActions = messages.length === 1 && stage === "greeting";
 


### PR DESCRIPTION
## What
VibeFinder Bot's "Evaluate a builder" quick action suggested three hardcoded placeholder users — `@indie_hacker`, `@web3_builder`, `@vibemaster` — none of whom exist. Clicking through landed on "Builder Not Found".

## Why it matters
VibeFinder Bot is linked from the main nav ("AI Agents") and pitches itself as *"I read platform data."* Suggesting invented builders directly undercuts that — the kind of thing a demo viewer notices instantly.

## Fix
Replace the static list with the real top 3 builders from the `allUsers` state the page already loads (live Supabase data), sorted by `vibe_score`, formatted with each builder's real badge tier + longest streak. Graceful fallback if users haven't loaded yet.

## Verification
- Typecheck clean
- Driven live in-browser: the bot now renders real builders (@allensaji, @karan, @aaron) matching the leaderboard; DOM check confirms zero placeholder users remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The chat's "evaluate" quick action now dynamically generates suggestions based on current live data instead of static examples, ensuring recommendations remain synchronized with the latest information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->