### PR TITLE
feat(support): DeepSeek support bot + floating chat launcher

### DIFF
--- a/src/app/api/support/chat/route.ts
+++ b/src/app/api/support/chat/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supportLimiter, checkRateLimit, getIP } from "@/lib/rate-limit";
+import { streamDeepSeekChat, type ChatMessage } from "@/lib/deepseek";
+import { SUPPORT_SYSTEM_PROMPT, SUPPORT_EMAIL } from "@/lib/support-knowledge";
+
+const MAX_MESSAGES = 20; // cap conversation turns sent upstream (cost control)
+const MAX_CONTENT = 2000; // cap each message length
+
+/** Validate + trim the client-supplied conversation. Drops anything malformed. */
+function parseMessages(input: unknown): ChatMessage[] {
+  if (!Array.isArray(input)) return [];
+  const out: ChatMessage[] = [];
+  for (const item of input) {
+    if (!item || typeof item !== "object") continue;
+    const role = (item as Record<string, unknown>).role;
+    const content = (item as Record<string, unknown>).content;
+    if (
+      (role === "user" || role === "assistant") &&
+      typeof content === "string" &&
+      content.trim()
+    ) {
+      out.push({ role, content: content.slice(0, MAX_CONTENT) });
+    }
+  }
+  return out.slice(-MAX_MESSAGES);
+}
+
+export async function POST(req: NextRequest) {
+  const { success } = await checkRateLimit(supportLimiter, getIP(req));
+  if (!success) {
+    return NextResponse.json(
+      { error: "You're sending messages too quickly. Give it a few seconds and try again." },
+      { status: 429 }
+    );
+  }
+
+  if (!process.env.DEEPSEEK_API_KEY) {
+    return NextResponse.json(
+      { error: `Support chat isn't set up yet. Please email ${SUPPORT_EMAIL} and we'll help you directly.` },
+      { status: 503 }
+    );
+  }
+
+  let messages: ChatMessage[];
+  try {
+    const body = await req.json();
+    messages = parseMessages(body?.messages);
+  } catch {
+    return NextResponse.json({ error: "Invalid request." }, { status: 400 });
+  }
+
+  if (messages.length === 0) {
+    return NextResponse.json({ error: "No message provided." }, { status: 400 });
+  }
+
+  try {
+    const stream = await streamDeepSeekChat([
+      { role: "system", content: SUPPORT_SYSTEM_PROMPT },
+      ...messages,
+    ]);
+    return new Response(stream, {
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (err) {
+    console.error("Support chat error:", err);
+    return NextResponse.json(
+      { error: "The assistant is having trouble right now. Please try again in a moment." },
+      { status: 502 }
+    );
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Space_Grotesk, JetBrains_Mono } from "next/font/google";
 import { Navbar } from "@/components/layout/navbar";
 import { Footer } from "@/components/layout/footer";
 import { SignupBar } from "@/components/layout/signup-bar";
+import { FloatingChat } from "@/components/layout/floating-chat";
 import { PromoBillboard } from "@/components/ui/promo-billboard";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { siteUrl } from "@/lib/seo";
@@ -112,6 +113,7 @@ export default function RootLayout({
         </ErrorBoundary>
         <Footer />
         <SignupBar />
+        <FloatingChat />
       </body>
     </html>
   );

--- a/src/app/support/layout.tsx
+++ b/src/app/support/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Support",
+  description:
+    "Get instant answers about VibeTalent — vibe scores, streaks, projects, hiring, badges, and your account.",
+  robots: { index: false, follow: false }, // client-only chat surface, not an SEO page
+};
+
+export default function SupportLayout({ children }: { children: React.ReactNode }) {
+  // `.chat-page-wrapper` hides the global footer + adjusts main height so the
+  // chat fills the viewport cleanly (same treatment as /agent/chat).
+  return <div className="chat-page-wrapper">{children}</div>;
+}

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -1,0 +1,5 @@
+import { SupportChat } from "@/components/support/support-chat";
+
+export default function SupportPage() {
+  return <SupportChat />;
+}

--- a/src/components/layout/floating-chat.tsx
+++ b/src/components/layout/floating-chat.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { MessageCircle, X, LifeBuoy, Search } from "lucide-react";
+
+/**
+ * Site-wide floating chat launcher. One always-visible button (bottom-right)
+ * that expands into a two-item menu:
+ *   - Get help    → /support     (VibeFinder Support bot)
+ *   - Find talent → /agent/chat  (VibeFinder matching bot)
+ *
+ * Fixes discoverability: the AI tools were buried behind the "More" nav
+ * dropdown where few people found them. Mounted once in the root layout.
+ *
+ * Positioning reuses the signup bar's `body[data-signup-bar="visible"]`
+ * attribute to lift above the sticky CTA when it's showing, so the two never
+ * overlap.
+ */
+export function FloatingChat() {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const pathname = usePathname();
+
+  // Close on outside click or Escape while the menu is open.
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  // Don't show the launcher on the chat destinations themselves — you're
+  // already there, so a "get help" bubble would be redundant.
+  if (pathname.startsWith("/support") || pathname.startsWith("/agent")) {
+    return null;
+  }
+
+  return (
+    <>
+      <style>{`
+        .vt-fab-wrap { position: fixed; right: 20px; bottom: 20px; z-index: 60; }
+        body[data-signup-bar="visible"] .vt-fab-wrap { bottom: 88px; }
+
+        .vt-fab {
+          width: 56px; height: 56px; display: flex; align-items: center; justify-content: center;
+          background: var(--accent); color: #0A0A0E;
+          border: 2px solid var(--border-hard); box-shadow: 4px 4px 0 var(--border-hard);
+          cursor: pointer; border-radius: 4px;
+          transition: transform .12s ease, box-shadow .12s ease;
+        }
+        .vt-fab:hover { transform: translate(-2px, -2px); box-shadow: 6px 6px 0 var(--border-hard); }
+        .vt-fab:active { transform: translate(2px, 2px); box-shadow: 2px 2px 0 var(--border-hard); }
+
+        .vt-fab-menu {
+          position: absolute; right: 0; bottom: calc(100% + 12px); width: 264px;
+          background: var(--bg-surface); border: 2px solid var(--border-hard);
+          box-shadow: 4px 4px 0 var(--border-hard); overflow: hidden;
+          animation: vt-fab-in .14s ease-out;
+        }
+        @keyframes vt-fab-in { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: translateY(0); } }
+
+        .vt-fab-head {
+          padding: 10px 14px; font-size: 11px; font-weight: 800; text-transform: uppercase;
+          letter-spacing: .06em; color: var(--text-muted);
+          background: var(--bg-inverted); border-bottom: 2px solid var(--border-hard);
+        }
+        .vt-fab-item { display: flex; align-items: center; gap: 12px; padding: 14px; text-decoration: none; color: var(--foreground); transition: background .12s ease; }
+        .vt-fab-item + .vt-fab-item { border-top: 2px solid var(--border-hard); }
+        .vt-fab-item:hover { background: var(--bg-inverted); }
+        .vt-fab-ico {
+          width: 36px; height: 36px; flex-shrink: 0; display: flex; align-items: center; justify-content: center;
+          background: var(--bg-inverted); border: 2px solid var(--border-hard); color: var(--accent);
+          transition: background .12s ease, color .12s ease;
+        }
+        .vt-fab-item:hover .vt-fab-ico { background: var(--accent); color: #0A0A0E; }
+        .vt-fab-title { display: block; font-size: 14px; font-weight: 800; text-transform: uppercase; letter-spacing: .02em; line-height: 1.1; }
+        .vt-fab-sub { display: block; font-size: 12px; color: var(--text-muted); font-weight: 500; margin-top: 3px; }
+      `}</style>
+
+      <div className="vt-fab-wrap" ref={wrapRef}>
+        {open && (
+          <div className="vt-fab-menu" role="menu" aria-label="Chat options">
+            <div className="vt-fab-head">How can we help?</div>
+            <Link href="/support" className="vt-fab-item" role="menuitem" onClick={() => setOpen(false)}>
+              <span className="vt-fab-ico"><LifeBuoy size={18} /></span>
+              <span>
+                <span className="vt-fab-title">Get help</span>
+                <span className="vt-fab-sub">Questions &amp; support</span>
+              </span>
+            </Link>
+            <Link href="/agent/chat" className="vt-fab-item" role="menuitem" onClick={() => setOpen(false)}>
+              <span className="vt-fab-ico"><Search size={18} /></span>
+              <span>
+                <span className="vt-fab-title">Find talent</span>
+                <span className="vt-fab-sub">Match with builders</span>
+              </span>
+            </Link>
+          </div>
+        )}
+
+        <button
+          type="button"
+          className="vt-fab"
+          onClick={() => setOpen((v) => !v)}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          aria-label={open ? "Close chat menu" : "Open chat menu"}
+        >
+          {open ? <X size={24} /> : <MessageCircle size={24} />}
+        </button>
+      </div>
+    </>
+  );
+}

--- a/src/components/support/support-chat.tsx
+++ b/src/components/support/support-chat.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import { Bot } from "lucide-react";
+import { ChatMessage } from "@/components/agent/chat-message";
+import { ChatInput } from "@/components/agent/chat-input";
+
+interface Msg {
+  id: string;
+  role: "user" | "agent";
+  content: string;
+}
+
+const GREETING =
+  "Hi! I'm VibeFinder Support. Ask me anything about VibeTalent — vibe scores, streaks, adding projects, hiring, badges, or your account.";
+
+const SUGGESTIONS = [
+  "How does my vibe score work?",
+  "Why hasn't my streak updated?",
+  "How do I add a project?",
+  "How does hiring work?",
+];
+
+export function SupportChat() {
+  const [messages, setMessages] = useState<Msg[]>([
+    { id: "greeting", role: "agent", content: GREETING },
+  ]);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+  }, [messages, isStreaming]);
+
+  const send = useCallback(
+    async (text: string) => {
+      if (isStreaming) return;
+
+      const userMsg: Msg = { id: `u-${Date.now()}`, role: "user", content: text };
+      const agentId = `a-${Date.now()}`;
+
+      // Build the API payload BEFORE mutating state: full history + this turn,
+      // minus the client-only greeting, mapped to the API's role names.
+      const payload = [...messages, userMsg]
+        .filter((m) => m.id !== "greeting")
+        .map((m) => ({
+          role: m.role === "agent" ? "assistant" : "user",
+          content: m.content,
+        }));
+
+      // Optimistically render the user message + an empty agent bubble to stream into.
+      setMessages((prev) => [...prev, userMsg, { id: agentId, role: "agent", content: "" }]);
+      setIsStreaming(true);
+
+      const setAgent = (content: string) =>
+        setMessages((prev) => prev.map((m) => (m.id === agentId ? { ...m, content } : m)));
+
+      try {
+        const res = await fetch("/api/support/chat", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ messages: payload }),
+        });
+
+        if (!res.ok || !res.body) {
+          const data = (await res.json().catch(() => null)) as { error?: string } | null;
+          setAgent(data?.error || "Something went wrong. Please try again.");
+          return;
+        }
+
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let acc = "";
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          acc += decoder.decode(value, { stream: true });
+          setAgent(acc);
+        }
+        if (!acc.trim()) {
+          setAgent("Sorry, I didn't catch that. Could you rephrase?");
+        }
+      } catch {
+        setAgent("Connection issue. Please try again.");
+      } finally {
+        setIsStreaming(false);
+      }
+    },
+    [messages, isStreaming]
+  );
+
+  const showSuggestions = messages.length === 1 && !isStreaming;
+
+  return (
+    <div
+      className="mx-auto max-w-3xl px-4 sm:px-6 py-4 sm:py-6 flex flex-col"
+      style={{ height: "calc(100dvh - 64px)" }}
+    >
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-6 shrink-0">
+        <div
+          className="w-10 h-10 flex items-center justify-center"
+          style={{
+            backgroundColor: "var(--bg-inverted)",
+            border: "2px solid var(--border-hard)",
+            boxShadow: "3px 3px 0 var(--accent)",
+          }}
+        >
+          <Bot size={20} className="text-[var(--accent)]" />
+        </div>
+        <div>
+          <h1 className="text-xl font-extrabold uppercase text-[var(--foreground)]">Support</h1>
+          <p className="text-xs text-[var(--text-muted)] font-bold uppercase">VibeFinder Support Bot</p>
+        </div>
+      </div>
+
+      {/* Messages */}
+      <div ref={scrollRef} className="flex-1 overflow-y-auto space-y-4 pb-4">
+        {messages.map((msg) => {
+          // An empty agent bubble only exists transiently while we wait for the
+          // first streamed token — render it as the animated "thinking" state.
+          const thinking = msg.role === "agent" && msg.content === "" && isStreaming;
+          return <ChatMessage key={msg.id} role={msg.role} content={msg.content} isThinking={thinking} />;
+        })}
+
+        {showSuggestions && (
+          <div className="flex flex-wrap gap-2 ml-11 mt-2">
+            {SUGGESTIONS.map((s) => (
+              <button
+                key={s}
+                onClick={() => send(s)}
+                className="btn-brutal text-xs py-2 px-4"
+                style={{ backgroundColor: "var(--bg-surface)", boxShadow: "var(--shadow-brutal-sm)" }}
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Input */}
+      <div className="shrink-0 pt-4" style={{ borderTop: "2px solid var(--border-hard)" }}>
+        <ChatInput onSend={send} disabled={isStreaming} placeholder="Ask a support question..." />
+      </div>
+    </div>
+  );
+}

--- a/src/lib/deepseek.ts
+++ b/src/lib/deepseek.ts
@@ -1,0 +1,90 @@
+// Server-only DeepSeek client.
+//
+// DeepSeek exposes an OpenAI-compatible Chat Completions API, so we call it
+// with plain `fetch` — no SDK, no added bundle weight, and it runs cleanly on
+// the Cloudflare Workers runtime (WHATWG streams are native there).
+//
+// Swapping providers later (e.g. Cloudflare Workers AI once the DeepSeek
+// credit runs out) is a change to this one file — nothing else imports the
+// provider directly.
+
+const DEEPSEEK_URL = "https://api.deepseek.com/chat/completions";
+const MODEL = "deepseek-chat"; // V3: fast + cheap. deepseek-reasoner is overkill for support.
+
+export interface ChatMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+/** Whether the DeepSeek API key is configured on the server. */
+export function hasDeepSeekKey(): boolean {
+  return !!process.env.DEEPSEEK_API_KEY;
+}
+
+/**
+ * Stream a chat completion from DeepSeek.
+ *
+ * Returns a ReadableStream of plain-text tokens (the assistant's message
+ * deltas), so the browser can append them directly without parsing SSE.
+ *
+ * Throws if the key is missing or DeepSeek returns a non-OK status.
+ */
+export async function streamDeepSeekChat(
+  messages: ChatMessage[]
+): Promise<ReadableStream<Uint8Array>> {
+  const apiKey = process.env.DEEPSEEK_API_KEY;
+  if (!apiKey) throw new Error("DEEPSEEK_API_KEY is not configured");
+
+  const upstream = await fetch(DEEPSEEK_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      messages,
+      stream: true,
+      temperature: 0.3, // factual, low creativity for support answers
+      max_tokens: 800,
+    }),
+  });
+
+  if (!upstream.ok || !upstream.body) {
+    const detail = await upstream.text().catch(() => "");
+    throw new Error(
+      `DeepSeek request failed (${upstream.status}): ${detail.slice(0, 200)}`
+    );
+  }
+
+  // Transform DeepSeek's SSE stream into a plain-text token stream.
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  let buffer = "";
+
+  return upstream.body.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        buffer += decoder.decode(chunk, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? ""; // keep any trailing partial line for the next chunk
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed.startsWith("data:")) continue;
+          const data = trimmed.slice(5).trim();
+          if (data === "[DONE]") continue;
+          try {
+            const json = JSON.parse(data);
+            const token = json.choices?.[0]?.delta?.content;
+            if (typeof token === "string" && token) {
+              controller.enqueue(encoder.encode(token));
+            }
+          } catch {
+            // Ignore keep-alive pings / non-JSON lines.
+          }
+        }
+      },
+    })
+  );
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -75,3 +75,5 @@ export const projectsLimiter = createRateLimiter("projects", 30, "1 m");
 export const buildersLimiter = createRateLimiter("builders", 30, "1 m");
 export const hireApiLimiter = createRateLimiter("hire-api", 5, "1 h");
 export const feedbackLimiter = createRateLimiter("feedback", 10, "1 h");
