### PR TITLE
fix(images): drop unoptimized flag so Cloudflare optimizes next/image

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -26,7 +26,6 @@ const securityHeaders = [
 
 const nextConfig: NextConfig = {
   images: {
-    unoptimized: true,
     formats: ["image/avif", "image/webp"],
     minimumCacheTTL: 2592000,
     remotePatterns: [


### PR DESCRIPTION
## What
Removes `images.unoptimized = true` from `next.config.ts` so `next/image` is optimized (AVIF/WebP) via Cloudflare's image resizing.

## Why
The live Cloudflare Worker **already serves optimized images** — this was set up and verified during the cutover (AVIF confirmed). But that change lived only in the working tree and was never committed, so `main` still had `unoptimized: true`. Without this, **Workers Builds would deploy `main` and regress images back to unoptimized.** This aligns main with what's actually live.

## Risk
Config-only, one line. Matches current production behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)