### PR TITLE
Settings: unlink/reconnect GitHub + align select dropdown chevron

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -67,12 +67,16 @@ export async function GET(request: Request) {
         const githubIdentity = user.identities?.find((i: any) => i.provider === "github");
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const ghData = (githubIdentity?.identity_data ?? {}) as any;
-        const githubUsername =
-          ghData.user_name ||
-          ghData.preferred_username ||
-          user.user_metadata?.user_name ||
-          user.user_metadata?.preferred_username ||
-          null;
+        // Only derive the handle when a GitHub identity is actually linked.
+        // user_metadata persists after unlinkIdentity, so a later Google/email
+        // login must not resurrect a handle the builder disconnected.
+        const githubUsername = githubIdentity
+          ? ghData.user_name ||
+            ghData.preferred_username ||
+            user.user_metadata?.user_name ||
+            user.user_metadata?.preferred_username ||
+            null
+          : null;
         // GitHub's stable numeric ID lands in identity_data.sub (OIDC-style
         // subject identifier — string-encoded). We coerce here once because
         // github-sync uses this on every run to tell a legitimate rename

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -306,6 +306,25 @@ html {
   border-color: var(--accent);
 }
 
+/* Native <select> arrows render inconsistently across browsers and sit
+   misaligned inside the tall brutalist field. Swap in a custom chevron
+   pinned to the vertical center, 1rem in from the right edge. The extra
+   right padding keeps long option labels from sliding under the arrow. */
+select.input-brutal {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  padding-right: 2.5rem;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%2371717A' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 1rem center;
+  background-size: 1rem;
+}
+
+[data-theme="dark"] select.input-brutal {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%23A69A96' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+}
+
 /* Large accent numbers */
 .text-accent-brutal {
   color: var(--accent);

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -11,15 +11,10 @@ import { normalizeExternalUrl } from "@/lib/url-normalize";
 import type { UserWithSocials } from "@/lib/types/database";
 import { EmailPreferences } from "@/components/dashboard/email-preferences";
 import { PrivacyPreferences } from "@/components/dashboard/privacy-preferences";
+import { GithubConnection } from "@/components/dashboard/github-connection";
 import { isUsernameTakenError, validateUsername } from "@/lib/username";
 import { useUsernameAvailability } from "@/lib/use-username-availability";
-import {
-  Save,
-  Camera,
-  Users,
-  Github,
-  CheckCircle2,
-} from "lucide-react";
+import { Save, Camera, Users } from "lucide-react";
 
 // Drives the "@" decoration inside the handle inputs: show it for empty
 // fields and bare usernames, hide it once the user pastes a URL so they
@@ -48,7 +43,6 @@ export default function SettingsPage() {
     website: "",
     ide: "",
   });
-  const [connectingGithub, setConnectingGithub] = useState(false);
   const [highlightName, setHighlightName] = useState(false);
   const displayNameRef = useRef<HTMLInputElement>(null);
 
@@ -354,20 +348,6 @@ export default function SettingsPage() {
     setSaving(false);
   };
 
-  const handleConnectGithub = async () => {
-    setConnectingGithub(true);
-    const supabase = createClient();
-    const { error } = await supabase.auth.linkIdentity({
-      provider: "github",
-      options: { redirectTo: `${window.location.origin}/auth/callback?next=/settings` },
-    });
-    if (error) {
-      alert(`Couldn't connect GitHub: ${error.message}`);
-      setConnectingGithub(false);
-    }
-    // On success the browser redirects to GitHub, so no further UI update needed.
-  };
-
   if (loading) {
     return (
       <div className="mx-auto max-w-3xl px-4 sm:px-6 py-12">
@@ -527,69 +507,23 @@ export default function SettingsPage() {
                 />
               </div>
             </div>
-            <div>
-              <label className="text-xs font-bold uppercase tracking-wide text-[var(--text-muted)] mb-1.5 block">GitHub</label>
-              {searchParams.get("error_code") === "identity_already_exists" && user.github_username && (
-                <div
-                  className="mb-2 p-3 flex items-start gap-2 text-sm"
-                  style={{
-                    backgroundColor: "var(--status-success-bg)",
-                    border: "2px solid var(--border-hard)",
-                  }}
-                >
-                  <CheckCircle2 size={16} className="mt-0.5 shrink-0" style={{ color: "var(--status-success-text)" }} />
-                  <span className="font-bold text-[var(--status-success-text)]">
-                    GitHub connected successfully!
-                  </span>
-                </div>
-              )}
-              {searchParams.get("error_code") === "identity_already_exists" && !user.github_username && (
-                <div
-                  className="mb-2 p-3 flex items-start gap-2 text-sm"
-                  style={{
-                    backgroundColor: "var(--status-error-bg)",
-                    border: "2px solid var(--border-hard)",
-                  }}
-                >
-                  <Github size={16} className="mt-0.5 shrink-0" style={{ color: "var(--status-error-text)" }} />
-                  <span className="font-bold text-[var(--foreground)]">
-                    This GitHub account is already linked to another user. Use a different GitHub account or contact support.
-                  </span>
-                </div>
-              )}
-              {user.github_username ? (
-                <div
-                  className="flex items-center gap-2 px-3 py-2.5 text-sm"
-                  style={{
-                    backgroundColor: "var(--status-success-bg)",
-                    border: "2px solid var(--border-hard)",
-                  }}
-                >
-                  <CheckCircle2 size={16} className="text-[var(--status-success-text)] flex-shrink-0" />
-                  <span className="font-bold text-[var(--status-success-text)]">@{user.github_username}</span>
-                  <span className="text-xs font-bold uppercase text-[var(--status-success-text)] opacity-70 ml-auto">Verified</span>
-                </div>
-              ) : (
-                <button
-                  type="button"
-                  onClick={handleConnectGithub}
-                  disabled={connectingGithub}
-                  className="w-full flex items-center justify-center gap-2 px-3 py-2.5 text-sm font-extrabold uppercase tracking-wide text-white cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed transition-colors hover:bg-[var(--bg-pill-hover)]"
-                  style={{
-                    backgroundColor: "var(--bg-inverted)",
-                    border: "2px solid var(--border-hard)",
-                  }}
-                >
-                  <Github size={16} />
-                  {connectingGithub ? "Connecting..." : "Connect GitHub"}
-                </button>
-              )}
-              <p className="mt-1.5 text-xs font-medium text-[var(--text-muted)]">
-                {user.github_username
-                  ? "Ownership verified via GitHub OAuth."
-                  : "Verify ownership to enable streak sync."}
-              </p>
-            </div>
+            <GithubConnection
+              githubUsername={user.github_username}
+              oauthErrorCode={searchParams.get("error_code")}
+              onUnlinked={() =>
+                setUser((prev) =>
+                  prev
+                    ? {
+                        ...prev,
+                        github_username: null,
+                        social_links: prev.social_links
+                          ? { ...prev.social_links, github: null }
+                          : prev.social_links,
+                      }
+                    : prev
+                )
+              }
+            />
             <div>
               <label className="text-xs font-bold uppercase tracking-wide text-[var(--text-muted)] mb-1.5 block">Telegram</label>
               <div className="relative">

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -88,12 +88,16 @@ export default function SettingsPage() {
           const ghIdentity = authUser.identities?.find((i: any) => i.provider === "github");
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const ghData = (ghIdentity?.identity_data ?? {}) as any;
-          const ghUsername =
-            ghData.user_name ||
-            ghData.preferred_username ||
-            authUser.user_metadata?.user_name ||
-            authUser.user_metadata?.preferred_username ||
-            null;
+          // Only derive a handle when a GitHub identity is actually linked.
+          // user_metadata persists after unlinkIdentity, so trusting it
+          // unconditionally would resurrect an unlinked account on the next load.
+          const ghUsername = ghIdentity
+            ? ghData.user_name ||
+              ghData.preferred_username ||
+              authUser.user_metadata?.user_name ||
+              authUser.user_metadata?.preferred_username ||
+              null
+            : null;
           if (ghUsername) {
             profile.github_username = ghUsername;
             // Sync to DB in the background
@@ -274,12 +278,16 @@ export default function SettingsPage() {
     const ghIdentity = authUser?.identities?.find((i: any) => i.provider === "github");
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const ghData = (ghIdentity?.identity_data ?? {}) as any;
-    const oauthGithub =
-      ghData.user_name ||
-      ghData.preferred_username ||
-      authUser?.user_metadata?.user_name ||
-      authUser?.user_metadata?.preferred_username ||
-      null;
+    // Only trust the OAuth handle when a GitHub identity is still linked;
+    // user_metadata lingers after unlinkIdentity and would otherwise re-verify
+    // an account the builder just disconnected.
+    const oauthGithub = ghIdentity
+      ? ghData.user_name ||
+        ghData.preferred_username ||
+        authUser?.user_metadata?.user_name ||
+        authUser?.user_metadata?.preferred_username ||
+        null
+      : null;
     const verifiedGithub = user.github_username || oauthGithub;
 
     // Backfill users.github_username for accounts that linked GitHub after

--- a/src/components/dashboard/github-connection.tsx
+++ b/src/components/dashboard/github-connection.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useState } from "react";
+import { Github, CheckCircle2, Unlink } from "lucide-react";
+import { createClient } from "@/lib/supabase/client";
+
+interface GithubConnectionProps {
+  /** The currently verified GitHub handle, or null when nothing is linked. */
+  githubUsername: string | null;
+  /** Called after a successful unlink so the parent can drop the handle from its state. */
+  onUnlinked: () => void;
+  /** `error_code` from the OAuth callback redirect, used to show the post-connect banner. */
+  oauthErrorCode: string | null;
+}
+
+/**
+ * GitHub connection control for the settings profile card. Renders as a single
+ * grid cell (label + control) with three states:
+ *
+ *  - Connected: a verified pill plus an "Unlink account" affordance that expands
+ *    an inline confirm. Unlinking removes the GitHub OAuth identity from Supabase
+ *    Auth and clears the mirrored handle/id so a *different* account can be linked
+ *    afterwards — the recovery path for a builder who lost access to their GitHub.
+ *  - Not connected: a "Connect GitHub" button (OAuth linkIdentity round-trip).
+ *
+ * Supabase requires at least two linked identities to unlink one, so a builder
+ * whose only sign-in method is GitHub is told to add another first rather than
+ * being locked out of their own account.
+ */
+export function GithubConnection({ githubUsername, onUnlinked, oauthErrorCode }: GithubConnectionProps) {
+  const [connecting, setConnecting] = useState(false);
+  const [confirmingUnlink, setConfirmingUnlink] = useState(false);
+  const [unlinking, setUnlinking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Suppress the OAuth round-trip banners once the user starts the unlink flow,
+  // so a stale ?error_code from an earlier connect can't render a wrong message.
+  const [bannerDismissed, setBannerDismissed] = useState(false);
+
+  const handleConnect = async () => {
+    setConnecting(true);
+    setError(null);
+    const supabase = createClient();
+    const { error: linkError } = await supabase.auth.linkIdentity({
+      provider: "github",
+      options: { redirectTo: `${window.location.origin}/auth/callback?next=/settings` },
+    });
+    if (linkError) {
+      setError(`Couldn't connect GitHub: ${linkError.message}`);
+      setConnecting(false);
+    }
+    // On success the browser redirects to GitHub, so no further UI update needed.
+  };
+
+  const handleUnlink = async () => {
+    setUnlinking(true);
+    setError(null);
+    const supabase = createClient();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sb = supabase as any;
+
+    const { data: identityData, error: idError } = await supabase.auth.getUserIdentities();
+    if (idError || !identityData?.identities) {
+      setError("Couldn't load your linked accounts. Please try again.");
+      setUnlinking(false);
+      return;
+    }
+    const identities = identityData.identities;
+    const githubIdentity = identities.find((i) => i.provider === "github");
+
+    // The GitHub auth identity is still attached — remove it. Supabase rejects
+    // unlinking the *only* identity (it would orphan the login), so guard first.
+    if (githubIdentity) {
+      if (identities.length < 2) {
+        setError(
+          "GitHub is your only sign-in method. Add Google or email login first, then unlink — otherwise you'd be locked out."
+        );
+        setUnlinking(false);
+        return;
+      }
+      const { error: unlinkError } = await supabase.auth.unlinkIdentity(githubIdentity);
+      if (unlinkError) {
+        setError(`Couldn't unlink GitHub: ${unlinkError.message}`);
+        setUnlinking(false);
+        return;
+      }
+    }
+
+    // Whether we just removed the identity or it was already gone (a partial
+    // prior failure), clear the mirrored handle + stable id so the badge drops
+    // and a fresh account links cleanly. Clearing github_id matters: the OAuth
+    // callback only backfills it when null, so a lingering id would attach to a
+    // newly-linked account and defeat github-sync's rename/reclaim guard.
+    const { data: { user } } = await supabase.auth.getUser();
+    if (user) {
+      await sb.from("users").update({ github_username: null, github_id: null }).eq("id", user.id);
+      await sb.from("social_links").update({ github: null }).eq("user_id", user.id);
+    }
+
+    setConfirmingUnlink(false);
+    setUnlinking(false);
+    onUnlinked();
+  };
+
+  return (
+    <div>
+      <label className="text-xs font-bold uppercase tracking-wide text-[var(--text-muted)] mb-1.5 block">GitHub</label>
+
+      {/* Post-connect banners from the OAuth callback round-trip. Supabase
+          returns error_code=identity_already_exists both when the link
+          succeeds (handle now mirrored) and when the account belongs to
+          someone else (handle absent) — disambiguate on githubUsername. */}
+      {!bannerDismissed && oauthErrorCode === "identity_already_exists" && githubUsername && (
+        <div
+          className="mb-2 p-3 flex items-start gap-2 text-sm"
+          style={{ backgroundColor: "var(--status-success-bg)", border: "2px solid var(--border-hard)" }}
+        >
+          <CheckCircle2 size={16} className="mt-0.5 shrink-0" style={{ color: "var(--status-success-text)" }} />
+          <span className="font-bold text-[var(--status-success-text)]">GitHub connected successfully!</span>
+        </div>
+      )}
+      {!bannerDismissed && oauthErrorCode === "identity_already_exists" && !githubUsername && (
+        <div
+          className="mb-2 p-3 flex items-start gap-2 text-sm"
+          style={{ backgroundColor: "var(--status-error-bg)", border: "2px solid var(--border-hard)" }}
+        >
+          <Github size={16} className="mt-0.5 shrink-0" style={{ color: "var(--status-error-text)" }} />
+          <span className="font-bold text-[var(--foreground)]">
+            This GitHub account is already linked to another user. Use a different GitHub account or contact support.
+          </span>
+        </div>
+      )}
+
+      {githubUsername ? (
+        <div className="space-y-2">
+          <div
+            className="flex items-center gap-2 px-3 py-2.5 text-sm"
+            style={{ backgroundColor: "var(--status-success-bg)", border: "2px solid var(--border-hard)" }}
+          >
+            <CheckCircle2 size={16} className="text-[var(--status-success-text)] flex-shrink-0" />
+            <span className="font-bold text-[var(--status-success-text)] truncate">@{githubUsername}</span>
+            <span className="text-xs font-bold uppercase text-[var(--status-success-text)] opacity-70 ml-auto">Verified</span>
+          </div>
+
+          {confirmingUnlink ? (
+            <div
+              className="p-3 space-y-2"
+              style={{ backgroundColor: "var(--status-error-bg)", border: "2px solid var(--border-hard)" }}
+            >
+              <p className="text-xs font-bold text-[var(--foreground)] leading-relaxed">
+                Unlink @{githubUsername}? Daily streak sync stops until you connect a GitHub account again. Your projects, score, and endorsements stay.
+              </p>
+              {error && <p className="text-xs font-bold text-red-600">{error}</p>}
+              <div className="flex gap-2">
+                <button
+                  onClick={handleUnlink}
+                  disabled={unlinking}
+                  className="btn-brutal text-xs py-1.5 px-3 bg-red-500 text-white hover:bg-red-600"
+                >
+                  {unlinking ? "Unlinking..." : "Unlink"}
+                </button>
+                <button
+                  onClick={() => { setConfirmingUnlink(false); setError(null); }}
+                  disabled={unlinking}
+                  className="btn-brutal text-xs py-1.5 px-3"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => { setConfirmingUnlink(true); setBannerDismissed(true); }}
+              className="inline-flex items-center gap-1 text-xs font-bold text-[var(--text-muted)] hover:text-red-500 transition-colors"
+            >
+              <Unlink size={12} />
+              Unlink account
+            </button>
+          )}
+        </div>
+      ) : (
+        <>
+          <button
+            type="button"
+            onClick={handleConnect}
+            disabled={connecting}
+            className="w-full flex items-center justify-center gap-2 px-3 py-2.5 text-sm font-extrabold uppercase tracking-wide text-white cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed transition-colors hover:bg-[var(--bg-pill-hover)]"
+            style={{ backgroundColor: "var(--bg-inverted)", border: "2px solid var(--border-hard)" }}
+          >
+            <Github size={16} />
+            {connecting ? "Connecting..." : "Connect GitHub"}
+          </button>
+          {error && <p className="mt-1.5 text-xs font-bold text-red-600">{error}</p>}
+        </>
+      )}
+
+      <p className="mt-1.5 text-xs font-medium text-[var(--text-muted)]">
+        {githubUsername
+          ? "Ownership verified via GitHub OAuth. Unlink to switch to a different account."
+          : "Verify ownership to enable streak sync."}
+      </p>
+    </div>
+  );
+}

--- a/src/components/dashboard/github-connection.tsx
+++ b/src/components/dashboard/github-connection.tsx
@@ -92,8 +92,22 @@ export function GithubConnection({ githubUsername, onUnlinked, oauthErrorCode }:
     // newly-linked account and defeat github-sync's rename/reclaim guard.
     const { data: { user } } = await supabase.auth.getUser();
     if (user) {
-      await sb.from("users").update({ github_username: null, github_id: null }).eq("id", user.id);
-      await sb.from("social_links").update({ github: null }).eq("user_id", user.id);
+      const { error: usersError } = await sb
+        .from("users")
+        .update({ github_username: null, github_id: null })
+        .eq("id", user.id);
+      const { error: socialError } = await sb
+        .from("social_links")
+        .update({ github: null })
+        .eq("user_id", user.id);
+      // The auth identity is already removed, but if the mirror writes fail the
+      // DB still shows the old handle — don't report success. A retry is safe:
+      // the identity is gone, so the next attempt just re-clears the mirrors.
+      if (usersError || socialError) {
+        setError("Disconnected from GitHub, but clearing your profile failed. Reload and try again.");
+        setUnlinking(false);
+        return;
+      }
     }
 
     setConfirmingUnlink(false);
@@ -103,7 +117,7 @@ export function GithubConnection({ githubUsername, onUnlinked, oauthErrorCode }:
 
   return (
     <div>
-      <label className="text-xs font-bold uppercase tracking-wide text-[var(--text-muted)] mb-1.5 block">GitHub</label>
+      <span className="text-xs font-bold uppercase tracking-wide text-[var(--text-muted)] mb-1.5 block">GitHub</span>
 
       {/* Post-connect banners from the OAuth callback round-trip. Supabase
           returns error_code=identity_already_exists both when the link
@@ -152,6 +166,7 @@ export function GithubConnection({ githubUsername, onUnlinked, oauthErrorCode }:
               {error && <p className="text-xs font-bold text-red-600">{error}</p>}
               <div className="flex gap-2">
                 <button
+                  type="button"
                   onClick={handleUnlink}
                   disabled={unlinking}
                   className="btn-brutal text-xs py-1.5 px-3 bg-red-500 text-white hover:bg-red-600"
@@ -159,6 +174,7 @@ export function GithubConnection({ githubUsername, onUnlinked, oauthErrorCode }:
                   {unlinking ? "Unlinking..." : "Unlink"}
                 </button>
                 <button
+                  type="button"
                   onClick={() => { setConfirmingUnlink(false); setError(null); }}
                   disabled={unlinking}
                   className="btn-brutal text-xs py-1.5 px-3"


### PR DESCRIPTION
Two settings-area changes, isolated on a clean branch off \`main\` (kept separate from the CF-migration WIP).

## 1. Unlink & reconnect GitHub (account recovery)
Builders can now disconnect their linked GitHub and connect a different one — previously the verified pill had no unlink affordance, so a builder who lost access to their GitHub account was stuck.

New \`GithubConnection\` component (in the \`EmailPreferences\`/\`PrivacyPreferences\` sibling pattern) with three states: verified + **Unlink account** (inline confirm), and **Connect GitHub** to relink.

**What unlink does**
1. `supabase.auth.unlinkIdentity()` removes the GitHub OAuth identity.
2. Clears the mirrors: `users.github_username`, `users.github_id`, `social_links.github`.

**Why clear `github_id`:** the `/auth/callback` only backfills it when `null`, so a leftover id would stick to a newly-linked account and defeat github-sync's rename/reclaim guard.

**Edge case:** Supabase rejects unlinking the *last* identity (would orphan the login), so a GitHub-only builder is told to add another sign-in method first instead of getting a cryptic error.

Client-side DB writes are safe here — the security-hardening migration grants `authenticated` UPDATE on `github_username`/`github_id`, and `social_links` is managed via RLS.

## 2. Align select dropdown chevron
Native `<select>` arrows rendered inconsistently and sat misaligned in the tall brutalist field. Replaced with a custom, theme-aware chevron pinned to the vertical center 1rem from the right edge, scoped to `select.input-brutal`. Fixes the **Vibe Coding IDE** dropdown in settings plus the agent/find, hire, and explore selects in one shot.

## Test plan
- [x] `tsc --noEmit` + `eslint src` clean for changed files
- [x] Rendered all three `GithubConnection` states (verified / unlink confirm / connect) — styling matches the brutalist system
- [x] Verified chevron alignment in **light and dark** mode (computed styles + screenshots)
- [ ] Live unlink → reconnect round-trip on a real authenticated, GitHub-linked account (needs a real session — please verify on the beta deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a GitHub connection control to Settings with clear connected and disconnected states.
  * Added GitHub OAuth success and error messaging.
  * Added inline confirmation and safeguards when unlinking GitHub.
  * Improved select dropdown styling, including dark-theme support and better text spacing.

* **Bug Fixes**
  * GitHub profile information now stays synchronized after unlinking the account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->