### PR TITLE
perf(edge): cache static assets + optimized images at the edge

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -14,6 +14,13 @@
       "runtimeArgs": ["/opt/homebrew/bin/npm", "run", "dev"],
       "env": { "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" },
       "port": 3000
+    },
+    {
+      "name": "vibe-talent-worker",
+      "runtimeExecutable": "/opt/homebrew/bin/node",
+      "runtimeArgs": ["/opt/homebrew/bin/npx", "wrangler", "dev", "--port", "8788"],
+      "env": { "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" },
+      "port": 8788
     }
   ]
 }

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -17,8 +17,8 @@
     },
     {
       "name": "vibe-talent-worker",
-      "runtimeExecutable": "/opt/homebrew/bin/node",
-      "runtimeArgs": ["/opt/homebrew/bin/npx", "wrangler", "dev", "--port", "8788"],
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["wrangler", "dev", "--port", "8788"],
       "env": { "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" },
       "port": 8788
     }

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,41 @@
+# Cache policy for files served by Cloudflare Workers Static Assets.
+#
+# Workers Assets stamps EVERY asset with `public, max-age=0, must-revalidate`
+# by default, which tells the browser to re-check freshness before each use.
+# On this site that meant ~13 conditional requests (10 JS chunks, the CSS
+# bundle, 2 fonts) on every single page load — each a full round trip that
+# blocks hydration, and all of them paid again on the first visit of the day
+# once the in-memory cache is gone.
+#
+# Rules only apply to static-asset responses; SSR/route-handler responses come
+# from the Worker and are unaffected. Keep the patterns non-overlapping so
+# rule precedence never matters.
+#
+# https://developers.cloudflare.com/workers/static-assets/headers
+# https://opennext.js.org/cloudflare/caching#static-assets-caching
+
+# Next.js build output is content-hashed — the filename changes whenever the
+# bytes do — so it can be cached permanently and never revalidated.
+/_next/static/*
+  Cache-Control: public,max-age=31536000,immutable
+
+# Seed builder avatars. Stable filenames, so not immutable: a day of freshness
+# plus a week of stale-while-revalidate keeps return visits instant while a
+# replaced file still rolls out on its own.
+/avatars/*
+  Cache-Control: public,max-age=86400,stale-while-revalidate=604800
+
+# Brand/marketing images in public/. Same reasoning as above — these keep their
+# names across deploys, and og-image-v2.jpg is versioned in the filename when it
+# changes (social platforms cache previews by URL anyway).
+/logo.png
+  Cache-Control: public,max-age=86400,stale-while-revalidate=604800
+
+/og-image-v2.jpg
+  Cache-Control: public,max-age=86400,stale-while-revalidate=604800
+
+/roadmap.png
+  Cache-Control: public,max-age=86400,stale-while-revalidate=604800
+
+/favicon.ico
+  Cache-Control: public,max-age=86400,stale-while-revalidate=604800

--- a/worker.ts
+++ b/worker.ts
@@ -61,6 +61,23 @@ function negotiatedFormat(request: Request): string {
 }
 
 /**
+ * Is this `/_next/image` request pointed at an image this app generates?
+ *
+ * `/api/og/*`, `/api/share-card/*` and `/api/badge/*` render live user data —
+ * vibe score, streak, shipped project — behind a URL that carries no content
+ * version, which is why those routes deliberately choose a short TTL of their
+ * own (the receipt route caps the browser at 5 minutes). The optimizer drops
+ * that header — it returns no `Cache-Control` for *any* source — so taking
+ * over caching here would pin a stale badge or receipt for a full day.
+ *
+ * Leave them untouched. We only cache sources whose bytes are tied to their
+ * URL: remote avatars/thumbnails and files from public/.
+ */
+function isAppGeneratedImage(url: URL): boolean {
+  return (url.searchParams.get("url") ?? "").startsWith("/api/");
+}
+
+/**
  * Serve an optimized image from the colo cache when possible, otherwise let
  * OpenNext transform it and store the result. Output is deterministic for a
  * given (url, w, q) plus negotiated format, so this is safe to share across
@@ -120,7 +137,11 @@ export default {
         Response.redirect(`https://www.vibetalent.work${url.pathname}${url.search}`, 301),
       );
     }
-    if (request.method === "GET" && url.pathname === "/_next/image") {
+    if (
+      request.method === "GET" &&
+      url.pathname === "/_next/image" &&
+      !isAppGeneratedImage(url)
+    ) {
       return serveOptimizedImage(request, env, ctx, url);
     }
     return handler.fetch(request, env, ctx);

--- a/worker.ts
+++ b/worker.ts
@@ -3,9 +3,9 @@
  *
  * Wraps the OpenNext-generated worker (`.open-next/worker.js`, produced by
  * `opennextjs-cloudflare build`) to add Cloudflare Cron Trigger support via a
- * `scheduled()` handler, while preserving OpenNext's `fetch` handler and
- * re-exporting its Durable Object classes (which must be exported from the
- * Worker's main module).
+ * `scheduled()` handler and edge caching for optimized images, while preserving
+ * OpenNext's `fetch` handler and re-exporting its Durable Object classes (which
+ * must be exported from the Worker's main module).
  *
  * The cron schedules themselves live in wrangler.jsonc and are enabled at DNS
  * cutover (Phase 3). Each firing invokes the matching /api/cron/* route
@@ -22,6 +22,78 @@ type Env = {
   CRON_SECRET?: string;
   NEXT_PUBLIC_SITE_URL?: string;
 };
+
+/**
+ * Minimal shapes for the two Workers-only globals used below. The project's
+ * tsconfig loads the DOM lib rather than @cloudflare/workers-types (the two
+ * conflict), so these are declared locally — same approach the OpenNext import
+ * above already takes.
+ */
+type ExecutionContext = { waitUntil(promise: Promise<unknown>): void };
+type WorkerCaches = { default: Cache };
+
+/**
+ * Browser + edge TTL for `/_next/image` output.
+ *
+ * OpenNext's image route returns these with **no** `Cache-Control` at all — the
+ * Cloudflare IMAGES binding sets none, and `images.minimumCacheTTL` in
+ * next.config is a documented no-op on this adapter. So every avatar and
+ * project thumbnail was re-fetched *and* re-transformed on each page view
+ * (~1.2s for a 7KB avatar, measured on prod).
+ *
+ * A day of freshness keeps a swapped avatar from sticking around — GitHub and
+ * Supabase both reuse the same URL when a user changes their picture — and a
+ * week of stale-while-revalidate keeps return visits instant.
+ */
+const IMAGE_CACHE_CONTROL = "public, max-age=86400, stale-while-revalidate=604800";
+
+/**
+ * Output format the optimizer will negotiate for this request. One `/_next/image`
+ * URL can yield AVIF, WebP or the source bytes depending on `Accept`, so this
+ * has to be part of the cache key or a Safari user could be served AVIF.
+ * Mirrors Next.js' own pick-first-supported-of-`images.formats` order.
+ */
+function negotiatedFormat(request: Request): string {
+  const accept = request.headers.get("accept") ?? "";
+  if (accept.includes("image/avif")) return "avif";
+  if (accept.includes("image/webp")) return "webp";
+  return "src";
+}
+
+/**
+ * Serve an optimized image from the colo cache when possible, otherwise let
+ * OpenNext transform it and store the result. Output is deterministic for a
+ * given (url, w, q) plus negotiated format, so this is safe to share across
+ * users — and it turns the transform into a once-per-colo cost instead of a
+ * once-per-request one.
+ */
+async function serveOptimizedImage(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+  url: URL,
+): Promise<Response> {
+  const cache = (caches as unknown as WorkerCaches).default;
+
+  const keyUrl = new URL(url);
+  keyUrl.searchParams.set("_fmt", negotiatedFormat(request));
+  const cacheKey = new Request(keyUrl.toString(), { method: "GET" });
+
+  const hit = await cache.match(cacheKey);
+  if (hit) return hit;
+
+  const response = await handler.fetch(request, env, ctx);
+  // Only 200s are worth storing: errors should retry, and `cache.put` rejects
+  // on partial (206) responses anyway.
+  if (response.status !== 200) return response;
+
+  const cached = new Response(response.body, response);
+  cached.headers.set("cache-control", IMAGE_CACHE_CONTROL);
+  // Best-effort: a failed cache write costs us a transform next time, and must
+  // never surface as a Worker exception on a request that already succeeded.
+  ctx.waitUntil(cache.put(cacheKey, cached.clone()).catch(() => {}));
+  return cached;
+}
 
 /** Cloudflare cron expression -> internal cron route (mirrors vercel.json crons). */
 const CRON_ROUTES: Record<string, string> = {
@@ -40,13 +112,16 @@ const handler = openNextWorker as {
 };
 
 export default {
-  fetch(request: Request, env: Env, ctx: unknown): Promise<Response> {
+  fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     // apex -> www 301 redirect (replaces the vercel.json host redirect at cutover).
     const url = new URL(request.url);
     if (url.hostname === "vibetalent.work") {
       return Promise.resolve(
         Response.redirect(`https://www.vibetalent.work${url.pathname}${url.search}`, 301),
       );
+    }
+    if (request.method === "GET" && url.pathname === "/_next/image") {
+      return serveOptimizedImage(request, env, ctx, url);
     }
     return handler.fetch(request, env, ctx);
   },


### PR DESCRIPTION
## The report

> "visiting the site after a day … like we reboot the system. taking time to show the dashboard notification dot, loading takes time"

Reproduced and measured on prod. Two independent causes, both in how Cloudflare serves our responses — neither is in app code, which is why nothing in the React looked wrong.

## 1. Every static asset was revalidated on every page load

Cloudflare Workers Static Assets stamps `public, max-age=0, must-revalidate` on everything by default ([docs](https://developers.cloudflare.com/workers/static-assets/headers)). That tells the browser to re-check freshness before *using* a file it already has — so each page load fires a conditional request for all 10 JS chunks, the CSS bundle and both fonts, each a full round trip that blocks hydration. On the first visit of the day, with the in-memory cache gone, the entire set is paid at once. That is the "cold boot" feeling, and it's also why the notification dot is late — the bell can't fetch until React hydrates.

Measured on prod:

```
$ curl -sI https://www.vibetalent.work/_next/static/chunks/0_pck7j2o2yuy.js
cache-control: public, max-age=0, must-revalidate      # 209 hashed files ship with this
```

Next.js build output is content-hashed — the filename changes whenever the bytes do — so it's safe to cache permanently. `public/_headers` is copied verbatim into `.open-next/assets/` by the OpenNext build. This is the same fix `opennextjs-cloudflare migrate` writes for exactly this problem; this repo was migrated to Cloudflare by hand and never got the file.

`public/` files keep stable names across deploys, so they get a day of freshness plus a week of `stale-while-revalidate` rather than `immutable`.

## 2. Optimized images had no `Cache-Control` at all

OpenNext's image route returns `/_next/image` with **no** caching header — the Cloudflare IMAGES binding sets none, and `images.minimumCacheTTL` in next.config is a documented no-op on this adapter. Every avatar and thumbnail was re-fetched *and* re-transformed on each page view (~1.2s for a 7KB avatar). `worker.ts` now serves them through the colo cache and attaches a real TTL, so the transform becomes a once-per-colo cost.

The cache key includes the negotiated output format. One URL yields AVIF, WebP or the source bytes depending on `Accept`; keying on the URL alone would let a WebP-only browser be served AVIF.

TTL is 1 day + 7 days SWR rather than something longer because GitHub reuses the same avatar URL when a user swaps their picture. (Supabase-hosted avatars already bust themselves with a `?t=` param.)

## Verification

Against a local `wrangler dev` running the real built Worker:

| Request | Before | After |
|---|---|---|
| hashed JS chunk, fonts | `max-age=0, must-revalidate` | `max-age=31536000, immutable` |
| `logo.png`, `/avatars/*` | `max-age=0, must-revalidate` | `max-age=86400` + 7d SWR |
| `/_next/image` | *(no header)* | `max-age=86400` + 7d SWR |
| `/_next/image` repeat | — | 164ms → **6ms** (cache hit) |
| avif / webp / no-Accept | — | 3 distinct entries, no cross-serving |

- wrangler logs `✨ Parsed 6 valid header rules`
- `npm run test` — 333/333 pass
- `npx tsc --noEmit` — no new errors (the 2 `TS2578` on `worker.ts` pre-exist on main; a stale local `.open-next/` makes the directives look redundant, CI needs them)
- `eslint src worker.ts` — clean
- Homepage renders on the local Worker with no console errors

## Not addressed here

- **Worker cold start is 2.65s** (vs 0.05s warm, measured on prod). Inherent to a cold isolate on a bundle this size; it's why the HTML itself is slow on the first hit of the day. This PR doesn't change it — but it does mean the cold HTML is now the *only* thing paid, instead of the trigger for a 13-request revalidation cascade.
- **PR #229** (`/cdn-cgi/image` loader) stays blocked — `/cdn-cgi/image/...` still 404s, so Transformations aren't enabled on the zone yet. This PR is the unblocked interim fix and doesn't conflict with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved caching for optimized images to support faster repeat loads.
  * Added long-term caching for static build assets and selected public images.
* **Developer Experience**
  * Added a local debugging configuration for the worker service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->