### PR TITLE
perf+security: DB indexes, RLS initplan fix, drop over-permissive RLS policies, gate pollers

### DIFF
--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -13,7 +13,7 @@ const ALLOWED_NOTIFICATION_TYPES = [
   "referral_prompt",
 ] as const;
 
-export async function GET() {
+export async function GET(req: NextRequest) {
   try {
     const supabase = await createServerSupabaseClient();
     const { data: { user } } = await supabase.auth.getUser();
@@ -24,6 +24,19 @@ export async function GET() {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sb = supabase as any;
+
+    // The bell polls this endpoint on an interval purely to keep its unread
+    // badge current; it doesn't need the (up to 50-row) list until the user
+    // opens the dropdown. `?count=1` returns just the count so background
+    // polls stay cheap on payload + Supabase egress.
+    if (req.nextUrl.searchParams.get("count") === "1") {
+      const { count } = await sb
+        .from("notifications")
+        .select("*", { count: "exact", head: true })
+        .eq("user_id", user.id)
+        .eq("read", false);
+      return NextResponse.json({ data: [], unread_count: count || 0 });
+    }
 
     const [{ data, error }, { count }] = await Promise.all([
       sb

--- a/src/components/ui/live-activity-feed.tsx
+++ b/src/components/ui/live-activity-feed.tsx
@@ -161,10 +161,14 @@ export function LiveActivityFeed() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    let cancelled = false;
+    let interval: ReturnType<typeof setInterval> | null = null;
+
     function fetchFeed() {
       fetch("/api/feed?limit=20")
         .then((r) => r.json())
         .then((d) => {
+          if (cancelled) return;
           // Drop any event types this snippet can't render correctly.
           const items: FeedItem[] = (d.feed || []).filter(
             (i: FeedItem) => SUPPORTED_LEGACY_TYPES.has(i.type),
@@ -174,13 +178,47 @@ export function LiveActivityFeed() {
           setError(null);
         })
         .catch(() => {
+          if (cancelled) return;
           setError("Couldn't load live activity");
           setLoaded(true);
         });
     }
+
+    // Pause polling while the tab is hidden so background tabs don't keep
+    // hitting /api/feed (burning Cloudflare Worker invocations + Supabase
+    // egress) for content nobody is looking at; resume with an immediate
+    // re-sync on focus. Mirrors components/feed/network-feed.
+    const startPolling = () => {
+      if (interval !== null) return;
+      interval = setInterval(fetchFeed, 30000);
+    };
+    const stopPolling = () => {
+      if (interval === null) return;
+      clearInterval(interval);
+      interval = null;
+    };
+    const onVisibilityChange = () => {
+      if (typeof document === "undefined") return;
+      if (document.hidden) {
+        stopPolling();
+      } else {
+        fetchFeed();
+        startPolling();
+      }
+    };
+
     fetchFeed();
-    const interval = setInterval(fetchFeed, 30000);
-    return () => clearInterval(interval);
+    startPolling();
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", onVisibilityChange);
+    }
+    return () => {
+      cancelled = true;
+      stopPolling();
+      if (typeof document !== "undefined") {
+        document.removeEventListener("visibilitychange", onVisibilityChange);
+      }
+    };
   }, []);
 
   const grouped = useMemo(() => groupFeedItems(feed).slice(0, 6), [feed]);

--- a/src/components/ui/notification-bell.tsx
+++ b/src/components/ui/notification-bell.tsx
@@ -96,17 +96,62 @@ export function NotificationBell() {
     }
   }, []);
 
+  // Lightweight badge-only refresh for the polling loop: skips the notification
+  // list (fetched lazily when the dropdown opens) and returns just the count.
+  const fetchUnreadCount = useCallback(async () => {
+    try {
+      const res = await fetch("/api/notifications?count=1");
+      if (!res.ok) return;
+      const data = await res.json();
+      setUnreadCount(data.unread_count || 0);
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
-    fetchNotifications();
-    const interval = setInterval(fetchNotifications, 60000);
-    const handleRefresh = () => fetchNotifications();
-    window.addEventListener("notifications-updated", handleRefresh);
-    return () => {
-      clearInterval(interval);
-      window.removeEventListener("notifications-updated", handleRefresh);
+    // Pause polling while the tab is hidden so background tabs don't keep
+    // hitting /api/notifications (burning Cloudflare Worker invocations +
+    // Supabase egress) for a badge nobody is looking at; resume with an
+    // immediate re-sync on focus. Mirrors components/feed/network-feed.
+    let interval: ReturnType<typeof setInterval> | null = null;
+    const startPolling = () => {
+      if (interval !== null) return;
+      interval = setInterval(fetchUnreadCount, 60000);
     };
-  }, [fetchNotifications]);
+    const stopPolling = () => {
+      if (interval === null) return;
+      clearInterval(interval);
+      interval = null;
+    };
+    const onVisibilityChange = () => {
+      if (typeof document === "undefined") return;
+      if (document.hidden) {
+        stopPolling();
+      } else {
+        fetchUnreadCount();
+        startPolling();
+      }
+    };
+    const handleRefresh = () => fetchNotifications();
+
+    // Initial load is the full fetch so the dropdown is populated the instant
+    // it's first opened; the repeating interval only needs the count.
+    fetchNotifications();
+    startPolling();
+    window.addEventListener("notifications-updated", handleRefresh);
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", onVisibilityChange);
+    }
+    return () => {
+      stopPolling();
+      window.removeEventListener("notifications-updated", handleRefresh);
+      if (typeof document !== "undefined") {
+        document.removeEventListener("visibilitychange", onVisibilityChange);
+      }
+    };
+  }, [fetchNotifications, fetchUnreadCount]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
   // Click outside to close
@@ -160,7 +205,12 @@ export function NotificationBell() {
   return (
     <div className="relative" ref={ref}>
       <button
-        onClick={() => setOpen(!open)}
+        onClick={() => {
+          // Opening the dropdown: pull the fresh list (the interval only keeps
+          // the count current, so the list may be stale or unloaded).
+          if (!open) fetchNotifications();
+          setOpen((o) => !o);
+        }}
         className="relative w-10 h-10 flex items-center justify-center cursor-pointer transition-all hover:translate-x-[1px] hover:translate-y-[1px]"
         style={{
           backgroundColor: "var(--bg-surface)",

--- a/supabase/migrations/20260714_fk_covering_indexes.sql
+++ b/supabase/migrations/20260714_fk_covering_indexes.sql
@@ -1,0 +1,22 @@
+-- Covering indexes for foreign keys flagged by Supabase's
+-- unindexed_foreign_keys performance advisor.
+--
+-- Each of these FK columns had no supporting index, so a join across the
+-- FK, and the parent-row reference check on ON DELETE / ON UPDATE, falls
+-- back to a sequential scan of the child table. Several of these columns
+-- also back RLS predicates (e.g. hire_requests.builder_id = auth.uid(),
+-- referrals.referrer_id = auth.uid()), so the index also speeds up policy
+-- enforcement on every access, not just explicit joins.
+--
+-- All IF NOT EXISTS (idempotent). Plain (non-CONCURRENT) form: these
+-- tables are small and the brief build lock is immaterial; CONCURRENTLY
+-- cannot run inside a transaction.
+
+CREATE INDEX IF NOT EXISTS idx_featured_promotions_user_id ON public.featured_promotions (user_id);
+CREATE INDEX IF NOT EXISTS idx_hire_requests_builder_id     ON public.hire_requests (builder_id);
+CREATE INDEX IF NOT EXISTS idx_profile_views_viewer_user_id ON public.profile_views (viewer_user_id);
+CREATE INDEX IF NOT EXISTS idx_project_endorsements_user_id ON public.project_endorsements (user_id);
+CREATE INDEX IF NOT EXISTS idx_promoted_slots_project_id    ON public.promoted_slots (project_id);
+CREATE INDEX IF NOT EXISTS idx_promoted_slots_user_id       ON public.promoted_slots (user_id);
+CREATE INDEX IF NOT EXISTS idx_referrals_referrer_id        ON public.referrals (referrer_id);
+CREATE INDEX IF NOT EXISTS idx_reviews_hire_request_id      ON public.reviews (hire_request_id);

--- a/supabase/migrations/20260714_rls_drop_overpermissive_policies.sql
+++ b/supabase/migrations/20260714_rls_drop_overpermissive_policies.sql
@@ -1,0 +1,29 @@
+-- Security fix: remove three permissive RLS policies whose USING(true) /
+-- WITH CHECK(true) silently OR-override the narrower intended policies.
+-- Permissive policies combine with OR, and RLS is this app's only access
+-- gate, so each of these widened access well beyond intent.
+--
+-- 1. hire_requests: "Anyone can read hire requests by id" (SELECT USING true,
+--    role public) exposed EVERY row -- including sender_email (PII), message,
+--    and budget -- to the public anon key. All real reads are server-side
+--    (service role) or builder-scoped ("Builders can view their own
+--    requests", builder_id = auth.uid()); src/app/api/hire/messages/route.ts
+--    already comments "RLS now blocks anon reads", so this policy was stale
+--    leftover the app code already assumes is gone.
+--
+-- 2. hire_messages: "Anyone can send hire messages" (INSERT WITH CHECK true,
+--    role public) let an anonymous caller inject a message into any thread.
+--    Authenticated inserts remain covered by "Service role or authed users
+--    can insert hire messages" (auth.role()='service_role' OR auth.uid()
+--    IS NOT NULL); the server route inserts via the service client.
+--
+-- 3. feed_events: "feed_events_read" (SELECT USING true) OR-overrode
+--    "Public feed events are readable" (COALESCE(is_private,false)=false),
+--    making the is_private privacy gate a no-op. 0 private rows exist today,
+--    so this restores the intended gate with no visible change.
+--
+-- Reversible: re-create any policy from git history if a flow needs it.
+
+DROP POLICY IF EXISTS "Anyone can read hire requests by id" ON public.hire_requests;
+DROP POLICY IF EXISTS "Anyone can send hire messages" ON public.hire_messages;
+DROP POLICY IF EXISTS "feed_events_read" ON public.feed_events;

--- a/supabase/migrations/20260714_rls_initplan_fix.sql
+++ b/supabase/migrations/20260714_rls_initplan_fix.sql
@@ -1,0 +1,109 @@
+-- RLS initplan performance fix (Supabase advisor: auth_rls_initplan).
+--
+-- 29 policies called auth.uid() / auth.role() directly in their USING or
+-- WITH CHECK expression. Postgres re-evaluates a bare auth.<fn>() call
+-- once PER ROW, so on any scan the policy touches it runs N times. Wrapping
+-- the call in a scalar subquery -- (select auth.uid()) -- turns it into an
+-- InitPlan that Postgres evaluates ONCE per statement and caches. This is
+-- Supabase's documented fix and is strictly behaviour-preserving: the
+-- returned value is identical, only the evaluation count changes, so the
+-- set of rows each policy admits (and for which users) is unchanged.
+--
+-- Every rewrite below was independently regenerated and adversarially
+-- verified (29/29 equivalent, 0 access-changing) before being written here.
+-- Only the auth.<fn>() calls changed; columns, operators, boolean logic,
+-- roles, and commands are untouched. ALTER POLICY preserves command, roles,
+-- and permissive/restrictive; INSERT policies alter WITH CHECK only,
+-- SELECT/DELETE alter USING only, UPDATE/ALL alter USING (none of these had
+-- a distinct WITH CHECK).
+
+ALTER POLICY "Service role only" ON public.email_log
+  USING ((select auth.role()) = 'service_role'::text);
+
+ALTER POLICY "Users can manage their own email preferences" ON public.email_preferences
+  USING (user_id = (select auth.uid()));
+
+ALTER POLICY "Service role can insert feedback" ON public.feedback
+  WITH CHECK ((select auth.role()) = 'service_role'::text);
+
+ALTER POLICY "Builders can delete messages from their requests" ON public.hire_messages
+  USING (hire_request_id IN ( SELECT hire_requests.id
+     FROM hire_requests
+    WHERE (hire_requests.builder_id = (select auth.uid()))));
+
+ALTER POLICY "Service role or authed users can insert hire messages" ON public.hire_messages
+  WITH CHECK (((select auth.role()) = 'service_role'::text) OR ((select auth.uid()) IS NOT NULL));
+
+ALTER POLICY "Builders read own hire messages" ON public.hire_messages
+  USING (EXISTS ( SELECT 1
+     FROM hire_requests hr
+    WHERE ((hr.id = hire_messages.hire_request_id) AND (hr.builder_id = (select auth.uid())))));
+
+ALTER POLICY "Builders can delete own hire requests" ON public.hire_requests
+  USING ((select auth.uid()) = builder_id);
+
+ALTER POLICY "Builders can delete their own requests" ON public.hire_requests
+  USING (builder_id = (select auth.uid()));
+
+ALTER POLICY "Service role can insert hire requests" ON public.hire_requests
+  WITH CHECK (((select auth.role()) = 'service_role'::text) OR ((select auth.uid()) IS NOT NULL));
+
+ALTER POLICY "Builders can view their own requests" ON public.hire_requests
+  USING (builder_id = (select auth.uid()));
+
+ALTER POLICY "Builders can update their own requests" ON public.hire_requests
+  USING (builder_id = (select auth.uid()));
+
+ALTER POLICY "Users can view own notifications" ON public.notifications
+  USING ((select auth.uid()) = user_id);
+
+ALTER POLICY "Users can update own notifications" ON public.notifications
+  USING ((select auth.uid()) = user_id);
+
+ALTER POLICY "Users can view their own profile views" ON public.profile_views
+  USING (viewed_user_id = (select auth.uid()));
+
+ALTER POLICY "Authenticated users can endorse" ON public.project_endorsements
+  WITH CHECK ((select auth.uid()) IS NOT NULL);
+
+ALTER POLICY "Service role can delete reports" ON public.project_reports
+  USING ((select auth.role()) = 'service_role'::text);
+
+ALTER POLICY "Service role or authed users can submit reports" ON public.project_reports
+  WITH CHECK (((select auth.role()) = 'service_role'::text) OR ((select auth.uid()) IS NOT NULL));
+
+ALTER POLICY "Users can delete own projects" ON public.projects
+  USING ((select auth.uid()) = user_id);
+
+ALTER POLICY "Users can insert own projects" ON public.projects
+  WITH CHECK ((select auth.uid()) = user_id);
+
+ALTER POLICY "Public projects are viewable by everyone" ON public.projects
+  USING ((COALESCE(is_private, false) = false) OR ((select auth.uid()) = user_id));
+
+ALTER POLICY "Users can update own projects" ON public.projects
+  USING ((select auth.uid()) = user_id);
+
+ALTER POLICY "Service role can manage referrals" ON public.referrals
+  USING ((select auth.role()) = 'service_role'::text);
+
+ALTER POLICY "Users can view own referrals" ON public.referrals
+  USING (((select auth.uid()) = referrer_id) OR ((select auth.uid()) = referred_id));
+
+ALTER POLICY "Service role or authed users can submit reviews" ON public.reviews
+  WITH CHECK (((select auth.role()) = 'service_role'::text) OR ((select auth.uid()) IS NOT NULL));
+
+ALTER POLICY "Users can insert own social links" ON public.social_links
+  WITH CHECK ((select auth.uid()) = user_id);
+
+ALTER POLICY "Users can update own social links" ON public.social_links
+  USING ((select auth.uid()) = user_id);
+
+ALTER POLICY "Users can insert own streak logs" ON public.streak_logs
+  WITH CHECK ((select auth.uid()) = user_id);
+
+ALTER POLICY "Users can insert own profile" ON public.users
+  WITH CHECK ((select auth.uid()) = id);
+
+ALTER POLICY "Users can update own profile" ON public.users
+  USING ((select auth.uid()) = id);

--- a/supabase/migrations/20260714_streak_logs_feed_index.sql
+++ b/supabase/migrations/20260714_streak_logs_feed_index.sql
@@ -1,0 +1,23 @@
+-- Missing feed index for the Live Network Feed's streak_logs source.
+--
+-- 20260502_feed_query_indexes.sql added supporting indexes for three of
+-- the feed's four time-ordered sources (project_endorsements, reviews,
+-- notifications) but overlooked the fourth:
+--
+--   streak_logs ORDER BY activity_date DESC LIMIT n   (no WHERE)
+--     -- src/lib/homepage-feed.ts and src/app/api/feed/route.ts
+--
+-- The existing indexes on streak_logs are (user_id), the (user_id,
+-- activity_date) unique key, and the (id) primary key. None can serve a
+-- global activity_date ordering, so this query degraded to a full Seq
+-- Scan of the entire table plus a top-N heapsort on every homepage / feed
+-- load. Over 105 days of pg_stat_statements it was the single largest
+-- consumer of database time (~19% of total, ~59 ms/call, EXPLAIN showed
+-- ~123 ms). This index turns it into a sub-millisecond index scan.
+--
+-- IF NOT EXISTS so re-running is a no-op. Plain (non-CONCURRENT) form to
+-- match the sibling migration; streak_logs is small enough that the brief
+-- write lock is immaterial. CONCURRENTLY can't run inside a transaction.
+
+CREATE INDEX IF NOT EXISTS idx_streak_logs_activity_date
+  ON public.streak_logs (activity_date DESC);


### PR DESCRIPTION
## Summary
A performance + security hardening pass on the Supabase database and the two always-on client pollers. **The DB changes are already applied to production** (via Supabase migrations) — the migration files here are the repo record. The poller code is what this PR actually deploys.

Isolated off `main`, separate from the image-loader work in #229.

## Database (already live)
- **`streak_logs(activity_date DESC)` index** — the global activity-feed query (homepage + `/api/feed`) was doing a full seq-scan + top-N sort of the whole table on every load: **~19% of total DB time**. Now a sub-ms index scan. It's the one feed source `20260502_feed_query_indexes.sql` missed.
- **8 FK covering indexes** — for foreign keys flagged as unindexed; several also back RLS predicates (e.g. `hire_requests.builder_id`).
- **29 RLS initplan rewrites** — `auth.uid()`/`auth.role()` → `(select …)` so they evaluate once per query instead of per row. Advisor `auth_rls_initplan`: 29 → 0. Behaviour-preserving; each rewrite independently verified.

## Security 🔴
Dropped 3 RLS policies whose `USING(true)` / `WITH CHECK(true)` silently OR-overrode the intended ones:
- **`hire_requests` was world-readable to the anon key** — `sender_email` (PII), `message`, and `budget` of every inbound hire request. The Supabase advisor doesn't flag `SELECT USING(true)`, so this was invisible to tooling — found by a manual full-schema sweep. Verified closed: **anon now reads 0 rows; builders still read their own.**
- `hire_messages` — anon could inject a message into any thread.
- `feed_events` — a `USING(true)` policy had silently disabled the `is_private` gate.

## Performance (app-level)
The DB is 26 MB / 100% cache-hit, so the real cost is **call volume + egress**, not query speed:
- Gate `notification-bell` + `live-activity-feed` polling on tab visibility (mirrors the existing `network-feed` pattern) — background tabs stop polling.
- Bell polls **count-only** (`/api/notifications?count=1`); the full list lazy-loads on dropdown open.

Cuts Cloudflare Worker invocations + Supabase egress — the scarce resources pre-revenue.

## Verification
- Advisor: perf lints **93 → 63** (initplan 29→0, unindexed FK 8→0).
- PII leak **closed** (anon `hire_requests` count = 0); legit access preserved (builder reads own = 1; anon public feed = 10k+; `reviews.reviewer_email` stays anon-hidden).
- Lint clean; app compiles (`✓ Compiled successfully`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notification updates now refresh unread counts more efficiently.
  * Notification lists load when the notification menu opens.
  * Activity and notification polling pauses in background tabs and resumes when visible.

* **Bug Fixes**
  * Prevented updates after activity feeds are closed.
  * Improved privacy enforcement for selected data access policies.

* **Performance**
  * Improved notification and activity polling efficiency.
  * Added database indexes to improve feed, relationship, and policy-related queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->