### PR TITLE
perf(images): Cloudflare edge image transformations (/cdn-cgi/image loader)

### DIFF
--- a/image-loader.ts
+++ b/image-loader.ts
@@ -1,0 +1,39 @@
+// Custom next/image loader → Cloudflare Image Transformations.
+//
+// Routes every <Image> through /cdn-cgi/image/<opts>/<src>, which Cloudflare's
+// edge CDN transforms ONCE and then serves from cache (cf-cache-status: HIT).
+// The previous path (@opennextjs/cloudflare's IMAGES binding) re-transformed
+// remote images on every request and set no Cache-Control — the root cause of
+// the slow, uncached image loads.
+//
+// Requires (Cloudflare dashboard → Images → Transformations):
+//   1. Transformations enabled on the vibetalent.work zone.
+//   2. Source hosts allow-listed under "Sources": okxjdenxztzuqqlekqdb.supabase.co,
+//      avatars.githubusercontent.com, lh3.googleusercontent.com, unavatar.io.
+// Until both are done, /cdn-cgi/image/... 404s — do not deploy this before then.
+
+interface CloudflareLoaderArgs {
+  src: string;
+  width: number;
+  quality?: number;
+}
+
+// The segment after the options is an absolute path OR a full URL. Strip the
+// leading slash on local /public paths; leave remote https:// URLs (Supabase +
+// avatar hosts, query string included) untouched.
+function normalizeSrc(src: string): string {
+  return src.startsWith("/") ? src.slice(1) : src;
+}
+
+export default function cloudflareImageLoader({ src, width, quality }: CloudflareLoaderArgs): string {
+  // data:/blob: images can't be transformed — pass through untouched.
+  if (src.startsWith("data:") || src.startsWith("blob:")) return src;
+
+  // Local dev has no /cdn-cgi/ endpoint — load the original source directly so
+  // `next dev` still works.
+  if (process.env.NODE_ENV === "development") return src;
+
+  const params = [`width=${width}`, "format=auto"];
+  if (quality) params.push(`quality=${quality}`);
+  return `/cdn-cgi/image/${params.join(",")}/${normalizeSrc(src)}`;
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -26,8 +26,15 @@ const securityHeaders = [
 
 const nextConfig: NextConfig = {
   images: {
-    formats: ["image/avif", "image/webp"],
-    minimumCacheTTL: 2592000,
+    // Route next/image through Cloudflare Image Transformations (/cdn-cgi/image)
+    // so results are edge-cached instead of re-transformed per request by the
+    // OpenNext IMAGES binding. Format negotiation happens via format=auto in the
+    // loader; `formats`/`minimumCacheTTL` are ignored once a custom loader is set
+    // (minimumCacheTTL was already a no-op on @opennextjs/cloudflare). See
+    // image-loader.ts for the required Cloudflare dashboard setup.
+    loader: "custom",
+    loaderFile: "./image-loader.ts",
+    // Kept so <Image src> host validation stays strict even with the custom loader.
     remotePatterns: [
       {
         protocol: "https",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -313,10 +313,11 @@ export default async function HomePage() {
             // grid on sm+. Keep stagger-children so the entrance animation
             // still cascades down the column.
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6 lg:grid-cols-3 stagger-children">
-              {featuredProjects.map((project) => (
+              {featuredProjects.map((project, i) => (
                 <ProjectCard
                   key={project.id}
                   project={project}
+                  priority={i < 3}
                   verified={!!project.verified}
                   authorUsername={project.users?.username ?? undefined}
                 />

--- a/src/components/ui/project-card.tsx
+++ b/src/components/ui/project-card.tsx
@@ -12,7 +12,7 @@ import { createClient } from "@/lib/supabase/client";
 import { parseImageCrop } from "@/lib/image-crop";
 import { normalizeExternalUrl, normalizeRepoUrl } from "@/lib/url-normalize";
 
-function ProjectImageBanner({ url, alt }: { url: string; alt: string }) {
+function ProjectImageBanner({ url, alt, priority }: { url: string; alt: string; priority?: boolean }) {
   const crop = parseImageCrop(url);
   return (
     <div className="relative w-full h-28 border-b-2 border-[var(--border-hard)] overflow-hidden bg-[var(--bg-surface-light)]">
@@ -21,6 +21,7 @@ function ProjectImageBanner({ url, alt }: { url: string; alt: string }) {
         alt={alt}
         fill
         sizes="(max-width: 768px) 100vw, 360px"
+        priority={priority}
         className="object-cover"
         style={{ objectPosition: crop.objectPosition, transform: `scale(${crop.scale})` }}
       />
@@ -69,9 +70,11 @@ interface ProjectCardProps {
   verified?: boolean;
   onEdit?: (project: Project) => void;
   onVerify?: (projectId: string) => void;
+  /** Eager-load the thumbnail (above-the-fold cards) instead of lazy-loading. */
+  priority?: boolean;
 }
 
-export function ProjectCard({ project, authorUsername, onEdit, showReport = true, verified = false, onVerify }: ProjectCardProps) {
+export function ProjectCard({ project, authorUsername, onEdit, showReport = true, verified = false, onVerify, priority = false }: ProjectCardProps) {
   const [reportOpen, setReportOpen] = useState(false);
   const [reported, setReported] = useState(() => !!getReportData(project.id));
   const [reporting, setReporting] = useState(false);
@@ -149,7 +152,7 @@ export function ProjectCard({ project, authorUsername, onEdit, showReport = true
       className="card-brutal h-full flex flex-col transition-all hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-[2px_2px_0_var(--border-hard)]"
     >
       {project.image_url ? (
-        <ProjectImageBanner url={project.image_url} alt={project.title} />
+        <ProjectImageBanner url={project.image_url} alt={project.title} priority={priority} />
       ) : (
         <div className="w-full h-28 border-b-2 border-[var(--border-hard)] bg-[var(--bg-surface-light)] flex items-center justify-center">
           <span className="text-3xl font-extrabold uppercase text-[var(--text-muted-soft)] tracking-widest select-none">{project.title?.charAt(0) ?? "P"}</span>


### PR DESCRIPTION
## ⚠️ DRAFT — do NOT merge until Cloudflare Transformations are enabled

Merging before the dashboard steps below **404s every image on the site**. Kept as a draft until the prod gate passes.

## What & why

Images are slow because `/_next/image` runs through the OpenNext **`IMAGES` binding**, which — per the maintainer ([issue #1125](https://github.com/opennextjs/opennextjs-cloudflare/issues/1125)) — *"is not good at caching"*: it re-transforms remote images on **every request** and sets no `Cache-Control`. Measured on prod: **zero cache hits**, a 2 KB avatar taking 448 ms, and project thumbnails unloaded for 10+ seconds.

This switches `next/image` to a **custom `/cdn-cgi/image/` loader** (Cloudflare edge Image Transformations). Those URLs are transformed **once** then served from Cloudflare's edge cache (`cf-cache-status: HIT`) — the maintainer-recommended caching fix. Plus `priority` on the first row of homepage cards so above-the-fold thumbnails eager-load.

**Free:** 5,000 unique transforms/month on all plans; over-limit just errors (never charges). Edge-caching means this *reduces* transform usage vs the always-re-transforming binding.

## 🚦 Required BEFORE merge (Cloudflare dashboard)
1. **Images → Transformations** → select the `vibetalent.work` zone → **Enable transformations**
2. **Sources** → allow-list these exact hosts: `okxjdenxztzuqqlekqdb.supabase.co`, `avatars.githubusercontent.com`, `lh3.googleusercontent.com`, `unavatar.io`
3. Gate check (must return 200 before un-drafting):
   ```
   curl -sI "https://www.vibetalent.work/cdn-cgi/image/width=96,format=auto/https://avatars.githubusercontent.com/u/1?v=4"
   ```
   → `HTTP 200`, `content-type: image/avif` or `image/webp`

## Changes
- `image-loader.ts` (new) — `data:`/`blob:`-guarded loader; dev guard returns raw src so `next dev` works
- `next.config.ts` — `images.loader: 'custom'` + `loaderFile` (drops the no-op `formats`/`minimumCacheTTL`)
- `project-card.tsx` + `page.tsx` — thread `priority` to the first 3 cards

## Verified
- ✅ `eslint` + `tsc` clean; dev boots and thumbnails render directly from Supabase (dev guard path)
- ⏳ Prod checks (request URLs → `/cdn-cgi/image`, `cf-cache-status: HIT` on 2nd fetch, faster loads, unavatar + Google `=s96-c` avatars still render) run after enable + merge

## Rollback
Clean `git revert` → images route back to today's (working, just uncached) `/_next/image` path. No data or infra state to unwind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
