### PR TITLE
perf(share): make share-image copy near-instant (prewarm + CDN cache)

### DIFF
--- a/src/app/api/og/receipt/[type]/[username]/route.tsx
+++ b/src/app/api/og/receipt/[type]/[username]/route.tsx
@@ -83,7 +83,15 @@ export async function GET(
         </div>
       </div>
     ),
-    { ...size },
+    {
+      ...size,
+      headers: {
+        // Cache at the CDN so repeat shares (and the prewarmed copy fetch) are
+        // instant instead of re-rendering via Satori each time.
+        "Cache-Control":
+          "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
+      },
+    },
   );
 }
 

--- a/src/app/api/share-card/[username]/route.tsx
+++ b/src/app/api/share-card/[username]/route.tsx
@@ -411,7 +411,16 @@ export async function GET(
         </div>
       </div>
     ),
-    { width: 1200, height: 630 }
+    {
+      width: 1200,
+      height: 630,
+      headers: {
+        // Cache at the CDN so the modal's copy/download (and repeat shares) are
+        // instant instead of re-rendering via Satori each time.
+        "Cache-Control":
+          "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
+      },
+    }
   );
 }
 

--- a/src/components/achievements/achievement-share-menu.tsx
+++ b/src/components/achievements/achievement-share-menu.tsx
@@ -154,6 +154,8 @@ export function AchievementShareMenu({ username, achievementId, title }: Achieve
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
+        onMouseEnter={() => void fetchImageBlob().catch(() => {})}
+        onFocus={() => void fetchImageBlob().catch(() => {})}
         aria-label={`Share ${title} achievement`}
         aria-expanded={open}
         className="inline-flex items-center gap-1.5 px-2.5 py-1 text-[10px] font-extrabold uppercase tracking-wide"

--- a/src/components/profile/share-card-modal.tsx
+++ b/src/components/profile/share-card-modal.tsx
@@ -63,10 +63,15 @@ export function ShareCardModal({ username, isOpen, onClose }: ShareCardModalProp
 
   const handleCopy = async () => {
     try {
-      const res = await fetch(cardUrl);
-      const blob = await res.blob();
+      // Build the ClipboardItem synchronously with the fetch promise so Safari
+      // keeps it tied to the click gesture. The preview <img> already warmed the
+      // (now cacheable) image, so this resolves from cache near-instantly.
+      const blobPromise = fetch(cardUrl).then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.blob();
+      });
       await navigator.clipboard.write([
-        new ClipboardItem({ "image/png": blob }),
+        new ClipboardItem({ "image/png": blobPromise }),
       ]);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);

--- a/src/components/share/share-button.tsx
+++ b/src/components/share/share-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 interface ShareButtonProps {
   url: string;
@@ -16,6 +16,26 @@ export function ShareButton({ url, text, imageUrl }: ShareButtonProps) {
   const absUrl = typeof window !== "undefined" ? new URL(url, window.location.origin).toString() : url;
   const absImageUrl = imageUrl && typeof window !== "undefined" ? new URL(imageUrl, window.location.origin).toString() : imageUrl;
 
+  // Hold the (in-flight) image blob so a hover/focus can start generating it
+  // before the click — the copy then resolves an already-warm promise instead
+  // of waiting on a cold Satori render. Null until warmed.
+  const blobRef = useRef<Promise<Blob> | null>(null);
+  function fetchBlob(u: string): Promise<Blob> {
+    return fetch(u).then((r) => {
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      return r.blob();
+    });
+  }
+  function prewarm() {
+    if (!absImageUrl || blobRef.current) return;
+    const p = fetchBlob(absImageUrl);
+    blobRef.current = p;
+    // Drop a failed warm so the click can retry from scratch.
+    void p.catch(() => {
+      if (blobRef.current === p) blobRef.current = null;
+    });
+  }
+
   async function copyLink() {
     try {
       await navigator.clipboard.writeText(absUrl);
@@ -30,17 +50,19 @@ export function ShareButton({ url, text, imageUrl }: ShareButtonProps) {
   async function copyImage() {
     if (!absImageUrl) return;
     setStatus("copying");
+    // Reuse the prewarmed blob if present; otherwise start now. The
+    // ClipboardItem is built synchronously with the promise so Safari keeps it
+    // tied to the click gesture. next/og emits image/png.
+    const blobPromise = blobRef.current ?? (blobRef.current = fetchBlob(absImageUrl));
     try {
-      const res = await fetch(absImageUrl);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const blob = await res.blob();
-      // Clipboard API in some browsers requires a PNG specifically.
-      // ImageResponse from next/og emits image/png.
-      await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })]);
+      await navigator.clipboard.write([
+        new ClipboardItem({ "image/png": blobPromise }),
+      ]);
       setStatus("copied-image");
       setTimeout(() => setStatus("idle"), 1500);
     } catch (e) {
       console.error("copy image failed:", e);
+      blobRef.current = null; // allow a fresh retry
       setStatus("image-error");
       setTimeout(() => setStatus("idle"), 2000);
     }
@@ -60,6 +82,9 @@ export function ShareButton({ url, text, imageUrl }: ShareButtonProps) {
       {absImageUrl && (
         <button
           onClick={copyImage}
+          onMouseEnter={prewarm}
+          onFocus={prewarm}
+          onPointerDown={prewarm}
           disabled={status === "copying"}
           className="bg-[var(--accent)] text-white px-4 py-2 text-[13px] font-extrabold rounded-sm hover:opacity-90 disabled:opacity-60"
           aria-label="Copy receipt image to clipboard"


### PR DESCRIPTION
## Problem
"Copy image" (and download) waited on a **cold `next/og` Satori render every click** — ~1–2s. The receipt and share-card image routes had no caching, and the copy buttons only fetched the image at click time.

## Fix
- **CDN caching** on `/api/og/receipt/[type]/[username]` and `/api/share-card/[username]` (the achievement OG route already had it). Cold render → **~1ms** on the cached repeat.
- **Prewarm** the image blob on hover/focus of the profile receipt **Copy image** button, and on hover/open of the achievement **Share** menu — the render overlaps the user's intent, so the click resolves an already-warm promise.
- The **Share Card modal**'s preview `<img>` warms the (now cacheable) image, so its **Copy to Clipboard** resolves from cache.
- All `ClipboardItem`s are now built **synchronously from the fetch promise** so the copy stays tied to the click gesture (fixes Safari, which rejects copies after an `await`).

## Covers all three share-image copies
- Profile receipt (`ShareButton`) · Achievement badge (`AchievementShareMenu`) · Share Card modal (`ShareCardModal`).

## Verified (dev server)
- Receipt image: **2277ms cold → 1ms cached**; share-card: **1047ms → 1ms**; both now return `Cache-Control`.
- Hovering the receipt "Copy image" warms it — post-hover fetch **~4ms** (so the actual click copies instantly).
- `tsc` + `eslint` clean.

Separate from the achievements redesign (PR #213) — this is a cross-cutting share-image perf fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Share buttons now prewarm images when hovered or focused to eliminate initial render delays and provide a faster, smoother sharing experience

* **Performance**
  * Receipt and share card images now include caching support to enable faster repeated access and better performance
  * Clipboard image copy mechanism improved for better reliability and consistent performance when sharing images

<!-- end of auto-generated comment: release notes by coderabbit.ai -->