### PR TITLE
feat(projects): detect VibeTalent badge in repo READMEs + Badge Holder chip

### DIFF
--- a/src/app/api/cron/quality-rescore/route.ts
+++ b/src/app/api/cron/quality-rescore/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
-import { analyzeRepository, checkLiveUrl, parseGithubRepoUrl } from "@/lib/github-quality";
+import { analyzeRepository, checkLiveUrl, parseGithubRepoUrl, toRepoQualityData } from "@/lib/github-quality";
 import { runWeeklySnapshot } from "@/lib/cron-jobs/weekly-snapshot";
 
 // Each project costs 4 api.github.com calls. At 50 projects per run that's
@@ -76,6 +76,24 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: "Failed to fetch projects" }, { status: 500 });
     }
 
+    // Map owner → VibeTalent profile slug so README badge detection can be
+    // scoped to the right builder. One query for the whole batch rather than
+    // a lookup per project. Note this is `users.username` (the profile slug in
+    // badge URLs), NOT `github_username`.
+    const profileUsernameById = new Map<string, string>();
+    const ownerIds = [...new Set(
+      ((needsRescore ?? []) as { user_id: string }[]).map((p) => p.user_id).filter(Boolean)
+    )];
+    if (ownerIds.length > 0) {
+      const { data: ownerRows } = await sb
+        .from("users")
+        .select("id, username")
+        .in("id", ownerIds);
+      for (const row of (ownerRows ?? []) as { id: string; username: string | null }[]) {
+        if (row.username) profileUsernameById.set(row.id, row.username);
+      }
+    }
+
     // Monday-only weekly snapshot of all users' vibe scores so we can compute
     // "climbed since last Monday" deltas. Runs in-process after rescoring (or
     // the no-op skip path) to avoid burning another Vercel cron slot. Isolated
