### PR TITLE
fix(auth+dashboard): survive midnight token races, faster dots, less DB load

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -41,6 +41,17 @@ import {
   Zap,
 } from "lucide-react";
 
+// Column lists for the dashboard's own queries, kept to what the page (plus
+// the GitHub self-heal and mandatory-socials gating) actually reads. The
+// previous `select("*")` paid full-row egress on every visit — including
+// projects.quality_metrics, a JSONB blob nothing here renders.
+const DASHBOARD_USER_FIELDS =
+  "id, username, display_name, bio, avatar_url, github_username, vibe_score, streak, longest_streak, badge_level, streak_freezes_remaining, streak_freezes_used, referral_count, created_at";
+const DASHBOARD_PROJECT_FIELDS =
+  "id, user_id, title, description, tech_stack, live_url, github_url, image_url, build_time, tags, verified, quality_score, endorsement_count, created_at";
+const DASHBOARD_SOCIAL_FIELDS = "id, user_id, twitter, telegram, github, website, farcaster";
+const INBOX_FIELDS = "id, sender_name, sender_email, budget, message, status, reply, replied_at, created_at";
+
 // Lazy: only loaded when the tour is actually armed (post-signup or ?tour=force).
 // Keeps the ~300-line tour module + its deps out of the initial dashboard chunk.
 const OnboardingTour = dynamic(
@@ -121,6 +132,12 @@ export default function DashboardPage() {
   const [ghTotal, setGhTotal] = useState<number>(0);
   const [loading, setLoading] = useState(true);
   const [hireRequests, setHireRequests] = useState<HireRequest[]>([]);
+  // Seed for the Inbox tab's "new" badge: a head-count fetched on initial
+  // load (the full list is deferred until the tab is opened). Once the list
+  // has loaded, the badge derives from it directly — see newHireCount below —
+  // so mark-read / delete / reply need no manual counter bookkeeping.
+  const [newHireSeed, setNewHireSeed] = useState(0);
+  const [inboxLoaded, setInboxLoaded] = useState(false);
   const [senderProfiles, setSenderProfiles] = useState<Record<string, { username: string }>>({});
   // Onboarding tour visibility. Initialized false on the server (SSR-safe);
   // the effect below reads the sessionStorage trigger or `?tour=force` query
@@ -188,13 +205,18 @@ export default function DashboardPage() {
       const sb = supabase as any;
 
       try {
-      // Fetch profile + projects + socials + streaks + inbox ALL in parallel (single round trip)
+      // Fetch profile + projects + socials + streaks + inbox badge ALL in
+      // parallel (single round trip). The inbox itself is deferred: the old
+      // hire_requests fetch pulled every request ever received — full message
+      // bodies included — plus a resolve-senders API call on every dashboard
+      // visit, just to derive the tab's "new" badge. A head-count covers the
+      // badge; the Inbox tab loads the real list via loadInbox() when opened.
       const results = await Promise.allSettled([
-        sb.from("users").select("*").eq("id", authUser.id).maybeSingle(),
-        sb.from("projects").select("*").eq("user_id", authUser.id).order("created_at", { ascending: false }),
-        sb.from("social_links").select("*").eq("user_id", authUser.id).maybeSingle(),
+        sb.from("users").select(DASHBOARD_USER_FIELDS).eq("id", authUser.id).maybeSingle(),
+        sb.from("projects").select(DASHBOARD_PROJECT_FIELDS).eq("user_id", authUser.id).order("created_at", { ascending: false }),
+        sb.from("social_links").select(DASHBOARD_SOCIAL_FIELDS).eq("user_id", authUser.id).maybeSingle(),
         fetchStreakLogs(authUser.id),
-        sb.from("hire_requests").select("*").eq("builder_id", authUser.id).order("created_at", { ascending: false }),
+        sb.from("hire_requests").select("id", { count: "exact", head: true }).eq("builder_id", authUser.id).eq("status", "new"),
       ]);
 
       const profile = results[0].status === "fulfilled" ? results[0].value?.data : null;
@@ -203,37 +225,7 @@ export default function DashboardPage() {
       // memory after a fire-and-forget DB upsert.
       let socials = results[2].status === "fulfilled" ? results[2].value?.data : null;
       const streakData = results[3].status === "fulfilled" ? results[3].value : {};
-      const inboxData = results[4].status === "fulfilled" ? results[4].value?.data : [];
-      setHireRequests(inboxData || []);
-
-      // Resolve hire request senders → profiles. The server only resolves
-      // requests where sender_user_id was captured at submission time (i.e.,
-      // the sender was logged in and their auth email matched the form email),
-      // so an unauthenticated form spoof can never link to a victim's profile.
-      // Fire-and-forget; failures keep names as plain text.
-      if (inboxData && inboxData.length > 0) {
-        const ids = (inboxData as HireRequest[]).map((r) => r.id).slice(0, 100);
-        fetch("/api/hire/resolve-senders", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ hire_request_ids: ids }),
-        })
-          .then((r) => {
-            if (!r.ok) {
-              console.warn("[dashboard] resolve-senders non-ok:", r.status);
-              return null;
-            }
-            return r.json();
-          })
-          .then((data) => {
-            if (!cancelled && data?.resolved) {
-              setSenderProfiles(data.resolved);
-            }
-          })
-          .catch((err) => {
-            console.warn("[dashboard] resolve-senders failed:", err);
-          });
-      }
+      setNewHireSeed(results[4].status === "fulfilled" ? results[4].value?.count || 0 : 0);
 
       if (!profile) {
         window.location.href = "/auth/profile-setup";
@@ -452,14 +444,6 @@ export default function DashboardPage() {
         }
       }
 
-      // Recompute streak/score server-side if our computed value differs
-      // (non-blocking). Routed through the SECURITY DEFINER update_user_streak
-      // RPC — reputation columns are no longer client-writable (see the
-      // 20260529 security migration); the RPC is the single source of truth.
-      if (profile && (actualStreak !== profile.streak || actualLongest !== profile.longest_streak)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (sb as any).rpc("update_user_streak", { p_user_id: authUser.id });
-      }
       } catch (err) {
         console.error("Dashboard loadUserData failed:", err);
         setLoading(false);
@@ -560,11 +544,11 @@ export default function DashboardPage() {
     if (!authUser) return;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sb = supabase as any;
-    const { data: profile } = await sb.from("users").select("id, username, bio, avatar_url, vibe_score, streak, longest_streak, badge_level, referral_count, created_at").eq("id", authUser.id).maybeSingle();
+    const { data: profile } = await sb.from("users").select(DASHBOARD_USER_FIELDS).eq("id", authUser.id).maybeSingle();
     if (!profile) return;
     const [{ data: projects }, { data: socials }, streakData] = await Promise.all([
-      sb.from("projects").select("id, user_id, title, description, tech_stack, live_url, github_url, image_url, build_time, tags, verified, created_at").eq("user_id", authUser.id).order("created_at", { ascending: false }),
-      sb.from("social_links").select("id, user_id, twitter, telegram, github, website, farcaster").eq("user_id", authUser.id).maybeSingle(),
+      sb.from("projects").select(DASHBOARD_PROJECT_FIELDS).eq("user_id", authUser.id).order("created_at", { ascending: false }),
+      sb.from("social_links").select(DASHBOARD_SOCIAL_FIELDS).eq("user_id", authUser.id).maybeSingle(),
       fetchStreakLogs(authUser.id),
     ]);
     setUser({ ...profile, projects: projects || [], social_links: socials || null });
@@ -736,18 +720,51 @@ export default function DashboardPage() {
     setTimeout(() => setGithubSyncResult(null), 5000);
   };
 
-  // Refresh inbox data directly from Supabase (skip API route hop)
+  // Fetch the inbox directly from Supabase (skip API route hop). Called when
+  // the Inbox tab is opened — the initial dashboard load only fetches the
+  // "new" head-count for the tab badge.
   const loadInbox = async () => {
     setLoadingInbox(true);
     const supabase = createClient();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { data } = await (supabase as any)
       .from("hire_requests")
-      .select("*")
+      .select(INBOX_FIELDS)
       .eq("builder_id", user?.id)
       .order("created_at", { ascending: false });
-    setHireRequests(data || []);
+    const list: HireRequest[] = data || [];
+    setHireRequests(list);
+    setInboxLoaded(true);
     setLoadingInbox(false);
+
+    // Resolve hire request senders → profiles. The server only resolves
+    // requests where sender_user_id was captured at submission time (i.e.,
+    // the sender was logged in and their auth email matched the form email),
+    // so an unauthenticated form spoof can never link to a victim's profile.
+    // Fire-and-forget; failures keep names as plain text.
+    if (list.length > 0) {
+      const ids = list.map((r) => r.id).slice(0, 100);
+      fetch("/api/hire/resolve-senders", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ hire_request_ids: ids }),
+      })
+        .then((r) => {
+          if (!r.ok) {
+            console.warn("[dashboard] resolve-senders non-ok:", r.status);
+            return null;
+          }
+          return r.json();
+        })
+        .then((data) => {
+          if (data?.resolved) {
+            setSenderProfiles(data.resolved);
+          }
+        })
+        .catch((err) => {
+          console.warn("[dashboard] resolve-senders failed:", err);
+        });
+    }
   };
 
   const handleMarkAsRead = async (requestId: string) => {
@@ -884,13 +901,24 @@ export default function DashboardPage() {
     // Route through the server API (admin client, upsert-safe). Previously this
     // page inserted via the browser Supabase client, which 404'd in production
     // due to RLS/JWT edge cases and left the user clicking with no feedback.
-    let res: Response;
-    try {
-      res = await fetch("/api/streak", {
+    const postStreak = () =>
+      fetch("/api/streak", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ date: today }),
       });
+    let res: Response;
+    try {
+      res = await postStreak();
+      if (res.status === 401) {
+        // Streaks get logged right after the midnight rollover — the moment a
+        // long-open tab's access token is most likely stale or mid-rotation
+        // (the rollover itself fires a burst of authed calls). Let supabase
+        // settle a fresh session and retry once before showing the scary
+        // "sign in again" message for what is usually a transient blip.
+        await createClient().auth.getSession();
+        res = await postStreak();
+      }
     } catch (err) {
       console.error("Failed to log activity (network):", err);
       setLogError("Network error — check your connection and try again.");
@@ -1172,6 +1200,12 @@ export default function DashboardPage() {
     );
   }
 
+  // Inbox "new" badge: derived from the fetched list once available, the
+  // initial head-count seed before that.
+  const newHireCount = inboxLoaded
+    ? hireRequests.filter((r) => r.status === "new").length
+    : newHireSeed;
+
   return (
     <div className="mx-auto max-w-7xl px-4 sm:px-6 py-12">
       <h1 className="text-3xl font-extrabold uppercase text-[var(--foreground)] mb-6">Dashboard</h1>
@@ -1202,7 +1236,7 @@ export default function DashboardPage() {
         >
           <Inbox size={16} />
           Inbox
-          {hireRequests.filter((r) => r.status === "new").length > 0 && (
+          {newHireCount > 0 && (
             <span
               className="ml-1 px-2 py-0.5 text-xs font-extrabold"
               style={{
@@ -1211,7 +1245,7 @@ export default function DashboardPage() {
                 border: "2px solid var(--border-hard)",
               }}
             >
-              {hireRequests.filter((r) => r.status === "new").length}
+              {newHireCount}
             </span>
           )}
         </button>

--- a/src/components/layout/navbar-client.tsx
+++ b/src/components/layout/navbar-client.tsx
@@ -150,26 +150,79 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
   // would still leave hasUnloggedActivity true from a prior session.
   const isLoggedInRef = useRef(initialIsLoggedIn);
 
-  const checkTodayLogged = useCallback(async () => {
+  // Serialize dot checks. The eager mount kick, getUser(), INITIAL_SESSION,
+  // and focus events can all request one within the same second; the previous
+  // concurrent fetches resolved last-write-wins, so one slow failure could
+  // erase the dot a successful check had just set.
+  const todayCheckRef = useRef<Promise<void> | null>(null);
+  const todayCheckQueuedRef = useRef(false);
+
+  // `fresh` forces a follow-up fetch when a check is already in flight — used
+  // after streak writes, where the in-flight response may predate the write
+  // that fired the event. Plain callers just join the in-flight check.
+  const checkTodayLogged = useCallback(async (fresh = false) => {
     if (!isLoggedInRef.current) {
       setHasUnloggedActivity(false);
       return;
     }
-    try {
-      const now = new Date();
-      const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
-      const res = await fetch(`/api/streak/today-logged?date=${today}`);
-      if (!res.ok) {
-        // 401 / 429 / 5xx — clear the dot rather than leaving a stale value.
-        setHasUnloggedActivity(false);
-        return;
-      }
-      const data = await res.json();
-      setHasUnloggedActivity(data.loggedToday === false);
-    } catch {
-      setHasUnloggedActivity(false);
+    if (todayCheckRef.current) {
+      if (fresh) todayCheckQueuedRef.current = true;
+      return todayCheckRef.current;
     }
+    const run = (async () => {
+      try {
+        const now = new Date();
+        const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+        const fetchToday = () => fetch(`/api/streak/today-logged?date=${today}`);
+        let res = await fetchToday();
+        if (res.status === 401 && isLoggedInRef.current) {
+          // Hard refreshes, tab wakes, and the midnight rollover all hit this
+          // endpoint right when the access token is most likely stale or
+          // mid-rotation. Let supabase settle the session, then retry once
+          // before believing the 401.
+          await createClient().auth.getSession();
+          res = await fetchToday();
+        }
+        if (res.status === 401) {
+          // Confirmed signed out — clear rather than leaving a stale dot.
+          setHasUnloggedActivity(false);
+          return;
+        }
+        if (!res.ok) return; // 429 / 5xx — transient; keep the last known state.
+        const data = await res.json();
+        setHasUnloggedActivity(data.loggedToday === false);
+      } catch {
+        // Network blip — keep the last known state; the next focus or streak
+        // event re-checks.
+      } finally {
+        todayCheckRef.current = null;
+        if (todayCheckQueuedRef.current) {
+          todayCheckQueuedRef.current = false;
+          void checkTodayLogged();
+        }
+      }
+    })();
+    todayCheckRef.current = run;
+    return run;
   }, []);
+
+  // Local-date rollover watcher: brings the "no activity logged today" dot up
+  // on ANY page shortly after midnight. The dashboard's MidnightCountdown only
+  // covers users parked on /dashboard — on every other page the dot kept
+  // yesterday's state until a tab switch or navigation. One date compare per
+  // minute; fetches only when the calendar day actually changes.
+  useEffect(() => {
+    let lastDate = new Date().toDateString();
+    const interval = setInterval(() => {
+      const today = new Date().toDateString();
+      if (today === lastDate) return;
+      lastDate = today;
+      // Hidden tabs re-sync via the visibilitychange listener the moment
+      // they're foregrounded; skip the fetch, not the date bookkeeping.
+      if (!document.hidden) void checkTodayLogged();
+    }, 60_000);
+    return () => clearInterval(interval);
+  }, [checkTodayLogged]);
 
   useEffect(() => {
     const supabase = createClient();
@@ -189,10 +242,24 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
     // is the canonical "is the client mounted" pattern; the lint rule's
     // suggestion to use a useState initializer doesn't apply here — we
     // explicitly want false during SSR + hydration and true afterwards.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+
     setAuthMounted(true);
 
-    async function fetchProfile(userId: string, email?: string) {
+    // One profile fetch per user per burst: mount getUser() and the
+    // INITIAL_SESSION auth event both land within ~a second of a hard load
+    // and used to double the users query on every page view. `force` bypasses
+    // the guard for real profile edits (profile-updated event).
+    let lastProfileFetch: { id: string; ts: number } | null = null;
+    async function fetchProfile(userId: string, email?: string, force = false) {
+      if (
+        !force &&
+        lastProfileFetch &&
+        lastProfileFetch.id === userId &&
+        Date.now() - lastProfileFetch.ts < 5000
+      ) {
+        return;
+      }
+      lastProfileFetch = { id: userId, ts: Date.now() };
       try {
         const { data: profile, error } = await sb
           .from("users")
@@ -269,11 +336,15 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
       }
     });
 
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
       if (cancelled) return;
       isLoggedInRef.current = !!session?.user;
       setIsLoggedIn(!!session?.user);
       if (session?.user) {
+        // Hourly TOKEN_REFRESHED churn changes nothing user-visible — it used
+        // to refire the profile + dot queries in every open tab on every
+        // token rotation.
+        if (event === "TOKEN_REFRESHED") return;
         fetchProfile(session.user.id, session.user.email);
         void checkTodayLogged();
       } else {
@@ -289,14 +360,18 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
     const handleProfileUpdated = async () => {
       const { data: { user } } = await supabase.auth.getUser();
       if (cancelled) return;
-      if (user) fetchProfile(user.id, user.email);
+      if (user) fetchProfile(user.id, user.email, true);
     };
     window.addEventListener("profile-updated", handleProfileUpdated);
 
     // The dashboard dispatches this after manual Log Activity, successful
     // GitHub sync, and midnight rollover. Refetch so the dot updates without
-    // a full page reload.
-    window.addEventListener("streak-updated", checkTodayLogged);
+    // a full page reload. `fresh` because the event follows a streak write —
+    // an already-in-flight check may carry a response from before the write.
+    const handleStreakUpdated = () => {
+      void checkTodayLogged(true);
+    };
+    window.addEventListener("streak-updated", handleStreakUpdated);
 
     // Catch the "pushed to GitHub in another tab/terminal, came back" case:
     // when the tab regains focus, re-check. GitHub auto-sync is scheduled
@@ -328,7 +403,7 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
       cancelled = true;
       subscription.unsubscribe();
       window.removeEventListener("profile-updated", handleProfileUpdated);
-      window.removeEventListener("streak-updated", checkTodayLogged);
+      window.removeEventListener("streak-updated", handleStreakUpdated);
       document.removeEventListener("visibilitychange", handleVisibility);
       window.removeEventListener("storage", handleStorage);
     };

--- a/src/components/ui/notification-bell.tsx
+++ b/src/components/ui/notification-bell.tsx
@@ -79,6 +79,9 @@ function BellChip({ n }: { n: Notification }) {
 export function NotificationBell() {
   const [open, setOpen] = useState(false);
   const [notifications, setNotifications] = useState<Notification[]>([]);
+  // False until the first successful list fetch — the dropdown shows a loading
+  // hint instead of a false "No notifications yet" while the lazy list loads.
+  const [listLoaded, setListLoaded] = useState(false);
   const [unreadCount, setUnreadCount] = useState(0);
   const [loading, setLoading] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -91,6 +94,7 @@ export function NotificationBell() {
       const data = await res.json();
       setNotifications(data.data || []);
       setUnreadCount(data.unread_count || 0);
+      setListLoaded(true);
     } catch {
       // Silently fail
     }
@@ -98,14 +102,16 @@ export function NotificationBell() {
 
   // Lightweight badge-only refresh for the polling loop: skips the notification
   // list (fetched lazily when the dropdown opens) and returns just the count.
-  const fetchUnreadCount = useCallback(async () => {
+  // Reports success so the initial load can schedule a one-shot retry.
+  const fetchUnreadCount = useCallback(async (): Promise<boolean> => {
     try {
       const res = await fetch("/api/notifications?count=1");
-      if (!res.ok) return;
+      if (!res.ok) return false;
       const data = await res.json();
       setUnreadCount(data.unread_count || 0);
+      return true;
     } catch {
-      // Silently fail
+      return false;
     }
   }, []);
 
@@ -136,9 +142,19 @@ export function NotificationBell() {
     };
     const handleRefresh = () => fetchNotifications();
 
-    // Initial load is the full fetch so the dropdown is populated the instant
-    // it's first opened; the repeating interval only needs the count.
-    fetchNotifications();
+    // Badge-first initial load: one head-count query paints the unread badge
+    // as fast as the Worker can auth, instead of waiting on the 50-row list +
+    // count the old full fetch pulled. The list stays lazy — opening the
+    // dropdown always fetches it fresh (see the bell button), so preloading
+    // it here bought latency and egress for nothing. The one-shot retry
+    // covers hard loads where the first hit lands while the auth cookie is
+    // still settling and 401s.
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    void fetchUnreadCount().then((ok) => {
+      if (!ok) {
+        retryTimer = setTimeout(() => void fetchUnreadCount(), 1500);
+      }
+    });
     startPolling();
     window.addEventListener("notifications-updated", handleRefresh);
     if (typeof document !== "undefined") {
@@ -146,6 +162,7 @@ export function NotificationBell() {
     }
     return () => {
       stopPolling();
+      if (retryTimer !== null) clearTimeout(retryTimer);
       window.removeEventListener("notifications-updated", handleRefresh);
       if (typeof document !== "undefined") {
         document.removeEventListener("visibilitychange", onVisibilityChange);
@@ -260,7 +277,9 @@ export function NotificationBell() {
           {notifications.length === 0 ? (
             <div className="px-4 py-8 text-center">
               <Bell size={24} className="mx-auto mb-2 text-[var(--text-muted-soft)]" />
-              <p className="text-sm font-medium text-[var(--text-muted-soft)]">No notifications yet</p>
+              <p className="text-sm font-medium text-[var(--text-muted-soft)]">
+                {listLoaded ? "No notifications yet" : "Loading notifications…"}
+              </p>
             </div>
           ) : (
             <div>

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -46,15 +46,17 @@ export async function updateSession(request: NextRequest) {
   // the cookie refresh above.
   const isProtectedRoute = request.nextUrl.pathname.startsWith("/dashboard");
   if (isProtectedRoute && !user) {
-    // Fall back to getSession() (local cookie read) on transient network
-    // errors so we don't bounce authenticated users on flakiness.
-    if (error) {
-      const {
-        data: { session },
-      } = await supabase.auth.getSession();
-      if (session) {
-        return supabaseResponse;
-      }
+    // getUser() failing WITH an auth cookie present is a refresh that raced or
+    // a transient auth-server blip — not proof of logout. This bites hardest
+    // overnight: a tab reopened after midnight carries an hours-expired access
+    // token, and one flaky refresh used to bounce a logged-in user to
+    // /auth/login. getSession() can't arbitrate (it re-attempts the refresh
+    // that just failed and returns null), so let the request through and let
+    // the client resolve the real state — the dashboard renders its own
+    // signed-out UI, and a genuinely dead session clears the cookie on the
+    // client, making the next navigation redirect normally.
+    if (error && hasAuthSessionCookie(request)) {
+      return supabaseResponse;
     }
     const url = request.nextUrl.clone();
     url.pathname = "/auth/login";
@@ -62,4 +64,16 @@ export async function updateSession(request: NextRequest) {
   }
 
   return supabaseResponse;
+}
+
+// Matches @supabase/ssr session cookies, including chunked ones
+// (sb-<ref>-auth-token, sb-<ref>-auth-token.0, .1, …) while excluding the
+// PKCE sb-<ref>-auth-token-code-verifier cookie that mid-OAuth visitors carry.
+export function hasAuthSessionCookie(request: NextRequest): boolean {
+  return request.cookies
+    .getAll()
+    .some(
+      (c) =>
+        /^sb-.+-auth-token(\.\d+)?$/.test(c.name) && c.value.length > 0,
+    );
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,18 +1,12 @@
-import { updateSession } from "@/lib/supabase/middleware";
+import { updateSession, hasAuthSessionCookie } from "@/lib/supabase/middleware";
 import { NextResponse, type NextRequest } from "next/server";
 
-const AUTH_COOKIE_PREFIX = "sb-";
-const AUTH_COOKIE_SUFFIX = "-auth-token";
-
-function hasSupabaseAuthCookie(request: NextRequest): boolean {
-  return request.cookies
-    .getAll()
-    .some(
-      (c) =>
-        c.name.startsWith(AUTH_COOKIE_PREFIX) &&
-        c.name.endsWith(AUTH_COOKIE_SUFFIX),
-    );
-}
+// Chunk-aware session-cookie check shared with updateSession. The previous
+// local prefix/suffix match missed chunked cookies (sb-…-auth-token.0), which
+// made the anonymous fast-path below skip the cookie refresh for logged-in
+// users with large sessions — their auth silently went stale on every page
+// except /dashboard.
+const hasSupabaseAuthCookie = hasAuthSessionCookie;
 
 export async function middleware(request: NextRequest) {
   // Catch Supabase auth error redirects (e.g. identity_already_exists)


### PR DESCRIPTION
## The reports

1. At 12 AM the dashboard says you have to log in again
2. The notification dot takes a while to appear
3. The dashboard puts a big load on the database

## Root causes & fixes

### 1. Midnight "log in again"

Two mechanisms, both firing exactly when a long-open tab crosses midnight with an hours-stale access token:

- **Middleware bounced transient failures to `/auth/login`.** The `getSession()` "fallback for flakiness" was illusory: for an expired token, supabase-js `getSession()` re-attempts the refresh that just failed and returns null (verified in GoTrueClient `__loadSession`). Now, a `getUser()` error with an auth cookie still present passes through and lets the client resolve the real state — genuinely signed-out visitors (no cookie, no error) still redirect.
- **The anonymous fast-path cookie check missed chunked cookies** (`sb-…-auth-token.0`), so those users skipped the middleware session refresh on every non-dashboard page and their cookies went stale while browsing. Both middlewares now share one chunk-aware matcher (PKCE code-verifier cookie excluded).
- **`POST /api/streak` 401 → "Your session expired — refresh and sign in again"** with no retry — shown right when users click Log Activity at 00:00 while the token is mid-rotation (the rollover itself fires a burst of authed calls). Now settles the session and retries once before showing the message.

### 2. Notification dots

- **Navbar streak dot:** the mount path fired up to 3 concurrent `today-logged` checks racing last-write-wins (a slow failure could erase a fresh success); any failure hid the dot with no retry until the next tab switch; and midnight rollover was only detected on `/dashboard` (the event comes from `MidnightCountdown`). Now: checks are serialized with an in-flight guard (+ a `fresh` re-run after streak writes), 401s retry once after settling the session, transient failures keep the last known state, and a minute-level local-date watcher brings the dot up on any page after midnight.
- **Bell badge:** initial load pulled the full 50-row list + count before the badge could paint, even though opening the dropdown re-fetches the list anyway. Now badge-first (single head-count query) with one retry for the load-time auth race, and the first dropdown open shows a loading hint instead of a false "No notifications yet".

### 3. Dashboard DB load (per visit)

- `update_user_streak` SECURITY DEFINER RPC was called **twice** — verbatim duplicated block. Removed the duplicate.
- The inbox fetched **every hire request ever received** (`select("*")` — full message bodies) plus a `resolve-senders` API hop on every dashboard load, only to derive the tab badge. Now a `status='new'` head-count seeds the badge; the Inbox tab fetches the list (and resolves senders) when opened, and the badge derives from the list once loaded.
- `select("*")` on users/projects/social_links narrowed to the fields the page reads (drops `quality_metrics` JSONB and friends from the wire).
- Navbar fired the profile query twice per hard load (mount `getUser()` + `INITIAL_SESSION`) and re-fired profile + dot queries on every hourly `TOKEN_REFRESHED` in every open tab. Deduped and skipped respectively.

## Verification

- `tsc --noEmit` clean (two pre-existing `worker.ts` errors exist on main, caused by a stale local `.open-next/`; CI unaffected)
- `eslint src` clean, 319/319 vitest tests pass
- `next build` passes under CI-equivalent conditions
- Browser smoke test: anonymous `/dashboard` still redirects to `/auth/login`; homepage renders; signed-out navbar makes zero today-logged/notifications calls; both APIs 401 cleanly for anonymous

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Dashboard and inbox content now load more efficiently, with detailed inbox data fetched when needed.
  * Notification badges appear sooner while the full notification list loads in the background.

* **Bug Fixes**
  * Improved recovery from temporary authentication issues without unexpectedly redirecting users to sign in.
  * Reduced stale activity indicators and improved updates around daily streak activity.
  * Notification loading now provides clearer feedback when content is unavailable or still loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->