### PR TITLE
fix(projects): cap tech/tag chips on project cards with +N overflow

### DIFF
--- a/src/components/ui/project-card.tsx
+++ b/src/components/ui/project-card.tsx
@@ -281,9 +281,9 @@ export function ProjectCard({ project, authorUsername, onEdit, showReport = true
         const overflow = tech.length - shown.length;
         return (
           <div className="mt-2 flex flex-wrap gap-1">
-            {shown.map((t) => (
+            {shown.map((t, i) => (
               <span
-                key={t}
+                key={`${t}-${i}`}
                 className="px-1.5 py-0.5 text-[10px] font-bold uppercase text-[var(--text-tertiary)]"
                 style={PILL_STYLE}
               >
@@ -296,7 +296,8 @@ export function ProjectCard({ project, authorUsername, onEdit, showReport = true
                 style={PILL_STYLE}
                 title={tech.slice(MAX_TECH).join(", ")}
               >
-                +{overflow}
+                <span aria-hidden="true">+{overflow}</span>
+                <span className="sr-only">{overflow} more technologies: {tech.slice(MAX_TECH).join(", ")}</span>
               </span>
             )}
           </div>
@@ -327,7 +328,12 @@ export function ProjectCard({ project, authorUsername, onEdit, showReport = true
             <span className="flex items-center gap-1 min-w-0" title={tags.join(", ")}>
               <Tag size={10} className="shrink-0" />
               <span className="truncate">{shown.join(", ")}</span>
-              {overflow > 0 && <span className="shrink-0">+{overflow}</span>}
+              {overflow > 0 && (
+                <span className="shrink-0">
+                  <span aria-hidden="true">+{overflow}</span>
+                  <span className="sr-only">{overflow} more tags: {tags.slice(MAX_TAGS).join(", ")}</span>
+                </span>
+              )}
             </span>
           );
         })()}

--- a/src/components/ui/project-card.tsx
+++ b/src/components/ui/project-card.tsx
@@ -50,6 +50,17 @@ function clearReportData(projectId: string) {
   localStorage.removeItem(`report_${projectId}`);
 }
 
+// Keep cards uniform: cap how many tech/tag chips render before collapsing
+// the rest into a "+N" overflow chip. Unbounded lists made card heights wildly
+// uneven on the homepage grid.
+const MAX_TECH = 6;
+const MAX_TAGS = 3;
+
+const PILL_STYLE = {
+  backgroundColor: "var(--bg-surface-light)",
+  border: "1px solid var(--border-hard)",
+} as const;
+
 interface ProjectCardProps {
   project: Project;
   authorUsername?: string;
@@ -263,22 +274,34 @@ export function ProjectCard({ project, authorUsername, onEdit, showReport = true
         </Link>
       )}
 
-      {(project.tech_stack ?? []).length > 0 && (
-      <div className="mt-2 flex flex-wrap gap-1">
-        {(project.tech_stack ?? []).map((tech) => (
-          <span
-            key={tech}
-            className="px-1.5 py-0.5 text-[10px] font-bold uppercase text-[var(--text-tertiary)]"
-            style={{
-              backgroundColor: "var(--bg-surface-light)",
-              border: "1px solid var(--border-hard)",
-            }}
-          >
-            {tech}
-          </span>
-        ))}
-      </div>
-      )}
+      {(() => {
+        const tech = project.tech_stack ?? [];
+        if (tech.length === 0) return null;
+        const shown = tech.slice(0, MAX_TECH);
+        const overflow = tech.length - shown.length;
+        return (
+          <div className="mt-2 flex flex-wrap gap-1">
+            {shown.map((t) => (
+              <span
+                key={t}
+                className="px-1.5 py-0.5 text-[10px] font-bold uppercase text-[var(--text-tertiary)]"
+                style={PILL_STYLE}
+              >
+                {t}
+              </span>
+            ))}
+            {overflow > 0 && (
+              <span
+                className="px-1.5 py-0.5 text-[10px] font-bold uppercase text-[var(--text-muted)]"
+                style={PILL_STYLE}
+                title={tech.slice(MAX_TECH).join(", ")}
+              >
+                +{overflow}
+              </span>
+            )}
+          </div>
+        );
+      })()}
 
       <GithubSignal
         commits7d={null}
@@ -295,12 +318,19 @@ export function ProjectCard({ project, authorUsername, onEdit, showReport = true
             {project.build_time}
           </span>
         )}
-        {(project.tags ?? []).length > 0 && (
-          <span className="flex items-center gap-1">
-            <Tag size={10} />
-            {project.tags.join(", ")}
-          </span>
-        )}
+        {(() => {
+          const tags = project.tags ?? [];
+          if (tags.length === 0) return null;
+          const shown = tags.slice(0, MAX_TAGS);
+          const overflow = tags.length - shown.length;
+          return (
+            <span className="flex items-center gap-1 min-w-0" title={tags.join(", ")}>
+              <Tag size={10} className="shrink-0" />
+              <span className="truncate">{shown.join(", ")}</span>
+              {overflow > 0 && <span className="shrink-0">+{overflow}</span>}
+            </span>
+          );
+        })()}
       </div>
 
       {reportError && (


### PR DESCRIPTION
## What

Project cards rendered **unbounded** tech-stack and tag lists, making card heights wildly uneven on the homepage grid. One card showed ~16 tech pills (7 rows) plus an 18-item comma-joined tag wall; another card in the same row had a fraction of that — so the row stretched to the tallest and the rest looked messy.

## Change

In `src/components/ui/project-card.tsx` (used on the homepage, `/projects`, profiles, and dashboard):

- **Tech-stack pills** → first **6**, remainder collapses into a `+N` chip
- **Bottom category tags** → first **3**, kept to a single line with `truncate`, remainder collapses into `+N`
- Overflow chips carry a `title` tooltip so hidden items are still discoverable on hover

Display-only — no data is dropped. Limits are two constants (`MAX_TECH`, `MAX_TAGS`) at the top of the file for easy tuning. Description/title were already `line-clamp-2`.

## Verification

- `npx tsc --noEmit` — clean (only pre-existing unrelated errors in `src/app/dev/promote-preview/`)
- Verified locally in the dev server at 1280px (3-col): all three cards in the row are now uniform height; no new console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project cards now show a limited number of tech chips and tags with clear overflow indicators when there are more items.
  * Added a hover tooltip for hidden technology items so additional details remain accessible.

* **UI Improvements**
  * Updated chip styling for a more consistent project card appearance.
  * Tag display is now more compact and easier to scan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->