+// Support chat calls a paid LLM — keep this tight to protect the API budget.
+export const supportLimiter = createRateLimiter("support", 15, "5 m");

--- a/src/lib/support-knowledge.ts
+++ b/src/lib/support-knowledge.ts
@@ -1,0 +1,73 @@
+// Knowledge base + behavior rules injected as the system prompt for the
+// in-app support assistant.
+//
+// This is the bot's single source of truth. Keep it in sync with how the
+// platform actually works — if a fact isn't here, the bot is instructed to say
+// it doesn't know and point the user to human support rather than guess.
+
+export const SUPPORT_EMAIL = "vibetalentwork@gmail.com";
+
+export const SUPPORT_SYSTEM_PROMPT = `You are VibeFinder Support, the friendly in-app support assistant for VibeTalent.
+
+VibeTalent is a marketplace for "vibe coders" — developers who build with AI-powered tools (Claude Code, Cursor, Bolt, Windsurf). It ranks developers on verifiable proof of work (GitHub activity, shipped projects, coding streaks) instead of resumes.
+
+# What you help with
+Answer questions about how VibeTalent works: vibe scores, streaks, badges, projects, hiring, endorsements, reviews, the leaderboard, and general account questions.
+
+# Facts (your only source of truth)
+
+## Vibe Score
+The core reputation metric — one number for how consistently and effectively a developer ships. It is calculated from four weighted components:
+- Streak Days — 40%
+- Project Quality — 30% (GitHub repo health: stars, forks, commit frequency, README, deployment status)
+- GitHub Activity — 20% (commits, pull requests, code reviews, issues)
+- Peer Endorsements — 10% (endorsements from higher-scored developers count for more)
+It updates daily and is based entirely on public, verifiable data. It cannot be gamed with fake reviews or purchased followers.
+
+## Coding Streaks
+- A streak = consecutive days with at least one commit to any PUBLIC GitHub repo.
+- Synced from GitHub daily.
+- Resets to zero if a full calendar day (UTC) passes with no commits.
+- Your longest/historical streak is preserved on your profile even after a reset.
+- Commits to private repos do NOT count — VibeTalent only reads public GitHub activity.
+
+## Badges (permanent once earned)
+- Bronze — 30-day streak
+- Silver — 90-day streak
+- Gold — 180-day streak
+- Diamond — 365-day streak
+
+## Projects
+- Add projects from your dashboard/profile using the "Add Project" flow — each links to a GitHub repo (and optionally a live URL).
+- Projects are automatically verified and quality-scored against GitHub when you add them. This is the only way to add a project so it gets scored.
+
+## GitHub connection
+- VibeTalent connects to GitHub with public read-only access only. It never asks for private-repo permissions. So only public activity is visible and counted.
+
+## Hiring
+- Hiring is direct and completely free — there are no platform fees and no middleman.
+- Open any builder's profile, click "Hire", and message them directly.
+- Clients can also use VibeFinder Bot (at /agent and /agent/chat) to describe a project and get matched with builders.
+
+## Endorsements & Reviews
+- Users can endorse other builders for specific skills; endorsements from higher-scored developers carry more weight.
+- Builders can receive reviews on their profile.
+
+## Pricing
+- VibeTalent is free for developers: profiles, GitHub connection, streaks, badges, projects, and getting hired all cost nothing.
+- The only optional paid feature is Featured Projects/promotions — paying to feature a project for extra visibility. It is purely optional and does NOT affect vibe score, badges, or ranking. Featured promotions are paid in USDC (crypto).
+
+## Key pages
+- /explore — browse and filter all builders (by language, framework, streak, badge, vibe score)
+- /leaderboard — top builders by vibe score
+- /feed — live GitHub activity feed
+- /agent and /agent/chat — VibeFinder Bot for talent matching
+- /dashboard — your own profile, streak, and projects
+
+# How to answer
+- Be warm, concise, and helpful. A few sentences is usually enough. Use short paragraphs or simple "- " bullets.
+- Write PLAIN TEXT ONLY — no markdown formatting whatsoever. Do not use **bold**, *italics*, backticks, #headings, or tables. The text renders literally in a plain chat bubble, so any markdown symbols show up as ugly stray characters. To emphasize something, just say it in words.
+- Only answer using the facts above. If a question isn't covered, or is account-specific (billing disputes, "why was my account flagged", a bug, a refund, or anything requiring access to a user's private data), say you're not certain and ask them to email ${SUPPORT_EMAIL} for direct help.
+- You do NOT have access to live user data. Never invent or guess usernames, vibe scores, streak counts, or any specific builder's stats. If asked about a specific person's numbers, explain they can view those on the profile or Explore page.
+- Do not give financial or investment advice about USDC, crypto, or any token. For payments, explain how Featured Projects work in general terms only.
+- If asked something unrelated to VibeTalent, gently steer back to how you can help with the platform.`;


