### PR TITLE
feat(notifications): brutalist avatar-led redesign + faster load

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,6 +15,7 @@
 
   --bg-surface: #FFFFFF;
   --bg-surface-light: #F5F5F5;
+  --bg-unread: #FFF8F6;
   --bg-pill: #0F0F0F;
   --bg-pill-hover: #2a2a2a;
   --border-hard: #0F0F0F;
@@ -70,6 +71,7 @@
 
   --bg-surface: hsl(14, 4%, 10%);
   --bg-surface-light: hsl(14, 4%, 15%);
+  --bg-unread: hsl(14, 5%, 12%);
   --bg-pill: hsl(14, 4%, 15%);
   --bg-pill-hover: hsl(14, 4%, 23%);
   --border-hard: hsl(14, 10%, 45%);
@@ -145,6 +147,32 @@ body {
 
 html {
   scroll-behavior: smooth;
+}
+
+/* Notification card hover-lift (brutalist offset stays fixed → card lifts off its shadow) */
+.ntf-card {
+  transition: transform 0.14s ease, box-shadow 0.14s ease;
+}
+.ntf-card:hover {
+  transform: translate(-2px, -2px);
+}
+/* Title link stretches over the whole card so the card is clickable, with no
+   visible "open" button. Interactive children (Mark read) sit above it via
+   position:relative;z-index:1. */
+.ntf-stretched-link::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+}
+/* Notification-bell dropdown rows (compact variant of the page cards). */
+.ntf-row {
+  transition: background-color 0.12s ease;
+}
+.ntf-row:hover {
+  background: var(--bg-surface-light);
+}
+.ntf-row-unread {
+  background: var(--bg-unread);
 }
 
 /* Brutalist button base */

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -1,58 +1,50 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
-import Link from "next/link";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { Bell, ArrowLeft, ExternalLink, Check } from "lucide-react";
-import { createClient } from "@/lib/supabase/client";
 import type { Notification } from "@/lib/types/database";
