### PR TITLE
fix(cron): run scheduled jobs via GitHub Actions (Worker scheduled() no-op'd)

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,0 +1,57 @@
+name: Scheduled cron jobs
+
+# Reliable external scheduler for the /api/cron/* routes.
+#
+# Replaces the Cloudflare Worker `scheduled()` triggers, which fire inconsistently
+# on this OpenNext setup (the handler is invoked, but the in-process fetch to the
+# route doesn't reliably run the job). These routes work over plain HTTPS with the
+# CRON_SECRET bearer token — proven by manual invocation — so an external scheduler
+# is the dependable path. GitHub Actions cron is UTC and best-effort (may run a few
+# minutes late), which is fine for these daily maintenance jobs.
+on:
+  schedule:
+    - cron: "0 6 * * *" # daily — fans out to its child jobs internally
+    - cron: "0 3 * * 0" # check-live-urls (Sunday) — GH accepts 0 for Sunday
+    - cron: "0 4 * * *" # quality-rescore
+    - cron: "30 5 * * *" # verify-backfill
+    - cron: "0 15 * * 1,2" # weekly-digest (Mon + Tue)
+  workflow_dispatch:
+    inputs:
+      route:
+        description: "Cron route to run now (daily | check-live-urls | quality-rescore | verify-backfill | weekly-digest)"
+        required: true
+        default: "verify-backfill"
+
+concurrency:
+  group: cron-${{ github.event.schedule || github.event.inputs.route }}
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Resolve route from schedule (or manual input)
+        id: r
+        run: |
+          case "${{ github.event.schedule }}" in
+            "0 6 * * *")    ROUTE=daily ;;
+            "0 3 * * 0")    ROUTE=check-live-urls ;;
+            "0 4 * * *")    ROUTE=quality-rescore ;;
+            "30 5 * * *")   ROUTE=verify-backfill ;;
+            "0 15 * * 1,2") ROUTE=weekly-digest ;;
+            *)              ROUTE="${{ github.event.inputs.route }}" ;;
+          esac
+          echo "route=$ROUTE" >> "$GITHUB_OUTPUT"
+
+      - name: Run cron route
+        run: |
+          ROUTE="${{ steps.r.outputs.route }}"
+          echo "→ GET https://www.vibetalent.work/api/cron/$ROUTE"
+          CODE=$(curl -sS --max-time 600 -o /tmp/out -w "%{http_code}" \
+            "https://www.vibetalent.work/api/cron/$ROUTE" \
+            -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}")
+          echo "HTTP $CODE"
+          echo "--- response body ---"
+          head -c 2000 /tmp/out; echo
+          [ "$CODE" = "200" ] || { echo "::error::cron $ROUTE returned HTTP $CODE"; exit 1; }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -34,13 +34,13 @@
     "bindings": [{ "name": "NEXT_CACHE_DO_QUEUE", "class_name": "DOQueueHandler" }]
   },
   "migrations": [{ "tag": "v1", "new_sqlite_classes": ["DOQueueHandler"] }],
-  "services": [{ "binding": "WORKER_SELF_REFERENCE", "service": "vibetalent" }],
+  "services": [{ "binding": "WORKER_SELF_REFERENCE", "service": "vibetalent" }]
 
-  // Cron Triggers — ENABLED at cutover. Vercel crons were disabled in the same step
-  // (vercel.json, PR #218) to avoid duplicate runs / double emails. Each firing invokes
-  // the matching /api/cron/* route via the scheduled() handler in worker.ts, which
-  // authenticates with the CRON_SECRET bearer token (mirrors the old Vercel setup).
-  "triggers": {
-    "crons": ["0 6 * * *", "0 3 * * SUN", "0 4 * * *", "30 5 * * *", "0 15 * * 1,2"]
-  }
+  // Cron Triggers DISABLED — moved to GitHub Actions (.github/workflows/cron.yml).
+  // Cloudflare fires the Worker's scheduled() handler fine, but its in-process fetch
+  // to /api/cron/* does NOT execute the OpenNext route (jobs silently no-op'd). GitHub
+  // Actions calls those routes over real HTTPS (proven to work) on the same schedule.
+  // "triggers": {
+  //   "crons": ["0 6 * * *", "0 3 * * SUN", "0 4 * * *", "30 5 * * *", "0 15 * * 1,2"]
+  // }
 }


### PR DESCRIPTION
## Problem
Cron jobs have silently not run since the Cloudflare cutover. Root cause: the Worker's `scheduled()` handler **fires on schedule** (verified via `wrangler tail` — outcome `ok`), but it calls the `/api/cron/*` route via an **in-process fetch**, and OpenNext does **not** execute the Next.js route for in-process calls — only real external HTTPS requests run the job. So every cron returned `ok` and did nothing. (Confirmed: a manual `curl` to the same route runs the job and writes to the DB; the scheduler's internal call does not.)

## Fix
- **`.github/workflows/cron.yml`** — GitHub Actions runs the 5 schedules and `curl`s the matching `/api/cron/*` route over real HTTPS with the `CRON_SECRET` bearer token. Reliable, visible in the Actions tab, and `workflow_dispatch`-testable on demand.
- **`wrangler.jsonc`** — Worker cron triggers commented out (already cleared on the live Worker via API).

Requires the `CRON_SECRET` repo secret (already added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)