@@ -115,23 +133,15 @@ export async function GET(req: NextRequest) {
 
             const { owner: repoOwner, repo: repoName } = parsed;
 
-            const qualityResult = await analyzeRepository(repoOwner, repoName, githubToken);
+            const qualityResult = await analyzeRepository(
+              repoOwner,
+              repoName,
+              githubToken,
+              profileUsernameById.get(project.user_id) ?? null
+            );
             const qualityScore = qualityResult.success ? (qualityResult.metrics?.quality_score ?? 0) : 0;
             const qualityMetrics = (qualityResult.success && qualityResult.metrics)
-              ? {
-                  stars: qualityResult.metrics.stars,
-                  forks: qualityResult.metrics.forks,
-                  contributors: qualityResult.metrics.contributors,
-                  total_commits: qualityResult.metrics.total_commits,
-                  has_tests: qualityResult.metrics.has_tests,
-                  has_ci: qualityResult.metrics.has_ci,
-                  has_readme: qualityResult.metrics.has_readme,
-                  community_score: qualityResult.metrics.community_score,
-                  substance_score: qualityResult.metrics.substance_score,
-                  maintenance_score: qualityResult.metrics.maintenance_score,
-                  quality_score: qualityResult.metrics.quality_score,
-                  analyzed_at: new Date().toISOString(),
-                }
+              ? toRepoQualityData(qualityResult.metrics)
               : null;
 
             let live_url_ok: boolean | null = null;

--- a/src/app/api/cron/verify-backfill/route.ts
+++ b/src/app/api/cron/verify-backfill/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
-import { analyzeRepository, checkLiveUrl, parseGithubRepoUrl } from "@/lib/github-quality";
+import { analyzeRepository, checkLiveUrl, parseGithubRepoUrl, toRepoQualityData } from "@/lib/github-quality";
 import { createNotification } from "@/lib/notifications";
 
 const BATCH_SIZE = 5;
@@ -70,7 +70,7 @@ export async function GET(req: NextRequest) {
     // starving legitimate owner-mismatch retries.
     const { data: linkedUserRows, error: linkedUsersError } = await sb
       .from("users")
-      .select("id, github_username")
+      .select("id, github_username, username")
       .not("github_username", "is", null)
       .neq("github_username", "")
       .order("id", { ascending: true })
@@ -82,8 +82,12 @@ export async function GET(req: NextRequest) {
     }
 
     const usernameById = new Map<string, string>();
-    for (const row of (linkedUserRows ?? []) as { id: string; github_username: string }[]) {
+    // Separate map for the VibeTalent profile slug — that's what appears in
+    // badge/profile URLs we look for in the README, not the GitHub handle.
+    const profileUsernameById = new Map<string, string>();
+    for (const row of (linkedUserRows ?? []) as { id: string; github_username: string; username: string | null }[]) {
       if (row.github_username) usernameById.set(row.id, row.github_username);
+      if (row.username) profileUsernameById.set(row.id, row.username);
     }
 
     if (usernameById.size === 0) {
@@ -176,7 +180,12 @@ export async function GET(req: NextRequest) {
               }
 
               const { owner: repoOwner, repo: repoName } = parsed;
-              const qualityResult = await analyzeRepository(repoOwner, repoName);
+              const qualityResult = await analyzeRepository(
+                repoOwner,
+                repoName,
+                undefined,
+                profileUsernameById.get(project.user_id) ?? null
+              );
 
               // If GitHub API fails entirely, skip WITHOUT stamping — leave it
               // for a future run to retry. Don't mark verified without a valid
@@ -188,20 +197,7 @@ export async function GET(req: NextRequest) {
 
               const qualityScore = qualityResult.metrics?.quality_score ?? 0;
               const qualityMetrics = qualityResult.metrics
-                ? {
-                    stars: qualityResult.metrics.stars,
-                    forks: qualityResult.metrics.forks,
-                    contributors: qualityResult.metrics.contributors,
-                    total_commits: qualityResult.metrics.total_commits,
-                    has_tests: qualityResult.metrics.has_tests,
-                    has_ci: qualityResult.metrics.has_ci,
-                    has_readme: qualityResult.metrics.has_readme,
-                    community_score: qualityResult.metrics.community_score,
-                    substance_score: qualityResult.metrics.substance_score,
-                    maintenance_score: qualityResult.metrics.maintenance_score,
-                    quality_score: qualityResult.metrics.quality_score,
-                    analyzed_at: new Date().toISOString(),
-                  }
+                ? toRepoQualityData(qualityResult.metrics)
                 : null;
 
               let live_url_ok: boolean | null = null;

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { after } from "next/server";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { projectsLimiter, checkRateLimit, getIP } from "@/lib/rate-limit";
-import { analyzeRepository, checkLiveUrl, parseGithubRepoUrl } from "@/lib/github-quality";
+import { analyzeRepository, checkLiveUrl, parseGithubRepoUrl, toRepoQualityData } from "@/lib/github-quality";
 import { normalizeExternalUrl, normalizeRepoUrl } from "@/lib/url-normalize";
 import { createNotification } from "@/lib/notifications";
 
@@ -165,7 +165,7 @@ export async function POST(request: NextRequest) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const { data: userRow } = await (supabase as any)
         .from("users")
-        .select("github_username")
+        .select("github_username, username")
         .eq("id", user.id)
         .single();
 
@@ -174,6 +174,9 @@ export async function POST(request: NextRequest) {
         user.user_metadata?.user_name ||
         user.user_metadata?.preferred_username ||
         null;
+      // VibeTalent profile slug — distinct from the GitHub handle above, and
+      // the one that appears in badge/profile URLs we look for in the README.
+      const profileUsername: string | null = userRow?.username ?? null;
 
       const parsed = parseGithubRepoUrl(normalizedGithubUrl);
       if (githubUsername && parsed && parsed.owner.toLowerCase() === githubUsername.toLowerCase()) {
@@ -184,7 +187,7 @@ export async function POST(request: NextRequest) {
           try {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const sb = supabase as any;
-            const qualityResult = await analyzeRepository(repoOwner, repoName, providerToken);
+            const qualityResult = await analyzeRepository(repoOwner, repoName, providerToken, profileUsername);
 
             // If GitHub analysis fails (rate limit, transient API error, etc.)
             // leave the project unverified so the cron backfill can retry it.
@@ -201,20 +204,7 @@ export async function POST(request: NextRequest) {
             }
 
             const qualityScore = qualityResult.metrics.quality_score;
-            const qualityMetrics = {
-              stars: qualityResult.metrics.stars,
-              forks: qualityResult.metrics.forks,
-              contributors: qualityResult.metrics.contributors,
-              total_commits: qualityResult.metrics.total_commits,
-              has_tests: qualityResult.metrics.has_tests,
-              has_ci: qualityResult.metrics.has_ci,
-              has_readme: qualityResult.metrics.has_readme,
-              community_score: qualityResult.metrics.community_score,
-              substance_score: qualityResult.metrics.substance_score,
-              maintenance_score: qualityResult.metrics.maintenance_score,
-              quality_score: qualityResult.metrics.quality_score,
-              analyzed_at: new Date().toISOString(),
-            };
+            const qualityMetrics = toRepoQualityData(qualityResult.metrics);
 
             let live_url_ok: boolean | null = null;
             if (normalizedLiveUrl) {

--- a/src/app/api/projects/verify/route.ts
+++ b/src/app/api/projects/verify/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { createNotification } from "@/lib/notifications";
-import { analyzeRepository, checkLiveUrl, parseGithubRepoUrl } from "@/lib/github-quality";
+import { analyzeRepository, checkLiveUrl, parseGithubRepoUrl, toRepoQualityData } from "@/lib/github-quality";
 
 /**
  * Invalidate the cached profile read so the new "Verified" badge appears
@@ -146,7 +146,7 @@ export async function POST(request: Request) {
     // Method 1: Owner match
     if (repoOwner.toLowerCase() === githubUsername.toLowerCase()) {
       // Run quality analysis on the repo
-      const qualityResult = await analyzeRepository(repoOwner, repoName, providerToken);
+      const qualityResult = await analyzeRepository(repoOwner, repoName, providerToken, profileUsername);
 
       // Detected a private repo (our public-only OAuth can't read it). Private
       // repos aren't supported yet — read-only support is coming via a GitHub
@@ -164,20 +164,7 @@ export async function POST(request: Request) {
       }
       const qualityScore = qualityResult.success ? (qualityResult.metrics?.quality_score ?? 0) : 0;
       const qualityMetrics = (qualityResult.success && qualityResult.metrics)
-        ? {
-            stars: qualityResult.metrics.stars,
-            forks: qualityResult.metrics.forks,
-            contributors: qualityResult.metrics.contributors,
-            total_commits: qualityResult.metrics.total_commits,
-            has_tests: qualityResult.metrics.has_tests,
-            has_ci: qualityResult.metrics.has_ci,
-            has_readme: qualityResult.metrics.has_readme,
-            community_score: qualityResult.metrics.community_score,
-            substance_score: qualityResult.metrics.substance_score,
-            maintenance_score: qualityResult.metrics.maintenance_score,
-            quality_score: qualityResult.metrics.quality_score,
-            analyzed_at: new Date().toISOString(),
-          }
+        ? toRepoQualityData(qualityResult.metrics)
         : null;
 
       // Check live URL health if provided
@@ -262,23 +249,10 @@ export async function POST(request: Request) {
           fileContent.includes(user.id)
         ) {
           // Run quality analysis on the repo
-          const qualityResult = await analyzeRepository(repoOwner, repoName, providerToken);
+          const qualityResult = await analyzeRepository(repoOwner, repoName, providerToken, profileUsername);
           const qualityScore = qualityResult.success ? (qualityResult.metrics?.quality_score ?? 0) : 0;
           const qualityMetrics = (qualityResult.success && qualityResult.metrics)
-            ? {
-                stars: qualityResult.metrics.stars,
-                forks: qualityResult.metrics.forks,
-                contributors: qualityResult.metrics.contributors,
-                total_commits: qualityResult.metrics.total_commits,
-                has_tests: qualityResult.metrics.has_tests,
-                has_ci: qualityResult.metrics.has_ci,
-                has_readme: qualityResult.metrics.has_readme,
-                community_score: qualityResult.metrics.community_score,
-                substance_score: qualityResult.metrics.substance_score,
-                maintenance_score: qualityResult.metrics.maintenance_score,
-                quality_score: qualityResult.metrics.quality_score,
-                analyzed_at: new Date().toISOString(),
-              }
+            ? toRepoQualityData(qualityResult.metrics)
             : null;
 
           // Check live URL health

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -42,13 +42,17 @@ import {
 } from "lucide-react";
 
 // Column lists for the dashboard's own queries, kept to what the page (plus
-// the GitHub self-heal and mandatory-socials gating) actually reads. The
-// previous `select("*")` paid full-row egress on every visit — including
-// projects.quality_metrics, a JSONB blob nothing here renders.
+// the GitHub self-heal and mandatory-socials gating) actually reads, instead
+// of the `select("*")` that paid full-row egress on every visit.
+//
+// quality_metrics IS required despite being JSONB: QualityScoreBadge renders
+// its Community/Substance/Maintenance breakdown from it (and silently falls
+// back to a generic checklist without it), and the Badge Holder chip reads
+// has_vibetalent_badge. It's a flat ~13-key object, so the egress is trivial.
 const DASHBOARD_USER_FIELDS =
   "id, username, display_name, bio, avatar_url, github_username, vibe_score, streak, longest_streak, badge_level, streak_freezes_remaining, streak_freezes_used, referral_count, created_at";
 const DASHBOARD_PROJECT_FIELDS =
-  "id, user_id, title, description, tech_stack, live_url, github_url, image_url, build_time, tags, verified, quality_score, endorsement_count, created_at";
+  "id, user_id, title, description, tech_stack, live_url, github_url, image_url, build_time, tags, verified, quality_score, quality_metrics, endorsement_count, created_at";
 const DASHBOARD_SOCIAL_FIELDS = "id, user_id, twitter, telegram, github, website, farcaster";
 const INBOX_FIELDS = "id, sender_name, sender_email, budget, message, status, reply, replied_at, created_at";
 
@@ -1206,6 +1210,12 @@ export default function DashboardPage() {
     ? hireRequests.filter((r) => r.status === "new").length
     : newHireSeed;
 
+  // How many of this builder's projects have the VibeTalent badge in their
+  // README, per the last quality scan.
+  const badgedProjectCount = (user.projects ?? []).filter(
+    (p) => p.quality_metrics?.has_vibetalent_badge
+  ).length;
+
   return (
     <div className="mx-auto max-w-7xl px-4 sm:px-6 py-12">
       <h1 className="text-3xl font-extrabold uppercase text-[var(--foreground)] mb-6">Dashboard</h1>
@@ -1768,6 +1778,30 @@ export default function DashboardPage() {
           <ExternalLink size={16} className="text-[var(--accent)]" />
           Embeddable Badge
         </h2>
+
+        {/* Nudge / confirmation. `has_vibetalent_badge` is only populated on
+            projects analyzed since badge detection shipped, so "not found yet"
+            is phrased as an invitation rather than an accusation — an older
+            project genuinely may have the badge and not know it until its next
+            weekly rescore. */}
+        {badgedProjectCount > 0 ? (
+          <div
+            className="mb-3 px-3 py-2 flex items-center gap-2"
+            style={{ backgroundColor: "var(--status-success-bg)", border: "2px solid var(--border-hard)" }}
+          >
+            <ShieldCheck size={14} className="text-[var(--status-success-text)] shrink-0" />
+            <span className="text-xs font-bold text-[var(--status-success-text)]">
+              Badge found in {badgedProjectCount} {badgedProjectCount === 1 ? "repo" : "repos"} — nice.
+            </span>
+          </div>
+        ) : (
+          <p className="mb-3 text-xs font-medium text-[var(--text-secondary)] leading-relaxed">
+            Drop this in a repo README to show your streak and score where other
+            developers actually look. We&apos;ll spot it on the next scan and add a
+            <span className="font-extrabold text-[var(--accent)]"> Badge Holder </span>
+            chip to your projects.
+          </p>
+        )}
 
         <div className="flex items-center gap-4 p-3 bg-zinc-50 border-2 border-zinc-200 mb-3">
           {/* eslint-disable-next-line @next/next/no-img-element */}

--- a/src/components/ui/project-card.tsx
+++ b/src/components/ui/project-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { ExternalLink, Github, Clock, Tag, Pencil, Flag, CheckCircle, ShieldCheck, Undo2, User } from "lucide-react";
+import { ExternalLink, Github, Clock, Tag, Pencil, Flag, CheckCircle, ShieldCheck, Undo2, User, BadgeCheck } from "lucide-react";
 import Link from "next/link";
 import Image from "next/image";
 import type { Project } from "@/lib/types/database";
@@ -248,12 +248,23 @@ export function ProjectCard({ project, authorUsername, onEdit, showReport = true
         </div>
       </div>
 
-      {(verified || project.quality_score > 0) && (
+      {(verified || project.quality_score > 0 || project.quality_metrics?.has_vibetalent_badge) && (
         <div className="mt-1 flex items-center gap-2 flex-wrap">
           {verified && (
             <span className="inline-flex items-center gap-1 text-xs font-bold text-green-600" title="Verified owner">
               <CheckCircle size={14} />
               Verified
+            </span>
+          )}
+          {/* Social proof only — carries no score (a README link is trivially
+              fakeable, so it deliberately stays out of the quality formula). */}
+          {project.quality_metrics?.has_vibetalent_badge && (
+            <span
+              className="inline-flex items-center gap-1 text-xs font-bold text-[var(--accent)]"
+              title="This repo's README links back to the builder's VibeTalent profile"
+            >
+              <BadgeCheck size={14} />
+              Badge Holder
             </span>
           )}
           <QualityScoreBadge project={project} />

--- a/src/lib/__tests__/vibetalent-badge.test.ts
+++ b/src/lib/__tests__/vibetalent-badge.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { detectVibeTalentBadge, toRepoQualityData } from "../github-quality";
+import type { RepoQualityMetrics } from "../github-quality";
+
+// The two snippets the dashboard's copy buttons actually emit. If these
+// change, badge detection silently stops working for every new README — so
+// assert against the real shapes rather than hand-simplified URLs.
+const MARKDOWN_SNIPPET =
+  "[![VibeTalent](https://www.vibetalent.work/api/badge/alice)](https://www.vibetalent.work/profile/alice)";
+const HTML_SNIPPET =
+  '<a href="https://www.vibetalent.work/profile/alice"><img src="https://www.vibetalent.work/api/badge/alice" alt="VibeTalent Badge" /></a>';
+
+describe("detectVibeTalentBadge", () => {
+  it("detects the markdown snippet the dashboard copies", () => {
+    expect(detectVibeTalentBadge(MARKDOWN_SNIPPET, "alice")).toBe(true);
+  });
+
+  it("detects the HTML snippet the dashboard copies", () => {
+    expect(detectVibeTalentBadge(HTML_SNIPPET, "alice")).toBe(true);
+  });
+
+  it("detects a bare profile link inside a longer README", () => {
+    const readme = `# My Project\n\nBuilt by me.\nProfile: https://vibetalent.work/profile/alice\n\n## Install\n...`;
+    expect(detectVibeTalentBadge(readme, "alice")).toBe(true);
+  });
+
+  it("accepts http, no-www, and mixed case", () => {
+    expect(detectVibeTalentBadge("http://vibetalent.work/profile/alice", "alice")).toBe(true);
+    expect(detectVibeTalentBadge("HTTPS://WWW.VIBETALENT.WORK/PROFILE/ALICE", "alice")).toBe(true);
+  });
+
+  it("matches when the stored username is percent-encoded", () => {
+    // The dashboard copy helpers run the username through encodeURIComponent.
+    expect(detectVibeTalentBadge("https://www.vibetalent.work/profile/alice", "alice")).toBe(true);
+  });
+
+  // --- The important negatives: this drives a visible trust chip. ---
+
+  it("does NOT credit a different builder's badge", () => {
+    // Pasting someone else's badge must not earn you the chip.
+    expect(detectVibeTalentBadge(MARKDOWN_SNIPPET, "bob")).toBe(false);
+  });
+
+  it("does NOT match a username that is only a prefix of the linked one", () => {
+    const readme = "https://www.vibetalent.work/profile/alicia";
+    expect(detectVibeTalentBadge(readme, "alice")).toBe(false);
+  });
+
+  it("does NOT match a bare link to the site with no profile", () => {
+    expect(detectVibeTalentBadge("Check out https://vibetalent.work", "alice")).toBe(false);
+    expect(detectVibeTalentBadge("https://vibetalent.work/leaderboard", "alice")).toBe(false);
+  });
+
+  it("does NOT match a lookalike domain", () => {
+    expect(
+      detectVibeTalentBadge("https://vibetalent.work.evil.com/profile/alice", "alice")
+    ).toBe(false);
+    expect(detectVibeTalentBadge("https://notvibetalent.work/profile/alice", "alice")).toBe(false);
+  });
+
+  it("returns false for empty or missing inputs", () => {
+    expect(detectVibeTalentBadge("", "alice")).toBe(false);
+    expect(detectVibeTalentBadge(MARKDOWN_SNIPPET, "")).toBe(false);
+    expect(detectVibeTalentBadge(MARKDOWN_SNIPPET, null)).toBe(false);
+    expect(detectVibeTalentBadge(MARKDOWN_SNIPPET, undefined)).toBe(false);
+  });
+
+  it("treats regex metacharacters in a username as literal", () => {
+    // A username can never compile into a wildcard that matches anyone.
+    expect(detectVibeTalentBadge("https://vibetalent.work/profile/a.ice", "a.ice")).toBe(true);
+    expect(detectVibeTalentBadge("https://vibetalent.work/profile/alice", "a.ice")).toBe(false);
+    expect(detectVibeTalentBadge("https://vibetalent.work/profile/xxxx", ".*")).toBe(false);
+  });
+});
+
+describe("toRepoQualityData", () => {
+  const metrics: RepoQualityMetrics = {
+    stars: 12, forks: 3, open_issues: 2, contributors: 4, total_commits: 90,
+    languages: { TypeScript: 50000 }, has_tests: true, has_ci: true,
+    has_readme: true, readme_length: 3000, has_vibetalent_badge: true,
+    last_commit_date: "2026-07-01T00:00:00Z", created_at: "2026-01-01T00:00:00Z",
+    repo_age_days: 200, is_private: false, community_score: 80,
+    substance_score: 75, maintenance_score: 70, quality_score: 75,
+  };
+
+  it("carries the badge flag through to the persisted shape", () => {
+    expect(toRepoQualityData(metrics).has_vibetalent_badge).toBe(true);
+  });
+
+  it("uses a caller-supplied analyzed_at when given", () => {
+    expect(toRepoQualityData(metrics, "2026-07-20T00:00:00Z").analyzed_at).toBe(
+      "2026-07-20T00:00:00Z"
+    );
+  });
+
+  it("does not leak raw analysis internals into the stored row", () => {
+    // quality_metrics is served to clients via /api/v1/builders — keep it to
+    // the agreed projection rather than whatever analyzeRepository grows next.
+    const keys = Object.keys(toRepoQualityData(metrics)).sort();
+    expect(keys).toEqual([
+      "analyzed_at", "community_score", "contributors", "forks", "has_ci",
+      "has_readme", "has_tests", "has_vibetalent_badge", "maintenance_score",
+      "quality_score", "stars", "substance_score", "total_commits",
+    ]);
+  });
+});

--- a/src/lib/github-quality.ts
+++ b/src/lib/github-quality.ts
@@ -1,3 +1,5 @@
+import type { RepoQualityData } from "./types/database";
+
 /**
  * GitHub Repository Quality Scoring
  *
@@ -21,6 +23,11 @@ export interface RepoQualityMetrics {
   has_ci: boolean;
   has_readme: boolean;
   readme_length: number;
+  // True when the repo's README links back to this builder's VibeTalent
+  // profile or badge. Deliberately does NOT feed any score: a README link is
+  // trivially fakeable, and this file's whole premise is scoring only signals
+  // that are hard to fake. It exists to render a "Badge Holder" chip.
+  has_vibetalent_badge: boolean;
   last_commit_date: string | null;
   created_at: string | null;
   repo_age_days: number;
@@ -66,6 +73,61 @@ function parseOAuthScopes(res: Response): string[] | null {
 }
 
 const GITHUB_API = "https://api.github.com";
+
+/**
+ * Detect a VibeTalent badge / profile backlink in a README.
+ *
+ * Scoped to one username on purpose: matching any vibetalent.work link would
+ * hand the chip to someone who pasted a *different* builder's badge (or merely
+ * linked the site). With `username` supplied, only that builder's own badge or
+ * profile URL counts.
+ *
+ * Matches the two shapes the dashboard's copy buttons emit, with or without
+ * `www`, http or https, and tolerates percent-encoding (the copy helpers run
+ * the username through encodeURIComponent):
+ *   https://www.vibetalent.work/api/badge/<username>
+ *   https://www.vibetalent.work/profile/<username>
+ */
+export function detectVibeTalentBadge(
+  readme: string,
+  username: string | null | undefined
+): boolean {
+  if (!readme || typeof username !== "string" || !username.trim()) return false;
+  // Usernames are alphanumeric + [-_.], but decode first so an encoded form
+  // still matches, and escape after so a username can never inject regex.
+  let decoded = username.trim();
+  try {
+    decoded = decodeURIComponent(decoded);
+  } catch {
+    // Malformed escape sequence — fall back to the raw value.
+  }
+  const escaped = decoded.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(
+    `https?://(?:www\\.)?vibetalent\\.work/(?:api/badge|profile)/${escaped}(?![A-Za-z0-9_-])`,
+    "i"
+  );
+  return pattern.test(readme);
+}
+
+/**
+ * Decode the base64 body GitHub returns from the /readme endpoint.
+ * Returns "" when the payload is missing — GitHub omits `content` for files
+ * over 1MB, which is not an error, just a README we can't inspect inline.
+ *
+ * atob (not Buffer) because this runs on Cloudflare Workers. The result is a
+ * binary string, so multi-byte UTF-8 lands as mojibake — harmless here, since
+ * we only ever search it for ASCII URLs.
+ */
+function decodeGithubContent(content: unknown, encoding: unknown): string {
+  if (typeof content !== "string" || !content) return "";
+  if (encoding !== "base64") return typeof content === "string" ? content : "";
+  try {
+    // GitHub wraps the base64 payload at 60 chars; atob rejects the newlines.
+    return atob(content.replace(/\s/g, ""));
+  } catch {
+    return "";
+  }
+}
 
 async function githubFetch(url: string, token?: string): Promise<Response> {
   const headers: Record<string, string> = {
@@ -123,7 +185,8 @@ export function parseGithubRepoUrl(
 export async function analyzeRepository(
   owner: string,
   repo: string,
-  token?: string
+  token?: string,
+  vibetalentUsername?: string | null
 ): Promise<RepoAnalysisResult> {
   try {
     // Fetch repo metadata, languages, contributors, and file tree in parallel
@@ -235,13 +298,22 @@ export async function analyzeRepository(
       );
     }
 
-    // Fetch README length if it exists
+    // Fetch README length if it exists. The same response already carries the
+    // file body, so badge detection rides along on this request rather than
+    // costing another GitHub API call against the rate limit.
+    let has_vibetalent_badge = false;
     if (has_readme) {
       try {
         const readmeRes = await githubFetch(`${GITHUB_API}/repos/${owner}/${repo}/readme`, token);
         if (readmeRes.ok) {
           const readmeData = await readmeRes.json();
           readme_length = readmeData.size || 0;
+          if (vibetalentUsername) {
+            has_vibetalent_badge = detectVibeTalentBadge(
+              decodeGithubContent(readmeData.content, readmeData.encoding),
+              vibetalentUsername
+            );
+          }
         }
       } catch {
         // non-critical
@@ -334,6 +406,7 @@ export async function analyzeRepository(
       has_ci,
       has_readme,
       readme_length,
+      has_vibetalent_badge,
       last_commit_date: lastPush?.toISOString() || null,
       created_at: repoData.created_at || null,
       repo_age_days: repoAgeDays,
@@ -353,6 +426,34 @@ export async function analyzeRepository(
       errorCode: "network_error",
     };
   }
+}
+
+/**
+ * Project the full analysis result down to the subset persisted in
+ * `projects.quality_metrics`. All four write paths (project create, manual
+ * verify, quality-rescore cron, verify-backfill cron) built this object by
+ * hand and identically — one shared projection so a new metric can't reach
+ * some paths and silently miss others.
+ */
+export function toRepoQualityData(
+  metrics: RepoQualityMetrics,
+  analyzedAt: string = new Date().toISOString()
+): RepoQualityData {
+  return {
+    stars: metrics.stars,
+    forks: metrics.forks,
+    contributors: metrics.contributors,
+    total_commits: metrics.total_commits,
+    has_tests: metrics.has_tests,
+    has_ci: metrics.has_ci,
+    has_readme: metrics.has_readme,
+    has_vibetalent_badge: metrics.has_vibetalent_badge,
+    community_score: metrics.community_score,
+    substance_score: metrics.substance_score,
+    maintenance_score: metrics.maintenance_score,
+    quality_score: metrics.quality_score,
+    analyzed_at: analyzedAt,
+  };
 }
 
 /**

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -46,6 +46,10 @@ export interface RepoQualityData {
   has_tests: boolean;
   has_ci: boolean;
   has_readme: boolean;
+  // Optional: absent on rows analyzed before badge detection shipped. Treat
+  // `undefined` as "unknown", not "no badge" — it only becomes authoritative
+  // after the next quality rescore of that project.
+  has_vibetalent_badge?: boolean;
   community_score: number;
   substance_score: number;
   maintenance_score: number;


### PR DESCRIPTION
The embeddable badge is your cheapest distribution channel — every one in a GitHub README is a backlink plus developer eyeballs — but it was buried in a dashboard sidebar with zero feedback once you used it. Now we detect it and acknowledge it.

## Deliberately worth zero points

Per your call: **flair only, no score.** A README link is trivially fakeable, and `github-quality.ts` exists to score "signals that are hard to fake" — inflating `quality_score` for a copy-paste would undercut the ranking model you've built. The reward is the visible chip.

- Project cards get a **`✓ Badge Holder`** chip next to Verified
- The dashboard's Embeddable Badge widget swaps its nudge for a confirmation ("Badge found in 2 repos — nice.")
- `quality_score` and `vibe_score` are untouched — `scoring-baseline` tests confirm zero drift

## Correctness details that mattered

- **Scoped to the owner's own username.** Pasting another builder's badge earns nothing. The check uses `users.username` (the profile slug in badge URLs), **not** `github_username` — two different values that both flow through this code path, and mixing them up would have made detection silently never match.
- **Zero extra GitHub API calls.** `analyzeRepository` already fetches `/readme` for its length; the same response carries the base64 body, so detection rides along instead of costing another call against the rate limit.
- **Wired into all four analysis paths** — project create, manual verify, quality-rescore cron, verify-backfill cron. A feature that only worked on one path would look broken at random.
- `atob`, not `Buffer` — this runs on Cloudflare Workers.

## Drive-by: `toRepoQualityData()`

All four paths hand-built the persisted `quality_metrics` object, identically, by hand. Adding a field meant editing four places and hoping. Extracted to one shared projection, with a test asserting the exact key set so the client-facing shape (it's served via `/api/v1/builders`) can't grow unnoticed.

## ⚠️ This fixes a regression I shipped in #233

#233 dropped `quality_metrics` from the dashboard's project select with the comment *"a JSONB blob nothing here renders."* **That was wrong.** `QualityScoreBadge` renders its Community/Substance/Maintenance breakdown from it.

**Live impact since #233 deployed:** on the dashboard only, clicking a project's quality score showed the generic beginner checklist ("Live URL / GitHub URL / Description >50 chars") instead of the real GitHub breakdown. Profile and `/projects` pages were unaffected — they use a different query that kept the column. No data loss, but wrong information shown. Restored here, with a comment explaining why the column has to stay.

## Verification

- **14 new tests**, including the negatives that matter: another builder's badge, a username that's only a prefix (`alice` vs `alicia`), lookalike domains (`vibetalent.work.evil.com`, `notvibetalent.work`), and regex metacharacters in a username (a username can never compile into a wildcard)
- **Verified against the live GitHub API**, not just fixtures — confirmed the real `/readme` payload is base64 *with embedded newlines* (so the whitespace strip is load-bearing), `atob` decodes byte-exact (11999 = reported size), and detection returns false when absent / true when present / false for a different user
- Browser-confirmed the quality popover renders the real breakdown when `quality_metrics` is present (screenshot evidence of the #233 fix path)
- 333/333 tests, `tsc`, `eslint src`, and `next build` all clean

## Rollout note

`has_vibetalent_badge` is only populated when a project is next analyzed, so chips appear gradually as the weekly `quality-rescore` cron works through the backlog — existing projects won't light up instantly. The type marks it optional so `undefined` reads as "unknown", not "no badge". To light everyone up sooner, trigger `quality-rescore` manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection of VibeTalent badges and profile links in repository READMEs.
  * Displayed a “Badge Holder” indicator on qualifying project cards.
  * Added dashboard guidance and success messaging for embeddable badges.
  * Included badge status in repository quality results.

* **Bug Fixes**
  * Standardized quality metric reporting across repository verification and analysis flows.
  * Improved badge matching for varied URL formats, capitalization, and encoded usernames.

* **Tests**
  * Added coverage for badge detection, edge cases, and quality metric output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->