-import { NOTIFICATION_ICONS, NOTIFICATION_COLORS, notificationTimeAgo, extractNotificationLink } from "@/lib/notification-display";
+import { NotificationsView } from "@/components/notifications/notifications-view";
 
 export default function NotificationsPage() {
   const router = useRouter();
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [loading, setLoading] = useState(true);
-  const [authChecking, setAuthChecking] = useState(true);
   const [marking, setMarking] = useState(false);
 
-  const fetchNotifications = useCallback(async () => {
-    try {
-      const res = await fetch("/api/notifications");
-      if (!res.ok) return;
-      const data = await res.json();
-      setNotifications(data.data || []);
-    } catch {
-      // Silently fail
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
   useEffect(() => {
-    const supabase = createClient();
-    supabase.auth
-      .getUser()
-      .then(({ data: { user } }) => {
-        if (!user) {
-          // The login page reads `?redirect=` (not `?next=`) to decide where
-          // to send the user after a successful sign-in.
-          router.push("/auth/login?redirect=/notifications");
+    // Fetch immediately on mount. We skip a separate client-side
+    // supabase.auth.getUser() round-trip (it only gated the redirect and is
+    // redundant — the API enforces auth itself) and act on the API's 401.
+    // This removes a full Supabase Auth round-trip from the critical path.
+    let cancelled = false;
+    fetch("/api/notifications")
+      .then(async (res) => {
+        if (cancelled) return;
+        if (res.status === 401) {
+          // The login page reads `?redirect=` (not `?next=`) to decide where to
+          // send the user back after sign-in. `replace` so the bounced-through
+          // page doesn't linger in history. Leave loading=true so the redirect
+          // doesn't flash the empty state.
+          router.replace("/auth/login?redirect=/notifications");
           return;
         }
-        setAuthChecking(false);
-        fetchNotifications();
+        if (res.ok) {
+          const data = await res.json();
+          if (!cancelled) setNotifications(data.data || []);
+        }
+        if (!cancelled) setLoading(false);
       })
       .catch(() => {
-        // Treat a getUser rejection (network drop, transient Supabase error)
-        // as unauthenticated rather than letting authChecking stall forever.
-        router.push("/auth/login?redirect=/notifications");
+        // Network drop / transient error — render the empty state.
+        if (!cancelled) setLoading(false);
       });
-  }, [fetchNotifications, router]);
-
-  const unreadCount = notifications.filter(n => !n.read).length;
+    return () => {
+      cancelled = true;
+    };
+  }, [router]);
 
   const handleMarkAllRead = async () => {
-    if (unreadCount === 0) return;
+    if (notifications.every((n) => n.read)) return;
     setMarking(true);
     try {
       const res = await fetch("/api/notifications", {
@@ -61,7 +53,7 @@ export default function NotificationsPage() {
         body: JSON.stringify({ mark_all: true }),
       });
       if (res.ok) {
-        setNotifications(prev => prev.map(n => ({ ...n, read: true })));
+        setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
         window.dispatchEvent(new Event("notifications-updated"));
       }
     } catch {
@@ -76,10 +68,11 @@ export default function NotificationsPage() {
     // the DB still treated it as unread. Reverting just this row (not the
     // whole list) avoids clobbering concurrent updates from other handlers
     // that may have fired between the optimistic write and the failure.
-    const previousRead = notifications.find(n => n.id === id)?.read ?? false;
-    setNotifications(prev => prev.map(n => (n.id === id ? { ...n, read: true } : n)));
+    const previousRead = notifications.find((n) => n.id === id)?.read ?? false;
+    if (previousRead) return; // already read — nothing to do
+    setNotifications((prev) => prev.map((n) => (n.id === id ? { ...n, read: true } : n)));
     const revert = () =>
-      setNotifications(prev => prev.map(n => (n.id === id ? { ...n, read: previousRead } : n)));
+      setNotifications((prev) => prev.map((n) => (n.id === id ? { ...n, read: previousRead } : n)));
     try {
       const res = await fetch("/api/notifications", {
         method: "PATCH",
@@ -96,161 +89,13 @@ export default function NotificationsPage() {
     }
   };
 
-  if (authChecking) {
-    return (
-      <div className="min-h-screen flex items-center justify-center" style={{ background: "var(--bg-base)" }}>
-        <p className="text-sm font-medium text-[var(--text-muted-soft)]">Loading…</p>
-      </div>
-    );
-  }
-
   return (
-    <div className="min-h-screen" style={{ background: "var(--bg-base)" }}>
-      <div className="max-w-3xl mx-auto px-4 sm:px-6 py-8 sm:py-12">
-        <Link
-          href="/dashboard"
-          className="inline-flex items-center gap-1.5 text-xs font-bold uppercase tracking-wide text-[var(--text-muted)] hover:text-[var(--foreground)] mb-6"
-        >
-          <ArrowLeft size={14} />
-          Back to dashboard
-        </Link>
-
-        <div
-          className="flex items-center justify-between gap-4 px-5 py-4 mb-6"
-          style={{
-            backgroundColor: "var(--bg-surface)",
-            border: "2px solid var(--border-hard)",
-            boxShadow: "var(--shadow-brutal-sm)",
-          }}
-        >
-          <div className="min-w-0">
-            <h1 className="text-xl sm:text-2xl font-extrabold uppercase tracking-tight text-[var(--foreground)]">
-              Notifications
-            </h1>
-            <p className="text-xs sm:text-sm font-medium text-[var(--text-muted)] mt-0.5">
-              {unreadCount > 0
-                ? `${unreadCount} unread`
-                : notifications.length > 0
-                  ? "All caught up"
-                  : "Nothing here yet"}
-            </p>
-          </div>
-          {unreadCount > 0 && (
-            <button
-              onClick={handleMarkAllRead}
-              disabled={marking}
-              className="shrink-0 px-3 py-2 text-xs font-extrabold uppercase tracking-wide text-white cursor-pointer disabled:opacity-50"
-              style={{
-                backgroundColor: "var(--accent)",
-                border: "2px solid var(--border-hard)",
-                boxShadow: "var(--shadow-brutal-xs)",
-              }}
-            >
-              Mark all read
-            </button>
-          )}
-        </div>
-
-        {loading ? (
-          <div
-            className="px-5 py-10 text-center"
-            style={{
-              backgroundColor: "var(--bg-surface)",
-              border: "2px solid var(--border-hard)",
-              boxShadow: "var(--shadow-brutal-sm)",
-            }}
-          >
-            <p className="text-sm font-medium text-[var(--text-muted-soft)]">Loading notifications…</p>
-          </div>
-        ) : notifications.length === 0 ? (
-          <div
-            className="px-5 py-12 text-center"
-            style={{
-              backgroundColor: "var(--bg-surface)",
-              border: "2px solid var(--border-hard)",
-              boxShadow: "var(--shadow-brutal-sm)",
-            }}
-          >
-            <Bell size={32} className="mx-auto mb-3 text-[var(--text-muted-soft)]" />
-            <p className="text-base font-bold text-[var(--foreground)] mb-1">No notifications yet</p>
-            <p className="text-sm text-[var(--text-muted)]">
-              You&apos;ll see streak reminders, hire requests, and milestones here.
-            </p>
-          </div>
-        ) : (
-          <div className="flex flex-col gap-3">
-            {notifications.map((n) => {
-              const Icon = NOTIFICATION_ICONS[n.type] || Bell;
-              const color = NOTIFICATION_COLORS[n.type] || "var(--text-muted)";
-              const link = extractNotificationLink(n.metadata as Record<string, unknown> | null);
-              return (
-                <article
-                  key={n.id}
-                  className="px-5 py-4 flex gap-3 sm:gap-4 items-start"
-                  style={{
-                    backgroundColor: n.read ? "var(--bg-surface)" : "var(--bg-surface-light, var(--bg-surface))",
-                    border: "2px solid var(--border-hard)",
-                    boxShadow: "var(--shadow-brutal-sm)",
-                    borderLeftWidth: 6,
-                    borderLeftColor: color,
-                  }}
-                >
-                  <div
-                    className="shrink-0 w-9 h-9 flex items-center justify-center"
-                    style={{ backgroundColor: `${color}1A`, color }}
-                  >
-                    <Icon size={18} />
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-start gap-2 flex-wrap">
-                      <h2 className={`text-sm sm:text-base leading-snug ${n.read ? "font-bold text-[var(--text-secondary)]" : "font-extrabold text-[var(--foreground)]"}`}>
-                        {n.title}
-                      </h2>
-                      {!n.read && (
-                        <span
-                          className="mt-1 inline-block w-2 h-2 rounded-full shrink-0"
-                          style={{ backgroundColor: "var(--accent)" }}
-                          aria-label="Unread"
-                        />
-                      )}
-                    </div>
-                    <p
-                      className="text-sm mt-1.5 whitespace-pre-wrap break-words"
-                      style={{ color: n.read ? "var(--text-muted)" : "var(--text-secondary)" }}
-                    >
-                      {n.message}
-                    </p>
-                    <div className="flex items-center gap-3 mt-3 flex-wrap">
-                      <span className="text-[11px] font-bold uppercase tracking-wide text-[var(--text-muted-soft)]">
-                        {notificationTimeAgo(n.created_at)}
-                      </span>
-                      {link && (
-                        <Link
-                          href={link}
-                          onClick={() => !n.read && handleMarkRead(n.id)}
-                          className="inline-flex items-center gap-1 text-xs font-extrabold uppercase tracking-wide text-[var(--accent)] hover:underline"
-                        >
-                          Open
-                          <ExternalLink size={12} />
-                        </Link>
-                      )}
-                      {!n.read && (
-                        <button
-                          onClick={() => handleMarkRead(n.id)}
-                          className="inline-flex items-center gap-1 text-xs font-bold uppercase tracking-wide text-[var(--text-muted)] hover:text-[var(--foreground)] cursor-pointer"
-                        >
-                          <Check size={12} />
-                          Mark read
-                        </button>
-                      )}
-                    </div>
-                  </div>
-                </article>
-              );
-            })}
-          </div>
-        )}
-      </div>
-    </div>
+    <NotificationsView
+      notifications={notifications}
+      loading={loading}
+      marking={marking}
+      onMarkRead={handleMarkRead}
+      onMarkAllRead={handleMarkAllRead}
+    />
   );
 }

--- a/src/components/notifications/notifications-view.tsx
+++ b/src/components/notifications/notifications-view.tsx
@@ -1,0 +1,514 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Bell, ArrowLeft, Check } from "lucide-react";
+import type { Notification } from "@/lib/types/database";
+import {
+  NOTIFICATION_ICONS,
+  NOTIFICATION_TAGS,
+  HIRE_NOTIFICATION_TYPES,
+  notificationTimeAgo,
+  notificationBucket,
+  extractNotificationLink,
+  extractNotificationAvatar,
+  type NotificationBucket,
+} from "@/lib/notification-display";
+
+// JetBrains Mono is loaded as a CSS var by the root layout; fall back gracefully.
+const MONO = "var(--font-jetbrains-mono), 'JetBrains Mono', monospace";
+const HARD = "var(--border-hard)";
+const BUCKET_ORDER: NotificationBucket[] = ["Today", "This week", "Earlier"];
+
+type Filter = "all" | "unread" | "hires" | "activity";
+
+/**
+ * Avatar-led chip: a person's photo (with a small type badge) when the
+ * notification carries one in metadata, otherwise a bordered type icon. Read
+ * items mute to a subtle border + grey; unread items get the hard border and
+ * accent treatment.
+ */
+function NotificationChip({ n }: { n: Notification }) {
+  const Icon = NOTIFICATION_ICONS[n.type] || Bell;
+  const avatar = extractNotificationAvatar(n.metadata as Record<string, unknown> | null);
+  const read = n.read;
+
+  if (avatar) {
+    return (
+      <div style={{ position: "relative", width: 46, height: 46 }}>
+        {/* eslint-disable-next-line @next/next/no-img-element -- metadata avatar URL is free-form; plain img avoids next/image remote-host config requirements */}
+        <img
+          src={avatar}
+          alt=""
+          width={46}
+          height={46}
+          style={{
+            display: "block",
+            width: 46,
+            height: 46,
+            objectFit: "cover",
+            border: `2px solid ${read ? "var(--border-subtle)" : HARD}`,
+            filter: read ? "grayscale(1) opacity(0.7)" : "none",
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            right: -7,
+            bottom: -7,
+            width: 22,
+            height: 22,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            background: read ? "var(--bg-surface-light)" : "var(--accent)",
+            border: `2px solid ${read ? "var(--border-subtle)" : HARD}`,
+            color: read ? "var(--text-muted-soft)" : "#fff",
+          }}
+        >
+          <Icon size={12} />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        width: 44,
+        height: 44,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        border: `2px solid ${read ? "var(--border-subtle)" : HARD}`,
+        color: read ? "var(--text-muted-soft)" : "var(--accent)",
+        background: "var(--bg-surface)",
+        boxShadow: read ? "none" : `2.5px 2.5px 0 ${HARD}`,
+      }}
+    >
+      <Icon size={20} />
+    </div>
+  );
+}
+
+function NotificationCard({
+  n,
+  onRead,
+}: {
+  n: Notification;
+  onRead: (id: string) => void;
+}) {
+  const read = n.read;
+  const link = extractNotificationLink(n.metadata as Record<string, unknown> | null);
+  const tag = NOTIFICATION_TAGS[n.type] || "Update";
+
+  return (
+    <article
+      className="ntf-card"
+      style={{
+        position: "relative",
+        display: "flex",
+        gap: 14,
+        alignItems: "flex-start",
+        padding: "16px 18px",
+        border: `2px solid ${HARD}`,
+        background: read ? "var(--bg-surface)" : "var(--bg-unread)",
+        boxShadow: read ? `3px 3px 0 ${HARD}` : `4px 4px 0 ${HARD}`,
+      }}
+    >
+      <div style={{ position: "relative", flexShrink: 0 }}>
+        <NotificationChip n={n} />
+      </div>
+
+      <div style={{ minWidth: 0, flex: 1 }}>
+        <div style={{ display: "flex", alignItems: "flex-start", gap: 10 }}>
+          <h2
+            style={{
+              margin: 0,
+              fontSize: 15,
+              lineHeight: 1.35,
+              fontWeight: read ? 600 : 700,
+              color: read ? "var(--text-muted)" : "var(--foreground)",
+            }}
+          >
+            {link ? (
+              <Link
+                href={link}
+                onClick={() => {
+                  if (!read) onRead(n.id);
+                }}
+                className="ntf-stretched-link"
+                style={{ color: "inherit", textDecoration: "none" }}
+              >
+                {n.title}
+              </Link>
+            ) : (
+              n.title
+            )}
+          </h2>
+          {!read && (
+            <span
+              aria-label="Unread"
+              style={{
+                marginLeft: "auto",
+                flexShrink: 0,
+                width: 9,
+                height: 9,
+                borderRadius: "50%",
+                background: "var(--accent)",
+                border: `1.5px solid ${HARD}`,
+                marginTop: 5,
+              }}
+            />
+          )}
+        </div>
+
+        <p
+          style={{
+            margin: "6px 0 0",
+            fontSize: 13,
+            lineHeight: 1.5,
+            color: read ? "var(--text-muted-soft)" : "var(--text-secondary)",
+            whiteSpace: "pre-wrap",
+            overflowWrap: "anywhere",
+          }}
+        >
+          {n.message}
+        </p>
+
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 14,
+            marginTop: 12,
+            flexWrap: "wrap",
+          }}
+        >
+          <span
+            style={{
+              fontFamily: MONO,
+              fontSize: 10,
+              fontWeight: 700,
+              textTransform: "uppercase",
+              letterSpacing: "0.08em",
+              color: "var(--text-muted-soft)",
+            }}
+          >
+            {notificationTimeAgo(n.created_at)}
+          </span>
+          <span
+            style={{
+              fontFamily: MONO,
+              fontSize: 10,
+              fontWeight: 700,
+              textTransform: "uppercase",
+              letterSpacing: "0.06em",
+              padding: "2px 7px",
+              border: `1.5px solid ${read ? "var(--border-subtle)" : HARD}`,
+              color: read ? "var(--text-muted-soft)" : "var(--text-muted)",
+            }}
+          >
+            {tag}
+          </span>
+          {!read && (
+            <button
+              onClick={() => onRead(n.id)}
+              style={{
+                position: "relative",
+                zIndex: 1,
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 5,
+                fontSize: 11,
+                fontWeight: 700,
+                textTransform: "uppercase",
+                letterSpacing: "0.05em",
+                color: "var(--text-muted)",
+                background: "none",
+                border: "none",
+                cursor: "pointer",
+                padding: 0,
+              }}
+            >
+              <Check size={12} strokeWidth={2.5} />
+              Mark read
+            </button>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+/**
+ * Presentational notifications screen: header, filter tabs, time-bucketed
+ * groups, and read/unread cards. Pure — it owns only the active-filter UI
+ * state; data fetching, auth, and the mark-read/all network calls are supplied
+ * by the caller (the route page, or the dev preview harness).
+ */
+export function NotificationsView({
+  notifications,
+  loading = false,
+  marking = false,
+  onMarkRead,
+  onMarkAllRead,
+}: {
+  notifications: Notification[];
+  loading?: boolean;
+  marking?: boolean;
+  onMarkRead: (id: string) => void;
+  onMarkAllRead: () => void;
+}) {
+  const [filter, setFilter] = useState<Filter>("all");
+
+  const unreadCount = notifications.filter((n) => !n.read).length;
+  const hireCount = notifications.filter((n) => HIRE_NOTIFICATION_TYPES.has(n.type)).length;
+  const activityCount = notifications.length - hireCount;
+
+  const tabs: { id: Filter; label: string; count: number }[] = [
+    { id: "all", label: "All", count: notifications.length },
+    { id: "unread", label: "Unread", count: unreadCount },
+    { id: "hires", label: "Hires", count: hireCount },
+    { id: "activity", label: "Activity", count: activityCount },
+  ];
+
+  const matchesFilter = (n: Notification) => {
+    if (filter === "unread") return !n.read;
+    if (filter === "hires") return HIRE_NOTIFICATION_TYPES.has(n.type);
+    if (filter === "activity") return !HIRE_NOTIFICATION_TYPES.has(n.type);
+    return true;
+  };
+  const filtered = notifications.filter(matchesFilter);
+
+  const groups = (() => {
+    const map: Record<NotificationBucket, Notification[]> = {
+      Today: [],
+      "This week": [],
+      Earlier: [],
+    };
+    for (const n of filtered) map[notificationBucket(n.created_at)].push(n);
+    return BUCKET_ORDER.map((label) => ({ label, items: map[label] })).filter(
+      (g) => g.items.length > 0
+    );
+  })();
+
+  const statusLine =
+    unreadCount > 0
+      ? `${unreadCount} unread`
+      : notifications.length > 0
+        ? "All caught up"
+        : "Nothing yet";
+
+  const surfaceCard = {
+    background: "var(--bg-surface)",
+    border: `2px solid ${HARD}`,
+    boxShadow: `5px 5px 0 ${HARD}`,
+  } as const;
+
+  return (
+    <div className="min-h-screen">
+      <div style={{ maxWidth: 720, margin: "0 auto", padding: "40px 16px 80px" }}>
+        <Link
+          href="/dashboard"
+          className="inline-flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-[0.08em] text-[var(--text-muted)] hover:text-[var(--foreground)] no-underline"
+          style={{ marginBottom: 22 }}
+        >
+          <ArrowLeft size={14} strokeWidth={2.5} />
+          Back to dashboard
+        </Link>
+
+        {/* HEADER */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 16,
+            padding: "20px 22px",
+            marginBottom: 18,
+            ...surfaceCard,
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: 14, minWidth: 0 }}>
+            <div
+              style={{
+                width: 46,
+                height: 46,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                background: "var(--accent)",
+                border: `2px solid ${HARD}`,
+                boxShadow: `3px 3px 0 ${HARD}`,
+                color: "#fff",
+                flexShrink: 0,
+              }}
+            >
+              <Bell size={22} />
+            </div>
+            <div style={{ minWidth: 0 }}>
+              <h1
+                style={{
+                  margin: 0,
+                  fontSize: 26,
+                  fontWeight: 700,
+                  letterSpacing: "-0.02em",
+                  lineHeight: 1,
+                  color: "var(--foreground)",
+                }}
+              >
+                Notifications
+              </h1>
+              <p
+                style={{
+                  margin: "6px 0 0",
+                  fontFamily: MONO,
+                  fontSize: 11,
+                  fontWeight: 600,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.06em",
+                  color: "var(--text-muted)",
+                }}
+              >
+                {statusLine}
+              </p>
+            </div>
+          </div>
+
+          {unreadCount > 0 && (
+            <button
+              onClick={onMarkAllRead}
+              disabled={marking}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 7,
+                flexShrink: 0,
+                padding: "10px 15px",
+                fontSize: 12,
+                fontWeight: 700,
+                textTransform: "uppercase",
+                letterSpacing: "0.05em",
+                color: "#fff",
+                background: "var(--accent)",
+                border: `2px solid ${HARD}`,
+                boxShadow: `2.5px 2.5px 0 ${HARD}`,
+                cursor: marking ? "default" : "pointer",
+                opacity: marking ? 0.5 : 1,
+              }}
+            >
+              <Check size={14} strokeWidth={2.5} />
+              Mark all read
+            </button>
+          )}
+        </div>
+
+        {/* FILTERS */}
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 24 }}>
+          {tabs.map((t) => {
+            const active = filter === t.id;
+            return (
+              <button
+                key={t.id}
+                onClick={() => setFilter(t.id)}
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 8,
+                  padding: "9px 15px",
+                  fontSize: 12,
+                  fontWeight: 700,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.05em",
+                  cursor: "pointer",
+                  border: `2px solid ${HARD}`,
+                  background: active ? "var(--foreground)" : "var(--bg-surface)",
+                  color: active ? "var(--background)" : "var(--foreground)",
+                  boxShadow: active ? "none" : `2px 2px 0 ${HARD}`,
+                  transition: "all 0.12s",
+                }}
+              >
+                {t.label}
+                {t.count > 0 && (
+                  <span
+                    style={{
+                      fontFamily: MONO,
+                      fontSize: 10,
+                      fontWeight: 700,
+                      padding: "1px 6px",
+                      border: `1.5px solid ${active ? "var(--background)" : HARD}`,
+                      color: active ? "var(--background)" : "var(--text-muted)",
+                    }}
+                  >
+                    {t.count}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* LIST / STATES */}
+        {loading ? (
+          <div style={{ padding: "40px 24px", textAlign: "center", ...surfaceCard }}>
+            <p style={{ margin: 0, fontSize: 13, color: "var(--text-muted-soft)" }}>
+              Loading notifications…
+            </p>
+          </div>
+        ) : groups.length === 0 ? (
+          <div style={{ padding: "56px 24px", textAlign: "center", ...surfaceCard }}>
+            <div
+              style={{
+                width: 56,
+                height: 56,
+                margin: "0 auto 16px",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                background: "var(--bg-surface-light)",
+                border: `2px solid ${HARD}`,
+                color: "var(--text-muted-soft)",
+              }}
+            >
+              <Bell size={26} />
+            </div>
+            <p style={{ margin: "0 0 6px", fontSize: 16, fontWeight: 700, color: "var(--foreground)" }}>
+              {filter === "unread" ? "No unread notifications" : "No notifications yet"}
+            </p>
+            <p style={{ margin: 0, fontSize: 13, color: "var(--text-muted)" }}>
+              You&apos;re all caught up. Streak reminders, hire requests, and milestones show up here.
+            </p>
+          </div>
+        ) : (
+          <div>
+            {groups.map((group) => (
+              <div key={group.label} style={{ marginBottom: 26 }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 12 }}>
+                  <span
+                    style={{
+                      fontFamily: MONO,
+                      fontSize: 11,
+                      fontWeight: 700,
+                      textTransform: "uppercase",
+                      letterSpacing: "0.12em",
+                      color: "var(--text-muted-soft)",
+                    }}
+                  >
+                    {group.label}
+                  </span>
+                  <span style={{ flex: 1, height: 2, background: "var(--border-subtle)" }} />
+                </div>
+                <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+                  {group.items.map((n) => (
+                    <NotificationCard key={n.id} n={n} onRead={onMarkRead} />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/notification-bell.tsx
+++ b/src/components/ui/notification-bell.tsx
@@ -4,7 +4,77 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { Bell } from "lucide-react";
 import { useRouter } from "next/navigation";
 import type { Notification } from "@/lib/types/database";
-import { NOTIFICATION_ICONS, NOTIFICATION_COLORS, notificationTimeAgo } from "@/lib/notification-display";
+import { NOTIFICATION_ICONS, notificationTimeAgo, extractNotificationAvatar } from "@/lib/notification-display";
+
+// JetBrains Mono is loaded as a CSS var by the root layout; fall back gracefully.
+const MONO = "var(--font-jetbrains-mono), 'JetBrains Mono', monospace";
+
+/** Compact (34px) version of the notifications-page chip: avatar with a type
+ *  badge when present, otherwise a bordered type icon. Read items mute. */
+function BellChip({ n }: { n: Notification }) {
+  const Icon = NOTIFICATION_ICONS[n.type] || Bell;
+  const avatar = extractNotificationAvatar(n.metadata as Record<string, unknown> | null);
+  const read = n.read;
+  const ring = read ? "var(--border-subtle)" : "var(--border-hard)";
+
+  if (avatar) {
+    return (
+      <div style={{ position: "relative", width: 34, height: 34, flexShrink: 0 }}>
+        {/* eslint-disable-next-line @next/next/no-img-element -- free-form metadata URL; plain img avoids next/image remote-host config */}
+        <img
+          src={avatar}
+          alt=""
+          width={34}
+          height={34}
+          style={{
+            display: "block",
+            width: 34,
+            height: 34,
+            objectFit: "cover",
+            border: `2px solid ${ring}`,
+            filter: read ? "grayscale(1) opacity(0.7)" : "none",
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            right: -5,
+            bottom: -5,
+            width: 16,
+            height: 16,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            background: read ? "var(--bg-surface-light)" : "var(--accent)",
+            border: `1.5px solid ${ring}`,
+            color: read ? "var(--text-muted-soft)" : "#fff",
+          }}
+        >
+          <Icon size={9} />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        width: 34,
+        height: 34,
+        flexShrink: 0,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        border: `2px solid ${ring}`,
+        color: read ? "var(--text-muted-soft)" : "var(--accent)",
+        background: "var(--bg-surface)",
+        boxShadow: read ? "none" : "2px 2px 0 var(--border-hard)",
+      }}
+    >
+      <Icon size={16} />
+    </div>
+  );
+}
 
 export function NotificationBell() {
   const [open, setOpen] = useState(false);
@@ -144,36 +214,29 @@ export function NotificationBell() {
             </div>
           ) : (
             <div>
-              {notifications.slice(0, 10).map((n) => {
-                const Icon = NOTIFICATION_ICONS[n.type] || Bell;
-                const color = NOTIFICATION_COLORS[n.type] || "var(--text-muted)";
-                return (
-                  <button
-                    key={n.id}
-                    onClick={() => handleClickNotification(n)}
-                    className="w-full text-left px-4 py-3 flex gap-3 items-start transition-colors hover:bg-[var(--bg-surface-light)] cursor-pointer"
-                    style={{
-                      borderLeft: `3px solid ${color}`,
-                      backgroundColor: n.read ? "transparent" : "var(--bg-surface-light, #FFFBEB)",
-                    }}
-                  >
-                    <Icon size={16} style={{ color, marginTop: 2, flexShrink: 0 }} />
-                    <div className="min-w-0 flex-1">
-                      <p className={`text-sm leading-tight ${n.read ? "font-medium text-[var(--text-secondary)]" : "font-bold text-[var(--foreground)]"}`}>
-                        {n.title}
-                      </p>
-                      <p className="text-xs mt-0.5 truncate" style={{ color: n.read ? "var(--text-muted)" : "var(--text-secondary)" }}>{n.message}</p>
-                      <p className="text-[10px] mt-1 font-medium" style={{ color: "var(--text-muted)" }}>{notificationTimeAgo(n.created_at)}</p>
-                    </div>
-                    {!n.read && (
-                      <span
-                        className="w-2 h-2 rounded-full mt-1.5 shrink-0"
-                        style={{ backgroundColor: "var(--accent)" }}
-                      />
-                    )}
-                  </button>
-                );
-              })}
+              {notifications.slice(0, 10).map((n) => (
+                <button
+                  key={n.id}
+                  role="menuitem"
+                  onClick={() => handleClickNotification(n)}
+                  className={`ntf-row${n.read ? "" : " ntf-row-unread"} w-full text-left px-3.5 py-3 flex gap-3 items-start cursor-pointer`}
+                >
+                  <BellChip n={n} />
+                  <div className="min-w-0 flex-1">
+                    <p className={`text-sm leading-tight ${n.read ? "font-semibold text-[var(--text-muted)]" : "font-bold text-[var(--foreground)]"}`}>
+                      {n.title}
+                    </p>
+                    <p className="text-xs mt-0.5 truncate" style={{ color: n.read ? "var(--text-muted-soft)" : "var(--text-secondary)" }}>{n.message}</p>
+                    <p className="text-[10px] mt-1.5 font-bold uppercase tracking-wide" style={{ fontFamily: MONO, color: "var(--text-muted-soft)" }}>{notificationTimeAgo(n.created_at)}</p>
+                  </div>
+                  {!n.read && (
+                    <span
+                      className="w-2 h-2 rounded-full mt-1.5 shrink-0"
+                      style={{ backgroundColor: "var(--accent)", border: "1.5px solid var(--border-hard)" }}
+                    />
+                  )}
+                </button>
+              ))}
               <button
                 onClick={() => {
                   setOpen(false);

--- a/src/lib/notification-display.ts
+++ b/src/lib/notification-display.ts
@@ -31,6 +31,32 @@ export const NOTIFICATION_COLORS: Record<string, string> = {
 };
 
 /**
+ * Short, uppercase category label shown as a tag pill on each notification card.
+ * Keep in sync with the `type` CHECK constraint in supabase/schema.sql.
+ */
+export const NOTIFICATION_TAGS: Record<string, string> = {
+  hire_request: "Hire",
+  streak_milestone: "Streak",
+  streak_warning: "Warning",
+  badge_earned: "Badge",
+  project_verified: "Project",
+  project_flagged: "Flagged",
+  new_review: "Review",
+  profile_view_summary: "Views",
+  weekly_digest: "Digest",
+  vibe_score_milestone: "Score",
+  project_missing_links: "Project",
+  referral_prompt: "Referral",
+};
+
+/**
+ * Notification types that belong to the "Hires" filter tab. Everything not in
+ * this set is treated as "Activity" — so new types automatically fall under
+ * Activity without needing to be enumerated.
+ */
+export const HIRE_NOTIFICATION_TYPES = new Set<string>(["hire_request", "hire_message"]);
+
+/**
  * Returns a safe URL extracted from a notification's metadata.link, or null if
  * the field is missing/unsafe. Defends against `javascript:`, `data:`,
  * `vbscript:`, protocol-relative (`//evil.com`), and backslash-trick URLs.
@@ -63,6 +89,47 @@ export function extractNotificationLink(
     // unparseable
   }
   return null;
+}
+
+/**
+ * Returns a safe avatar URL from a notification's metadata.avatar_url, or null
+ * when absent/unsafe. Mirrors {@link extractNotificationLink}: metadata is a
+ * free-form jsonb column, so we validate at the render boundary rather than
+ * trust the producer. Accepts same-origin paths ("/avatars/x.jpg") and absolute
+ * http(s) URLs; rejects javascript:/data:/protocol-relative/backslash tricks.
+ *
+ * People-driven notifications (a review, a hire request) can carry the actor's
+ * photo here; system events have none and fall back to a type icon.
+ */
+export function extractNotificationAvatar(
+  metadata: Record<string, unknown> | null | undefined
+): string | null {
+  if (!metadata) return null;
+  const url = metadata.avatar_url;
+  if (typeof url !== "string" || url.length === 0) return null;
+  if (url.startsWith("/")) {
+    if (url.startsWith("//") || url.includes("\\")) return null;
+    return url;
+  }
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") return url;
+  } catch {
+    // unparseable
+  }
+  return null;
+}
+
+export type NotificationBucket = "Today" | "This week" | "Earlier";
+
+/** Buckets a notification by age for the grouped list: <24h, <7d, older. */
+export function notificationBucket(dateStr: string): NotificationBucket {
+  const timestamp = new Date(dateStr).getTime();
+  if (Number.isNaN(timestamp)) return "Earlier";
+  const diff = Date.now() - timestamp;
+  if (diff < 86_400_000) return "Today";
+  if (diff < 7 * 86_400_000) return "This week";
+  return "Earlier";
 }
 
 export function notificationTimeAgo(dateStr: string): string {


### PR DESCRIPTION
## Summary
Rebuilds `/notifications` to the brutalist, avatar-led design from the Claude Design handoff, brings the navbar bell dropdown in line with it, and removes a client-side auth waterfall that slowed initial load.

## Page redesign
- Accent bell header with status line (`3 unread` / `All caught up`) + **Mark all read**
- Filter tabs — **All / Unread / Hires / Activity** — with live counts
- Time-bucketed groups: **Today / This week / Earlier**
- Avatar-or-icon chips: a person's photo + type badge when available, otherwise a bordered type icon; read items mute, unread get the accent treatment
- Read/unread card states (warm `--bg-unread`, offset shadows), plus empty + loading states
- Whole-card click navigates via an invisible stretched link (no off-design "Open" button); per-row + global **Mark read**

## Bell dropdown
- Compact (34px) version of the same chip language — warm unread rows, mono timestamps, accent unread dots
- Drops the old per-type colored left-border scheme

## Performance
The page was doing a serial auth waterfall: client `supabase.auth.getUser()` (a Supabase Auth round-trip) → **then** `fetch('/api/notifications')` (which re-validates auth + queries the DB). The client `getUser()` was redundant — the API enforces auth itself.

It now fetches `/api/notifications` immediately on mount and redirects on the API's `401`, removing a full auth round-trip from the critical path and collapsing the two-phase spinner into one.

## Structure
- Extracted a presentational `<NotificationsView>` (`src/components/notifications/notifications-view.tsx`); the route is now a thin auth/fetch wrapper
- Added `NOTIFICATION_TAGS`, `notificationBucket()`, `HIRE_NOTIFICATION_TYPES`, and `extractNotificationAvatar()` (mirrors the existing `extractNotificationLink` metadata-safety pattern)
- Added the `--bg-unread` token + `.ntf-*` styles

## Notes
- Avatars render when a notification carries a safe `metadata.avatar_url`, otherwise fall back to a type icon. Production notifications carry only free-text actor names today (actors are often non-users — anonymous reviewers, external hire requesters), so cards currently show icons — matching the handoff's read-state screenshot. Wiring real actor avatars (e.g. reviews with a `reviewer_user_id`) is a tracked follow-up.
- No schema or API changes.

## Testing
- `eslint src` clean · `tsc` clean on changed files · `vitest` **294/294** passing
- Verified in dev (light + dark): rendering, tab filtering, read/unread states, mark-read, the avatar chip branch, and the logged-out → `/auth/login` redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a richer notifications page with filters, grouped sections, status summaries, and quicker read actions.
  * Notification items now show clearer icons/avatars, labels, and improved unread styling.
  * Notification rows and cards now have more polished hover and highlight behavior.

* **Bug Fixes**
  * Improved notification loading to avoid flashing empty content before data arrives.
  * Made read/unread actions more reliable when updating notification status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->