### PR TITLE
ci: skip deploy on config-only changes (vercel.json, .github, docs)

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -10,6 +10,8 @@ on:
       - "**.md"
       - "docs/**"
       - "infographics/**"
+      - "vercel.json"
+      - ".github/**"
 
 # Never run two deploys at once; let an in-flight deploy finish rather than cancel it.
 concurrency:


### PR DESCRIPTION
Adds `vercel.json` and `.github/**` to the deploy workflow's `paths-ignore`, so config/docs-only pushes stop triggering redundant Cloudflare builds (like the `vercel.json` edit in #222 did). Real code changes still deploy normally — `paths-ignore` only skips when *every* changed file matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)