### PR TITLE
fix(navbar): stop transient auth failures from blanking the avatar

### DIFF
--- a/src/components/layout/navbar-client.tsx
+++ b/src/components/layout/navbar-client.tsx
@@ -200,7 +200,14 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
           .eq("id", userId)
           .single();
         if (cancelled) return;
-        if (error) console.error("Navbar profile fetch error:", error);
+        if (error) {
+          // A transient query failure (network / auth blip on a rapid
+          // refresh) is not the same as "no profile" — do NOT fall through to
+          // the blanking fallback below. Keep whatever is already on screen
+          // (SSR / localStorage cache); the next successful fetch reconciles.
+          console.error("Navbar profile fetch error:", error);
+          return;
+        }
         if (profile && profile.username) {
           const next: NavbarProfile = {
             username: profile.username,
@@ -219,8 +226,10 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
       } catch (err) {
         if (cancelled) return;
         console.error("Navbar profile fetch failed:", err);
+        // Don't blank a known profile on a transient throw — only fall back to
+        // the email stub if we have nothing to show yet.
         if (email) {
-          setUserProfile({ username: email.split("@")[0], avatar_url: null, github_username: null, display_name: null });
+          setUserProfile((prev) => prev ?? { username: email.split("@")[0], avatar_url: null, github_username: null, display_name: null });
         }
       }
     }
@@ -238,15 +247,21 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
     // Check auth once on mount, then listen for changes. This still runs even
     // when SSR pre-populated state, in case the cookie changed between render
     // and hydration (e.g. user signed out in another tab).
-    supabase.auth.getUser().then(({ data: { user } }) => {
+    supabase.auth.getUser().then(({ data: { user }, error }) => {
       if (cancelled) return;
+      // A failed getUser() — a transient 500 from /auth/v1/user, a network
+      // blip, or token-refresh churn from rapid hard refreshes — is NOT a
+      // logout. Treating it as one blanks the avatar and (below) wipes the
+      // cached profile, so bail without touching state; onAuthStateChange's
+      // INITIAL_SESSION and the next check reconcile the real auth state.
+      if (error) return;
       isLoggedInRef.current = !!user;
       setIsLoggedIn(!!user);
       if (user) {
         fetchProfile(user.id, user.email);
         void checkTodayLogged();
       } else {
-        // Cookie expired or cleared between cache write and now — drop the
+        // Cookie genuinely expired or cleared (no error, no user) — drop the
         // cached profile so the next hard refresh doesn't flash it.
         setUserProfile(null);
         writeCachedNavProfile(null);


### PR DESCRIPTION
## The bug
Hard-refresh the site 3-4 times quickly and your profile avatar goes blank (and the UI feels like it's "loading slowly").

## Root cause — it's the auth check, not the database
The navbar gates the avatar on `supabase.auth.getUser()`, a network call to `/auth/v1/user` on **every** mount. The handler only read `data.user` and **ignored `error`**, so any transient failure returned a null user and was treated as a **logout** — clearing `userProfile` and **wiping the localStorage profile cache**. `fetchProfile` had the same shape (a failed `users` query fell through to a null-avatar email stub).

Rapid hard-refreshes compound the odds of catching one bad response — which is exactly why it takes 3-4 tries.

**Evidence gathered:**
- **Not the image** — 8 rapid cache-busting requests to the avatar's `/_next/image` URL all returned `200` (and got *faster*).
- **Not the DB / Worker** — 8 rapid homepage loads all `200` in ~50ms.
- **The auth endpoint is the weak link** — auth logs show `/auth/v1/user` hit on every mount, with intermittent `500`s among the `200`s.

## Fix
Distinguish a transient auth/query **error** from an actual signed-out state:
- `getUser()`: bail on `error` instead of clearing state + wiping the cache.
- `fetchProfile()`: return on query error; only apply the email stub when there's no existing profile to preserve.

Worst case after this: the avatar just doesn't update that cycle — it never blanks or loses its cache on a hiccup.

Client-only change; pre-existing bug, unrelated to the recent DB/RLS work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile and authentication handling during temporary network or service failures.
  * Prevented cached profile information from being cleared or overwritten when authentication checks fail unexpectedly.
  * Ensured genuine logged-out states continue to be handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->