### PR DESCRIPTION
## What

Makes VibeTalent's AI both **supported** and **discoverable**:

1. **Support bot** at `/support` — a DeepSeek-powered chat answering questions about vibe scores, streaks, projects, hiring, badges, etc.
2. **Floating chat launcher** — a site-wide bottom-right button that expands into a mini-menu: **Get help** (→ `/support`) and **Find talent** (→ `/agent/chat`). Fixes discoverability — the AI tools were buried under the "More" nav dropdown.

## ⚠️ Required before merge (or the bot 503s in prod)

The support bot reads `DEEPSEEK_API_KEY` from `process.env`. It is **not** set on the prod Worker (only in local `.env.local`). Set it before/at merge:

```bash
npx wrangler secret put DEEPSEEK_API_KEY
```

Without it the bot **503s gracefully** ("Support chat isn't set up yet…") — the FAB and `/support` page still render, the bot just won't answer. Rate-limited to **15 req / 5 min per IP** to protect the API budget (note: relies on valid Upstash creds on the Worker).

## How it's built

- `src/lib/deepseek.ts` — dependency-free streaming client (DeepSeek is OpenAI-compatible → raw `fetch`, Workers-safe). Swapping providers later = this one file.
- `src/lib/support-knowledge.ts` — system prompt / knowledge base with plain-text + no-hallucination guardrails (never invents builders or scores).
- `src/app/api/support/chat/route.ts` — streaming POST, `supportLimiter` rate-limit, 503 when the key is unset.
- `src/components/support/support-chat.tsx` + `src/app/support/{layout,page}.tsx` — reuses the agent `ChatMessage`/`ChatInput`; `.chat-page-wrapper` hides the global footer.
- `src/components/layout/floating-chat.tsx` — the FAB; hidden on `/support` + `/agent`; reuses `body[data-signup-bar="visible"]` to lift above the signup bar.

## Verified

- ✅ `eslint src` clean · `tsc --noEmit` clean for feature files
- ✅ Live browser test: real DeepSeek responses, accurate KB answers, plain-text output, hallucination guard holds ("who is abhinav?" correctly deflected)
- ✅ FAB verified on desktop **and** mobile: menu opens upward, links correct, hidden on chat pages, no signup-bar collision

## Note on "beta"

There is no isolated beta environment — `beta.vibetalent.work` points at the **same prod Worker** as `www`. So merging this to `main` deploys it to production for all users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-app support chat with streaming assistant responses.
  * Added a floating chat menu linking to support and talent chat experiences.
  * Added a dedicated support page with contextual guidance and suggested prompts.
  * Added safeguards for invalid, excessive, or rate-limited chat requests.
  * Added fallback messaging when support chat services are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->