### PR TITLE
fix: address CodeRabbit findings from #233 (4 production defects)

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -142,6 +142,7 @@ export default function DashboardPage() {
   // so mark-read / delete / reply need no manual counter bookkeeping.
   const [newHireSeed, setNewHireSeed] = useState(0);
   const [inboxLoaded, setInboxLoaded] = useState(false);
+  const [inboxError, setInboxError] = useState<string | null>(null);
   const [senderProfiles, setSenderProfiles] = useState<Record<string, { username: string }>>({});
   // Onboarding tour visibility. Initialized false on the server (SSR-safe);
   // the effect below reads the sessionStorage trigger or `?tour=force` query
@@ -731,12 +732,23 @@ export default function DashboardPage() {
     setLoadingInbox(true);
     const supabase = createClient();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { data } = await (supabase as any)
+    const { data, error } = await (supabase as any)
       .from("hire_requests")
       .select(INBOX_FIELDS)
       .eq("builder_id", user?.id)
       .order("created_at", { ascending: false });
+    // A failed query is not an empty inbox. Swallowing the error here would
+    // render "No hire requests yet" over real requests and — because the tab
+    // badge switches to deriving from this list once inboxLoaded flips — also
+    // clear the unread count the initial head-count had correctly seeded.
+    if (error) {
+      console.error("[dashboard] inbox fetch failed:", error);
+      setInboxError("Couldn't load your inbox. Check your connection and try again.");
+      setLoadingInbox(false);
+      return;
+    }
     const list: HireRequest[] = data || [];
+    setInboxError(null);
     setHireRequests(list);
     setInboxLoaded(true);
     setLoadingInbox(false);
@@ -1865,6 +1877,25 @@ export default function DashboardPage() {
               {[1, 2, 3].map((i) => (
                 <div key={i} className="skeleton h-32" />
               ))}
+            </div>
+          ) : inboxError ? (
+            <div
+              className="p-8 text-center"
+              style={{
+                backgroundColor: "var(--bg-surface)",
+                border: "2px solid var(--border-hard)",
+                boxShadow: "var(--shadow-brutal)",
+              }}
+              role="alert"
+            >
+              <Inbox size={40} className="mx-auto text-[var(--text-muted-soft)] mb-3" />
+              <h3 className="text-base font-extrabold uppercase text-[var(--foreground)]">
+                Couldn&apos;t load your inbox
+              </h3>
+              <p className="text-sm text-[var(--text-secondary)] font-medium mt-2">{inboxError}</p>
+              <button onClick={loadInbox} className="btn-brutal btn-brutal-secondary text-sm mt-4">
+                Retry
+              </button>
             </div>
           ) : hireRequests.length === 0 ? (
             <div

--- a/src/components/layout/navbar-client.tsx
+++ b/src/components/layout/navbar-client.tsx
@@ -156,10 +156,17 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
   // erase the dot a successful check had just set.
   const todayCheckRef = useRef<Promise<void> | null>(null);
   const todayCheckQueuedRef = useRef(false);
+  // Bumped on every auth transition (login, logout, account switch, cross-tab
+  // cache clear). A check captures the generation it started under and drops
+  // its result if that changed mid-flight — otherwise a response for the
+  // *previous* account can land after the new state is set and resurrect a dot
+  // for a user who just signed out.
+  const authGenerationRef = useRef(0);
 
   // `fresh` forces a follow-up fetch when a check is already in flight — used
-  // after streak writes, where the in-flight response may predate the write
-  // that fired the event. Plain callers just join the in-flight check.
+  // after streak writes (the in-flight response may predate the write that
+  // fired the event) and after auth transitions (it belongs to the old
+  // identity). Plain callers just join the in-flight check.
   const checkTodayLogged = useCallback(async (fresh = false) => {
     if (!isLoggedInRef.current) {
       setHasUnloggedActivity(false);
@@ -169,19 +176,25 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
       if (fresh) todayCheckQueuedRef.current = true;
       return todayCheckRef.current;
     }
+    const generation = authGenerationRef.current;
+    // True once the identity this check was issued for is no longer current.
+    const stale = () => authGenerationRef.current !== generation;
     const run = (async () => {
       try {
         const now = new Date();
         const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
         const fetchToday = () => fetch(`/api/streak/today-logged?date=${today}`);
         let res = await fetchToday();
+        if (stale()) return;
         if (res.status === 401 && isLoggedInRef.current) {
           // Hard refreshes, tab wakes, and the midnight rollover all hit this
           // endpoint right when the access token is most likely stale or
           // mid-rotation. Let supabase settle the session, then retry once
           // before believing the 401.
           await createClient().auth.getSession();
+          if (stale()) return;
           res = await fetchToday();
+          if (stale()) return;
         }
         if (res.status === 401) {
           // Confirmed signed out — clear rather than leaving a stale dot.
@@ -190,6 +203,7 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
         }
         if (!res.ok) return; // 429 / 5xx — transient; keep the last known state.
         const data = await res.json();
+        if (stale()) return;
         setHasUnloggedActivity(data.loggedToday === false);
       } catch {
         // Network blip — keep the last known state; the next focus or streak
@@ -322,11 +336,15 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
       // cached profile, so bail without touching state; onAuthStateChange's
       // INITIAL_SESSION and the next check reconcile the real auth state.
       if (error) return;
+      // Identity resolved — retire any check issued under the previous one.
+      authGenerationRef.current += 1;
       isLoggedInRef.current = !!user;
       setIsLoggedIn(!!user);
       if (user) {
         fetchProfile(user.id, user.email);
-        void checkTodayLogged();
+        // fresh: an in-flight check may belong to the prior identity, so join
+        // it AND queue a replacement rather than trusting its result.
+        void checkTodayLogged(true);
       } else {
         // Cookie genuinely expired or cleared (no error, no user) — drop the
         // cached profile so the next hard refresh doesn't flash it.
@@ -338,6 +356,9 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
 
     const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
       if (cancelled) return;
+      // Not on TOKEN_REFRESHED: the identity is unchanged there, and bumping
+      // would needlessly discard a perfectly valid in-flight check every hour.
+      if (event !== "TOKEN_REFRESHED") authGenerationRef.current += 1;
       isLoggedInRef.current = !!session?.user;
       setIsLoggedIn(!!session?.user);
       if (session?.user) {
@@ -346,7 +367,7 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
         // token rotation.
         if (event === "TOKEN_REFRESHED") return;
         fetchProfile(session.user.id, session.user.email);
-        void checkTodayLogged();
+        void checkTodayLogged(true);
       } else {
         setUserProfile(null);
         setHasUnloggedActivity(false);
@@ -391,6 +412,10 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
     const handleStorage = (e: StorageEvent) => {
       if (e.key !== NAV_PROFILE_CACHE_KEY) return;
       if (e.newValue === null) {
+        // Another tab logged out. Retire in-flight checks issued while we
+        // still believed we were signed in — otherwise one can resolve a
+        // moment later and re-light the dot on a logged-out navbar.
+        authGenerationRef.current += 1;
         isLoggedInRef.current = false;
         setIsLoggedIn(false);
         setUserProfile(null);
@@ -481,8 +506,13 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
   const handleLogout = async () => {
     const supabase = createClient();
     await supabase.auth.signOut();
+    // Retire in-flight dot checks and stop new ones before clearing state, so
+    // a response still in transit can't re-light the dot after logout.
+    authGenerationRef.current += 1;
+    isLoggedInRef.current = false;
     setIsLoggedIn(false);
     setUserProfile(null);
+    setHasUnloggedActivity(false);
     writeCachedNavProfile(null);
     setProfileDropdownOpen(false);
     router.push("/");

--- a/src/components/ui/notification-bell.tsx
+++ b/src/components/ui/notification-bell.tsx
@@ -85,6 +85,14 @@ export function NotificationBell() {
   const [unreadCount, setUnreadCount] = useState(0);
   const [loading, setLoading] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  // Mirrors `open` for the notifications-updated listener, which is registered
+  // once on mount and would otherwise capture the initial value forever.
+  // Synced in an effect rather than assigned during render — a render-phase
+  // ref write isn't safe under concurrent rendering (react-hooks/refs).
+  const openRef = useRef(open);
+  useEffect(() => {
+    openRef.current = open;
+  }, [open]);
   const router = useRouter();
 
   const fetchNotifications = useCallback(async () => {
@@ -115,7 +123,9 @@ export function NotificationBell() {
     }
   }, []);
 
-  /* eslint-disable react-hooks/set-state-in-effect */
+  /* eslint-disable react-hooks/set-state-in-effect -- this effect's setState
+     calls all happen after an await/timer boundary (fetch responses, polling
+     ticks), not during the effect body, so there's no cascading-render risk. */
   useEffect(() => {
     // Pause polling while the tab is hidden so background tabs don't keep
     // hitting /api/notifications (burning Cloudflare Worker invocations +
@@ -140,7 +150,17 @@ export function NotificationBell() {
         startPolling();
       }
     };
-    const handleRefresh = () => fetchNotifications();
+    // Refresh on external updates (e.g. logging activity clears streak
+    // warnings). Badge-only while the dropdown is closed: pulling the 50-row
+    // list for a popover nobody has opened would defeat the lazy-list contract
+    // below. Reads `open` through a ref so this listener never goes stale.
+    const handleRefresh = () => {
+      if (openRef.current) {
+        void fetchNotifications();
+      } else {
+        void fetchUnreadCount();
+      }
+    };
 
     // Badge-first initial load: one head-count query paints the unread badge
     // as fast as the Worker can auth, instead of waiting on the 50-row list +
@@ -150,8 +170,14 @@ export function NotificationBell() {
     // covers hard loads where the first hit lands while the auth cookie is
     // still settling and 401s.
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    // Cleanup can run while that first request is still in flight; without
+    // this flag the continuation would schedule a retry *after* unmount, past
+    // the clearTimeout in the cleanup, leaving a stray fetch and a setState on
+    // a dead component.
+     
+    let disposed = false;
     void fetchUnreadCount().then((ok) => {
-      if (!ok) {
+      if (!ok && !disposed) {
         retryTimer = setTimeout(() => void fetchUnreadCount(), 1500);
       }
     });
@@ -161,6 +187,7 @@ export function NotificationBell() {
       document.addEventListener("visibilitychange", onVisibilityChange);
     }
     return () => {
+      disposed = true;
       stopPolling();
       if (retryTimer !== null) clearTimeout(retryTimer);
       window.removeEventListener("notifications-updated", handleRefresh);
@@ -170,6 +197,7 @@ export function NotificationBell() {
     };
   }, [fetchNotifications, fetchUnreadCount]);
   /* eslint-enable react-hooks/set-state-in-effect */
+   
 
   // Click outside to close
   useEffect(() => {


### PR DESCRIPTION
CodeRabbit flagged 4 issues in code #233 already shipped to production. All four are real; all four are fixed here.

## 1. `loadInbox` treated a failed query as an empty inbox (Major)

`const { data } = await ...` discarded the error, so a transient auth or network failure rendered **"No hire requests yet" over real hire requests**. Worse, because #233 made the tab badge derive from the list once `inboxLoaded` flips, a failure also wiped the unread count the initial head-count had correctly seeded — so a user with pending requests saw an empty inbox *and* no badge.

Now checks the error, keeps the seeded badge, and shows an error state with a Retry button instead of a lie.

## 2. Navbar dot checks weren't tied to an auth identity (Major)

My serialization in #233 made this reachable: a check issued for the previous user could resolve **after** logout or an account switch and re-light the dot on a signed-out navbar.

Adds an auth generation counter, bumped on every identity transition — `getUser()` resolve, non-`TOKEN_REFRESHED` auth events, cross-tab logout via the `storage` event, and explicit logout. Each check captures the generation it started under and drops its result if it moved. Auth transitions now also request in `fresh` mode, so an in-flight check belonging to the *old* identity is replaced rather than joined and trusted.

Not bumped on `TOKEN_REFRESHED` — the identity is unchanged there, and bumping would discard a valid in-flight check every hour for nothing.

**Verified by modelling the race** in a standalone harness rather than asserting it by eye:

```
WITHOUT guard (pre-fix): dot after stale response = true    ← the bug
WITH guard:              dot after stale response = false   ← fixed
WITH guard, no auth change: dot set normally = true         ← no regression
```

## 3. Bell retry could be scheduled after unmount (Minor)

If the initial count request settled after unmount, cleanup had already seen a null timer, and the promise continuation then created one anyway — a stray fetch plus a `setState` on a dead component. Adds a `disposed` flag checked before scheduling.

## 4. `notifications-updated` defeated the lazy-list contract (Minor)

Good catch against my own stated design: #233 made the initial load badge-only so the 50-row list stays lazy, but the event listener still called `fetchNotifications()` — so logging activity pulled the full list even with the dropdown closed. Now badge-only while closed, full list only when open, read through a ref so the mount-time listener can't capture a stale value.

That ref is synced in an effect rather than assigned during render — the render-phase write tripped `react-hooks/refs`, and it isn't safe under concurrent rendering.

## Verification

- `tsc`, `eslint src`, 333/333 tests all clean
- Auth race modelled and asserted in both directions (see above)
- Note: two lint issues surfaced *during* this work (a `prefer-const` auto-fix colliding with a later reassignment, and a stripped `eslint-disable` block) — both resolved, not suppressed blindly

🤖 Generated with [Claude Code](https://claude.com/claude-code)