### PR TITLE
fix(ui): warm-grey image placeholders to kill white flash on load

### DIFF
--- a/src/components/feed/network-feed.tsx
+++ b/src/components/feed/network-feed.tsx
@@ -109,7 +109,7 @@ const FEED_STYLES = `
 .fl-feed-item--badge-silver { border-left-color: var(--badge-silver, #c0c0c0); }
 .fl-feed-item--badge-gold { border-left-color: var(--badge-gold, #ffd700); }
 .fl-feed-item--badge-diamond { border-left-color: var(--badge-diamond, #b9f2ff); }
-.fl-avatar { width: 48px; height: 48px; border-radius: 50%; background: var(--bg-surface, #15151A); border: 1px solid var(--border-hard, #2A2A33); display: flex; align-items: center; justify-content: center; flex-shrink: 0; overflow: hidden; }
+.fl-avatar { width: 48px; height: 48px; border-radius: 50%; background: var(--bg-surface-light, #15151A); border: 1px solid var(--border-hard, #2A2A33); display: flex; align-items: center; justify-content: center; flex-shrink: 0; overflow: hidden; }
 .fl-avatar img { width: 100%; height: 100%; object-fit: cover; opacity: 1; }
 .fl-avatar.orange { background: var(--accent, #FF4A2A); border-color: var(--accent, #FF4A2A); color: #0A0A0E; font-weight: 600; font-size: 14px; }
 .fl-tag { display: inline-flex; align-items: center; gap: 4px; padding: 2px 8px; border-radius: 999px; font-size: 12px; font-weight: 500; vertical-align: middle; margin: 0 4px; }

--- a/src/components/ui/live-activity-feed.tsx
+++ b/src/components/ui/live-activity-feed.tsx
@@ -69,7 +69,7 @@ function actionText(item: GroupedItem): string {
   return item.count > 1 ? `${item.count} commits` : "pushed";
 }
 
-const AVATAR_COLORS = ["#ff4400", "#4a4a4a", "#ffffff", "#ff4400", "#4a4a4a", "#ffffff"];
+const AVATAR_COLORS = ["#ff4400", "#4a4a4a", "var(--bg-surface-light)", "#ff4400", "#4a4a4a", "var(--bg-surface-light)"];
 
 const FRAME_STYLE: CSSProperties = {
   width: "100%",

--- a/src/components/ui/project-card.tsx
+++ b/src/components/ui/project-card.tsx
@@ -15,11 +15,12 @@ import { normalizeExternalUrl, normalizeRepoUrl } from "@/lib/url-normalize";
 function ProjectImageBanner({ url, alt }: { url: string; alt: string }) {
   const crop = parseImageCrop(url);
   return (
-    <div className="relative w-full h-28 border-b-2 border-[var(--border-hard)] overflow-hidden" style={{ backgroundColor: "#ffffff" }}>
+    <div className="relative w-full h-28 border-b-2 border-[var(--border-hard)] overflow-hidden bg-[var(--bg-surface-light)]">
       <Image
         src={url}
         alt={alt}
         fill
+        sizes="(max-width: 768px) 100vw, 360px"
         className="object-cover"
         style={{ objectPosition: crop.objectPosition, transform: `scale(${crop.scale})` }}
       />


### PR DESCRIPTION
## What

Fixes the **white flash** that appeared on image load — on the homepage "What are vibe coders building?" project cards and on builder avatars.

## Root cause

Every dynamic image uses `next/image` with no placeholder/blur. During the Cloudflare image-optimizer's load window the `<img>` is transparent, so whatever background sits *behind* it shows through. Three spots hardcoded a pure **white** background — jarring on the warm-grey dark theme (where white is reserved for primary elements only):

- `project-card.tsx:18` — `ProjectImageBanner` container `backgroundColor: "#ffffff"` (both themes)
- `live-activity-feed.tsx:72` — `AVATAR_COLORS` hardcodes `#ffffff` for every 3rd avatar cell (both themes)
- `network-feed.tsx:112` — `.fl-avatar` uses `var(--bg-surface)` = `#FFFFFF` in light mode

## Fix

Swap each white background for the warm-grey **`--bg-surface-light`** token — the exact value the project card's own no-image fallback already uses — so the placeholder matches the theme instead of flashing white. Also added a `sizes` hint on the card thumbnail so the optimizer picks a card-sized candidate (faster paint, shorter flash window, drops the next/image console warning).

Kept it a **pure color swap** (no `onLoad`/JS state), so there's zero risk of images getting stuck invisible on cached loads.

## Verified (dark mode, local)

- Project-card thumbnail placeholders now compute to `rgb(40,37,37)` (warm grey) — was `rgb(255,255,255)`
- 0 white avatar cells, 0 elements with a white inline background on the homepage
- `eslint src` + `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated avatar and activity tiles to use the light surface color, improving visual consistency across feeds.
  * Refined project image banner styling for a more cohesive appearance.

* **Bug Fixes**
  * Improved responsive project banner image sizing so images display more appropriately across mobile and desktop screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->