### PR TITLE
chore(vercel): disable crons — migrated to Cloudflare Workers cron triggers

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -17,27 +17,5 @@
       "destination": "https://www.vibetalent.work/$1",
       "permanent": true
     }
-  ],
-  "crons": [
-    {
-      "path": "/api/cron/daily",
-      "schedule": "0 6 * * *"
-    },
-    {
-      "path": "/api/cron/check-live-urls",
-      "schedule": "0 3 * * 0"
-    },
-    {
-      "path": "/api/cron/quality-rescore",
-      "schedule": "0 4 * * *"
-    },
-    {
-      "path": "/api/cron/verify-backfill",
-      "schedule": "30 5 * * *"
-    },
-    {
-      "path": "/api/cron/weekly-digest",
-      "schedule": "0 15 * * 1,2"
-    }
   ]
 }


### PR DESCRIPTION
## What

Removes the `crons` block from `vercel.json`. The 5 scheduled jobs now run on **Cloudflare Workers cron triggers** (`wrangler.jsonc` `triggers.crons` + the `scheduled()` shim in `worker.ts`), matching the same schedules and hitting the same `/api/cron/*` routes with the `CRON_SECRET` bearer token.

## Why

`www` + apex now serve from the Cloudflare Worker. Leaving Vercel's crons enabled would double-fire every job (duplicate daily runs, double emails). This disables them on the Vercel side so the schedules run in exactly one place.

## Kept intact
- **apex→www redirect** and `git`/`ignoreCommand` config stay, so the Vercel deployment remains a valid **instant-rollback** target.
- No code changes — config only.

## Rollback
Revert this commit (re-adds the Vercel crons) and disable the Cloudflare triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment settings to remove scheduled background jobs from the app configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->