### PR TITLE
perf(streak): make Log Activity feel instant

### DIFF
--- a/src/app/api/streak/route.ts
+++ b/src/app/api/streak/route.ts
@@ -6,15 +6,20 @@ import { messagesLimiter, getIP, checkRateLimit } from "@/lib/rate-limit";
 
 // POST /api/streak — Log activity (auth required, logs for authenticated user only)
 export async function POST(request: NextRequest) {
-  // Rate limit: reuse messages limiter (60/min per IP)
-  const { success } = await checkRateLimit(messagesLimiter, getIP(request));
-  if (!success) {
-    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
-  }
-
   try {
+    // Rate limit (Upstash) and auth (GoTrue) are independent lookups against
+    // two different services, so run them concurrently instead of paying both
+    // round trips serially. On the Cloudflare→Supabase(Seoul) path that's
+    // ~100ms off every log — the user-visible cost of tapping Log Activity.
     const supabase = await createServerSupabaseClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const [{ success }, { data: { user } }] = await Promise.all([
+      checkRateLimit(messagesLimiter, getIP(request)),
+      supabase.auth.getUser(),
+    ]);
+
+    if (!success) {
+      return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+    }
 
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/streak/today-logged/route.ts
+++ b/src/app/api/streak/today-logged/route.ts
@@ -12,15 +12,18 @@ import { messagesLimiter, getIP, checkRateLimit } from "@/lib/rate-limit";
 export async function GET(request: NextRequest) {
   // Same limiter the streak POST uses — 60/min per IP. Enough headroom for
   // navbar refetches on focus changes; cheap insurance against scripted abuse.
-  const { success } = await checkRateLimit(messagesLimiter, getIP(request));
+  // Run concurrently with the auth lookup: they hit different services and
+  // don't depend on each other, so serializing them just added a round trip to
+  // every navbar dot check.
+  const supabase = await createServerSupabaseClient();
+  const [{ success }, { data: { user } }] = await Promise.all([
+    checkRateLimit(messagesLimiter, getIP(request)),
+    supabase.auth.getUser(),
+  ]);
+
   if (!success) {
     return NextResponse.json({ error: "Too many requests" }, { status: 429 });
   }
-
-  const supabase = await createServerSupabaseClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
 
   if (!user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -909,10 +909,49 @@ export default function DashboardPage() {
 
   const handleLogActivity = async () => {
     if (!user || todayLogged || logging) return;
-    setLogging(true);
     setLogError(null);
     const now = new Date();
     const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+
+    // Paint the result BEFORE the network call, not after.
+    //
+    // A log round-trips browser → Cloudflare edge → GoTrue (Seoul) → Postgres
+    // (Seoul) → back: three serial hops, ~350-500ms at best, over a second on
+    // a cold Worker, and roughly double that when the access token is stale
+    // (the 401 path below re-auths and re-posts). Blocking the button on all
+    // of that left it sitting on "Logging…" long enough to feel broken.
+    //
+    // Safe to do optimistically because the write is idempotent: the server
+    // upserts against the unique (user_id, activity_date) index, so a retry —
+    // or a double click that slips through — converges on the same single row.
+    // Every field touched here is restored by `rollback` if the write fails.
+    const prevStreak = user.streak;
+    const prevLongest = user.longest_streak;
+    const optimisticStreak = prevStreak + 1;
+
+    setUser((u) =>
+      u ? { ...u, streak: optimisticStreak, longest_streak: Math.max(optimisticStreak, u.longest_streak) } : u
+    );
+    setHeatmapData((h) => ({ ...h, [today]: (h[today] || 0) + 1 }));
+    setTodayLogged(true);
+    setLogging(true);
+
+    // Undo the optimistic paint. Uses functional updates and adjusts only
+    // today's cell rather than restoring a whole snapshot — the GitHub sync
+    // running in the background may legitimately have written other days while
+    // this request was in flight, and clobbering those would lose real data.
+    const rollback = () => {
+      setUser((u) => (u ? { ...u, streak: prevStreak, longest_streak: prevLongest } : u));
+      setHeatmapData((h) => {
+        const next = { ...h };
+        const remaining = (next[today] ?? 1) - 1;
+        if (remaining > 0) next[today] = remaining;
+        else delete next[today];
+        return next;
+      });
+      setTodayLogged(false);
+      setLogging(false);
+    };
 
     // Route through the server API (admin client, upsert-safe). Previously this
     // page inserted via the browser Supabase client, which 404'd in production
@@ -937,8 +976,8 @@ export default function DashboardPage() {
       }
     } catch (err) {
       console.error("Failed to log activity (network):", err);
+      rollback();
       setLogError("Network error — check your connection and try again.");
-      setLogging(false);
       return;
     }
 
@@ -950,20 +989,17 @@ export default function DashboardPage() {
       } catch {}
       if (res.status === 401) message = "Your session expired — refresh and sign in again.";
       console.error("Failed to log activity:", res.status, message);
+      rollback();
       setLogError(message);
-      setLogging(false);
       return;
     }
 
-    // Optimistically update streak in UI
-    const newStreak = user.streak + 1;
-    const newLongest = Math.max(newStreak, user.longest_streak);
-    setUser({ ...user, streak: newStreak, longest_streak: newLongest });
-    setHeatmapData({ ...heatmapData, [today]: (heatmapData[today] || 0) + 1 });
-    setTodayLogged(true);
     setLogging(false);
 
-    // Drop the navbar "unlogged activity" dot without a reload.
+    // Drop the navbar "unlogged activity" dot without a reload. Fired only
+    // after the write lands — the navbar re-checks against the server, so
+    // announcing it optimistically would just race the write and get the
+    // pre-write answer back.
     window.dispatchEvent(new Event("streak-updated"));
 
     // Mark streak warning notifications as read and refresh the bell


### PR DESCRIPTION
**Reported:** the Log Activity button sits on "Logging…" long enough to feel broken.

## Where the time actually goes (measured, not guessed)

A log costs three serial hops — browser → Cloudflare edge → **GoTrue (Seoul)** → **Postgres (Seoul)** → back. I checked each candidate:

| Suspect | Verdict |
|---|---|
| Supabase auth/REST degraded? | **No** — both answer in ~90-100ms warm |
| The DB write? | **No** — upsert is index-backed (`streak_logs_user_id_activity_date_key`) |
| Upstash rate limiter? | **No** — an unauth POST including it returns in ~150ms warm |
| Cold Worker | **Yes, partly** — first hit measured **1.36s** |
| The 401 retry from #233 | **Yes** — doubles everything when the token is stale |

That last one is mine. The retry I added yesterday fixed the false "session expired" message, but when the access token is stale it now costs **two full POSTs plus a token refresh** before the button moves. I traded latency for correctness and didn't address the perceived cost — this PR does.

So the floor is ~350-500ms and the ceiling is seconds, all of it spent staring at "Logging…".

## The fix: stop waiting

The write is idempotent — the server upserts against the unique `(user_id, activity_date)` index — so the streak count, heatmap cell, and button now update **immediately**, and roll back if the write fails. A retry, or a double click that slips through, converges on the same single row.

Perceived latency goes from "350ms–3s" to **zero**, and it stays zero regardless of Seoul round trips, cold Workers, or token refreshes.

### Rollback is surgical, not a snapshot

The subtle part. The GitHub auto-sync can write *other* days to the heatmap while the POST is in flight, so restoring a whole snapshot on failure would silently delete them. Rollback instead uses functional updates and decrements only today's cell.

Verified in a standalone model:

```
concurrent-sync rollback — surgical keeps 07-18: 4 | snapshot keeps 07-18: undefined
```

The naive version loses the concurrently-synced day; the shipped one keeps it while still clearing today.

## Also: one less round trip on the server

`checkRateLimit` (Upstash) and `auth.getUser()` (GoTrue) hit different services and don't depend on each other, but ran sequentially. Now concurrent in both `POST /api/streak` and `GET /api/streak/today-logged` — the latter is the navbar dot check, so it gets faster too.

The `streak-updated` event still fires only *after* the write lands: the navbar re-checks against the server, so announcing it optimistically would race the write and get the pre-write answer back.

## Verification

- `tsc`, `eslint src`, 333/333 tests clean
- Both refactored routes still return a correct 401 unauthenticated (confirms the `Promise.all` destructuring)
- Optimistic + rollback logic modelled and asserted across three scenarios: success, failure, and failure-during-concurrent-sync
- Not verifiable from here: the real signed-in click, since I have no session — worth a sanity check on your side after deploy

## Follow-up worth considering

Every authenticated request pays a **network** `auth.getUser()` to validate the JWT. Verifying it locally against the project's JWT secret would remove that hop entirely from every authed endpoint, not just this one. It's a security-sensitive change (signature verification has to be exactly right), so I'd rather do it deliberately than fold it in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activity logging now updates streak displays and heatmaps immediately for a more responsive experience.
  * Failed activity logs automatically restore the previous streak and heatmap values.

* **Bug Fixes**
  * Improved error handling ensures failed or unauthorized activity requests leave the dashboard in a consistent state.

* **Performance**
  * Streak authentication and rate-limit checks now run concurrently, helping requests complete more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->