### PR TITLE
chore(vercel): disable git auto-deploys — Cloudflare is the only deploy path

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "git": {
     "deploymentEnabled": {
-      "main": true
+      "main": false
     }
   },
   "ignoreCommand": "git diff --quiet HEAD^ HEAD -- src public package.json package-lock.json next.config.ts next.config.js next.config.mjs tsconfig.json vercel.json",


### PR DESCRIPTION
Sets `git.deploymentEnabled.main = false` so pushes no longer trigger **Vercel** builds — they were still consuming the Hobby build quota this migration was meant to escape, and Vercel's Supabase is already non-functional (legacy keys disabled).

**Cloudflare Workers (GitHub Actions) is now the sole deploy path.** Vercel becomes a dormant standby you can still redeploy manually or re-enable by reverting this. The apex→www redirect is kept in case of that.

Next (optional, later): delete the Vercel project entirely once you're confident, and I'll update CLAUDE.md/infra docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)