### PR TITLE
perf(achievements): cache share-card OG image + prefetch on menu open

### DIFF
--- a/src/app/api/og/achievement/[username]/[id]/route.tsx
+++ b/src/app/api/og/achievement/[username]/[id]/route.tsx
@@ -31,6 +31,15 @@ export async function GET(
   const palette = PALETTES[art.palette];
   const statusLabel = achievement.earned ? "UNLOCKED" : "IN PROGRESS";
 
+  // Earned cards are effectively immutable — title, badge and "earned" copy
+  // never change again — so cache them hard at the CDN. In-progress cards render
+  // live counts that move as the user progresses, and the same URL must flip to
+  // the earned design the moment they unlock it, so keep their TTL short (~1 min)
+  // to bound how long a stale "IN PROGRESS" PNG can linger after they earn it.
+  const cacheControl = achievement.earned
+    ? "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400"
+    : "public, max-age=60, s-maxage=60, stale-while-revalidate=120";
+
   return new ImageResponse(
     (
       <div
@@ -221,15 +230,7 @@ export async function GET(
     ),
     {
       ...size,
-      // Cache the rendered PNG at the CDN so Copy/Download and social-preview
-      // hits after the first are served instantly instead of re-rendering
-      // (4 DB queries + Satori + avatar fetch). The card only changes when the
-      // user's stats cross a threshold, so an hour of CDN freshness — served
-      // stale for a day while it revalidates — is plenty.
-      headers: {
-        "Cache-Control":
-          "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
-      },
+      headers: { "Cache-Control": cacheControl },
     },
   );
 }

--- a/src/app/api/og/achievement/[username]/[id]/route.tsx
+++ b/src/app/api/og/achievement/[username]/[id]/route.tsx
@@ -219,7 +219,18 @@ export async function GET(
         </div>
       </div>
     ),
-    { ...size },
+    {
+      ...size,
+      // Cache the rendered PNG at the CDN so Copy/Download and social-preview
+      // hits after the first are served instantly instead of re-rendering
+      // (4 DB queries + Satori + avatar fetch). The card only changes when the
+      // user's stats cross a threshold, so an hour of CDN freshness — served
+      // stale for a day while it revalidates — is plenty.
+      headers: {
+        "Cache-Control":
+          "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
+      },
+    },
   );
 }
 

--- a/src/components/achievements/achievement-share-menu.tsx
+++ b/src/components/achievements/achievement-share-menu.tsx
@@ -31,10 +31,13 @@ export function AchievementShareMenu({ username, achievementId, title }: Achieve
   const [open, setOpen] = useState(false);
   const [status, setStatus] = useState<Status>("idle");
   const containerRef = useRef<HTMLDivElement | null>(null);
-  // Memoized, de-duped fetch of the generated share image. Warmed when the
-  // menu opens so Copy/Download resolve instantly instead of kicking off a
-  // multi-second OG render on click.
-  const imageBlobRef = useRef<Promise<Blob> | null>(null);
+  // Memoized, de-duped fetch of the generated share image, keyed by image URL.
+  // Warmed when the menu opens so Copy/Download resolve instantly instead of
+  // kicking off a multi-second OG render on click. Keying by path invalidates
+  // the cache when username/achievementId change — the same card instance is
+  // reused across client-side profile navigations (cards are keyed by
+  // achievement id), so without this Copy could serve the previous user's image.
+  const imageBlobRef = useRef<{ path: string; blob: Promise<Blob> } | null>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -55,22 +58,28 @@ export function AchievementShareMenu({ username, achievementId, title }: Achieve
   const sharePath = `/share/achievement/${encodeURIComponent(username)}/${encodeURIComponent(achievementId)}`;
   const imagePath = `/api/og/achievement/${encodeURIComponent(username)}/${encodeURIComponent(achievementId)}`;
 
-  // Fetch the share image once and reuse the in-flight/resolved promise for
-  // both Copy and Download. On failure we drop the cached rejection so a
+  // Fetch the share image once per URL and reuse the in-flight/resolved promise
+  // for both Copy and Download. On failure we drop the cached rejection so a
   // later click can retry cleanly.
   const fetchImageBlob = useCallback((): Promise<Blob> => {
-    if (!imageBlobRef.current) {
-      imageBlobRef.current = fetch(imagePath)
+    const cached = imageBlobRef.current;
+    if (cached && cached.path === imagePath) return cached.blob;
+    const entry = {
+      path: imagePath,
+      blob: fetch(imagePath)
         .then((r) => {
           if (!r.ok) throw new Error(`HTTP ${r.status}`);
           return r.blob();
         })
         .catch((err) => {
-          imageBlobRef.current = null;
+          // Only drop the cache if this entry is still current, so a newer
+          // fetch for a different URL isn't clobbered by a stale rejection.
+          if (imageBlobRef.current === entry) imageBlobRef.current = null;
           throw err;
-        });
-    }
-    return imageBlobRef.current;
+        }),
+    };
+    imageBlobRef.current = entry;
+    return entry.blob;
   }, [imagePath]);
 
   // Warm the image as soon as the menu opens so the OG render overlaps the

