### PR TITLE
fix(cron): restore daily fan-out (github-sync/feed) — service binding preserves auth

### DIFF
--- a/src/app/api/cron/daily/route.ts
+++ b/src/app/api/cron/daily/route.ts
@@ -1,11 +1,35 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSiteUrl } from "@/lib/seo";
 import { runReviewerCalibration } from "@/lib/cron-jobs/reviewer-calibration";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
 
 // Daily orchestrator awaits each child cron sequentially, so its own
 // timeout has to be long enough to cover the slowest child plus all
 // the others. github-sync alone can run up to 5 min at scale.
 export const maxDuration = 300;
+
+/**
+ * Fan out to a sibling cron route as its own Worker invocation.
+ *
+ * On Cloudflare, a plain fetch() to the Worker's own public hostname is an edge
+ * loopback that STRIPS the Authorization header, so every child cron 401s — even
+ * though this orchestrator authenticates fine (GitHub Actions calls it over real
+ * external HTTPS). The WORKER_SELF_REFERENCE service binding dispatches
+ * Worker-to-Worker directly, preserving the header. Off Cloudflare (Vercel/local)
+ * the binding is absent, so fall back to the public fetch.
+ */
+async function cronFetch(url: string, init: RequestInit): Promise<Response> {
+  try {
+    const { env } = getCloudflareContext();
+    const self = (env as {
+      WORKER_SELF_REFERENCE?: { fetch: (input: string, init?: RequestInit) => Promise<Response> };
+    }).WORKER_SELF_REFERENCE;
+    if (self) return await self.fetch(url, init);
+  } catch {
+    // Not running on Cloudflare (or context unavailable) — use the public URL.
+  }
+  return fetch(url, init);
+}
 
 /**
  * Daily orchestrator cron — fans out to individual cron job routes.
@@ -42,7 +66,7 @@ export async function GET(req: NextRequest) {
   // Run jobs sequentially to be predictable
   for (const job of jobs) {
     try {
-      const res = await fetch(`${siteUrl}${job.path}`, { headers });
+      const res = await cronFetch(`${siteUrl}${job.path}`, { headers });
       const data = await res.json().catch(() => ({}));
       results[job.name] = { status: res.status, data };
     } catch (error) {


### PR DESCRIPTION
## Why the feed stopped updating

The GitHub Actions crons **are** firing and the `daily` orchestrator returns `200` — but every child job inside it was silently `401`ing:

```json
"results":{
  "github-sync":{"status":401,"data":{"error":"Unauthorized"}},
  "reset-streaks":{"status":401,...},
  ... all 8 children 401 ...
}
```

`daily` fans out by `fetch()`-ing its own public hostname and forwarding the `Bearer` token. On Cloudflare that's an **edge loopback that strips the `Authorization` header**, so each child rejects the token. The parent authenticates fine only because GitHub Actions calls it over real external HTTPS (that's also why the *directly*-called crons — quality-rescore, verify-backfill — work).

Net effect since the CF cutover: **github-sync (the feed), streak resets, streak-warning emails, milestone-check and re-engagement have all no-op'd.** Only the feed was noticed.

## Fix

Route the fan-out through the `WORKER_SELF_REFERENCE` service binding (already bound in `wrangler.jsonc`) — a direct Worker-to-Worker dispatch that preserves headers — with a graceful fallback to the public `fetch()` off Cloudflare (Vercel/local). One file, no child route touched.

Children self-dedupe (e.g. weekly-digest guards on the `notifications` table per week), so restoring the fan-out just restores the proven Vercel behavior.

## Verification plan (post-merge/deploy)

- Trigger the `daily` workflow via `workflow_dispatch` and confirm `results` flips all children to `200`.
- Confirm github-sync actually wrote (contribution/project rows) and the feed advances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daily scheduled task execution in Cloudflare environments by preserving authorization when invoking related tasks.
  * Maintained existing sequential processing, response aggregation, and reviewer-calibration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->