--- a/src/components/achievements/achievement-share-menu.tsx
+++ b/src/components/achievements/achievement-share-menu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Share2,
   Link as LinkIcon,
@@ -31,6 +31,10 @@ export function AchievementShareMenu({ username, achievementId, title }: Achieve
   const [open, setOpen] = useState(false);
   const [status, setStatus] = useState<Status>("idle");
   const containerRef = useRef<HTMLDivElement | null>(null);
+  // Memoized, de-duped fetch of the generated share image. Warmed when the
+  // menu opens so Copy/Download resolve instantly instead of kicking off a
+  // multi-second OG render on click.
+  const imageBlobRef = useRef<Promise<Blob> | null>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -51,18 +55,39 @@ export function AchievementShareMenu({ username, achievementId, title }: Achieve
   const sharePath = `/share/achievement/${encodeURIComponent(username)}/${encodeURIComponent(achievementId)}`;
   const imagePath = `/api/og/achievement/${encodeURIComponent(username)}/${encodeURIComponent(achievementId)}`;
 
+  // Fetch the share image once and reuse the in-flight/resolved promise for
+  // both Copy and Download. On failure we drop the cached rejection so a
+  // later click can retry cleanly.
+  const fetchImageBlob = useCallback((): Promise<Blob> => {
+    if (!imageBlobRef.current) {
+      imageBlobRef.current = fetch(imagePath)
+        .then((r) => {
+          if (!r.ok) throw new Error(`HTTP ${r.status}`);
+          return r.blob();
+        })
+        .catch((err) => {
+          imageBlobRef.current = null;
+          throw err;
+        });
+    }
+    return imageBlobRef.current;
+  }, [imagePath]);
+
+  // Warm the image as soon as the menu opens so the OG render overlaps the
+  // user reading the menu rather than blocking their click on Copy/Download.
+  useEffect(() => {
+    if (!open) return;
+    void fetchImageBlob().catch(() => {});
+  }, [open, fetchImageBlob]);
+
   async function copyImage() {
     setStatus("copying-image");
     try {
-      // Safari requires the ClipboardItem to be created synchronously
-      // in the user-gesture handler — pass the Promise directly.
-      const blobPromise = fetch(imagePath).then((r) => {
-        if (!r.ok) throw new Error(`HTTP ${r.status}`);
-        return r.blob();
-      });
-      // ClipboardItem with a Promise is supported by Chrome/Edge/Safari.
-      // Firefox lacks image clipboard support and will throw — we surface
-      // that as an error and let the user fall back to Download.
+      // Reuse the prewarmed fetch. ClipboardItem must be created synchronously
+      // in the gesture for Safari — passing the Promise (even one already in
+      // flight) satisfies that. Firefox lacks image clipboard support and will
+      // throw; we surface that and let the user fall back to Download.
+      const blobPromise = fetchImageBlob();
       await navigator.clipboard.write([
         new ClipboardItem({ "image/png": blobPromise }),
       ]);
@@ -77,9 +102,7 @@ export function AchievementShareMenu({ username, achievementId, title }: Achieve
   async function downloadImage() {
     setStatus("downloading");
     try {
-      const res = await fetch(imagePath);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const blob = await res.blob();
+      const blob = await fetchImageBlob();
       const blobUrl = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = blobUrl;


### PR DESCRIPTION
## What & why

Copying an achievement share card ("Copy image") took ~10s. Every click regenerated the 1200×630 OG PNG server-side from scratch — 4 uncached Supabase queries + a Satori render + a synchronous avatar fetch — and the OG route set **no `Cache-Control` header**, so the CDN could never cache it. Every click re-paid the full cost.

## Changes

- **`/api/og/achievement/[username]/[id]` — CDN-cache the PNG.** Adds `Cache-Control: public, max-age=300, s-maxage=3600, stale-while-revalidate=86400`. The card only changes when a user's stats cross a threshold, so it renders once then serves from Vercel's edge. Also speeds up Discord/Twitter link-preview crawls.
- **Share menu — prefetch + de-dupe.** The image now fetches the moment the menu *opens* (overlapping the second or two the user spends reading it), and Copy/Download share one memoized blob instead of each firing its own request. `ClipboardItem` is still created synchronously in the click gesture, so Safari image-copy keeps working.

## Verification

- OG route returns HTTP 200, a valid 1200×630 PNG, with the `Cache-Control` header emitted intact (curl against dev).
- Opening a share menu fires exactly one `GET /api/og/achievement/...` from the *open* (baseline 0); clicking **Copy image** afterwards fires **no** second request (blob reused).
- `tsc --noEmit` and `eslint` clean on both files.

Note: the cold first render of a never-seen card is still a few seconds (real Satori work), but the user no longer waits on it (prefetch), and every subsequent hit — repeat copies, other viewers, crawlers — is now an instant CDN hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OG achievement cards now include optimized caching headers for enhanced browser and CDN performance, significantly reducing re-rendering frequency when the same card is requested multiple times

* **Refactor**
  * Achievement share menu now intelligently caches and reuses image fetches for both copy and download operations, eliminating redundant network requests and providing improved responsiveness when sharing achievements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->