### PR TITLE
perf(cache): stop the ISR revalidation storm, cache documents at the edge

### DIFF
--- a/open-next.config.ts
+++ b/open-next.config.ts
@@ -1,17 +1,44 @@
 import { defineCloudflareConfig } from "@opennextjs/cloudflare";
 import kvIncrementalCache from "@opennextjs/cloudflare/overrides/incremental-cache/kv-incremental-cache";
+import { withRegionalCache } from "@opennextjs/cloudflare/overrides/incremental-cache/regional-cache";
 import doQueue from "@opennextjs/cloudflare/overrides/queue/do-queue";
-import d1NextTagCache from "@opennextjs/cloudflare/overrides/tag-cache/d1-next-tag-cache";
+import doShardedTagCache from "@opennextjs/cloudflare/overrides/tag-cache/do-sharded-tag-cache";
 
 // OpenNext (Cloudflare) cache configuration.
-// - incrementalCache: KV      -> stores ISR output (`export const revalidate`).
-// - queue:            DO queue -> processes time-based ISR revalidations (required
-//                                 for time-based revalidate; DO = production-grade).
-// - tagCache:         D1       -> backs revalidateTag / revalidatePath.
+// - incrementalCache: KV behind a per-colo Cache API layer -> stores ISR output.
+// - queue:            DO queue -> processes time-based ISR revalidations.
+// - tagCache:         sharded DO -> backs revalidateTag / revalidatePath.
 // Bindings are declared in wrangler.jsonc (NEXT_INC_CACHE_KV, NEXT_CACHE_DO_QUEUE,
-// NEXT_TAG_CACHE_D1, WORKER_SELF_REFERENCE).
+// NEXT_TAG_CACHE_DO_SHARDED, WORKER_SELF_REFERENCE).
 export default defineCloudflareConfig({
-  incrementalCache: kvIncrementalCache,
+  // A bare Worker invocation on this account answers in ~30ms; a *cache-hit* page
+  // took ~330ms. That ~290ms gap was cache-layer I/O leaving the colo on every
+  // dynamic response. `withRegionalCache` keeps the ISR entry in the colo's
+  // Cache API so a hit stays local.
+  //
+  // `long-lived` sounds risky but isn't: a regional entry's max-age is the page's
+  // own `revalidate` (the 30-minute default only applies to entries that declare
+  // none), so the colo copy expires exactly when the ISR window does. On a
+  // regional hit OpenNext still refreshes from KV in `waitUntil`, off the
+  // response path.
+  //
+  // Second-order benefit, and the reason this ships with the queue fix: a
+  // regional hit is *fresh*, so it does not enqueue a revalidation. That removes
+  // most of the triggers that were driving the re-render storm.
+  incrementalCache: withRegionalCache(kvIncrementalCache, { mode: "long-lived" }),
   queue: doQueue,
-  tagCache: d1NextTagCache,
+  // Replaces the D1 tag cache. That D1 instance is pinned to ENAM (Newark) with
+  // read replication disabled, and OpenNext queries it with plain `prepare()`
+  // rather than the Sessions API — so read replicas would not have been used
+  // even if enabled. Every dynamic response paid a cross-planet round trip for a
+  // query whose own execution time is 0.2ms.
+  //
+  // `regionalCache` is the point: a hard refresh fires ~30 requests at once, and
+  // with it only the first pays the Durable Object hop while the rest read the
+  // colo copy. Its 5s default TTL bounds how long a `revalidateTag` takes to
+  // show up, comfortably inside what the profile and endorsement flows need.
+  tagCache: doShardedTagCache({
+    baseShardSize: 4,
+    regionalCache: true,
+  }),
 });

--- a/src/app/api/endorsements/route.ts
+++ b/src/app/api/endorsements/route.ts
@@ -107,11 +107,19 @@ export async function GET(req: NextRequest) {
     const endorsed = new Set<string>();
     const { data: { user } } = await supabase.auth.getUser();
     if (user) {
-      const { data: mine } = await sb
+      const { data: mine, error: mineError } = await sb
         .from("project_endorsements")
         .select("project_id")
         .in("project_id", projectIds)
         .eq("user_id", user.id);
+
+      // Swallowing this would report `user_endorsed: false` with a 200, so a
+      // user who has already endorsed sees an un-endorsed button and their next
+      // click POSTs a duplicate. Fail loudly instead — the button keeps its
+      // server-rendered count when the lookup errors.
+      if (mineError) {
+        return NextResponse.json({ error: "Failed to fetch endorsements" }, { status: 500 });
+      }
       for (const row of (mine ?? []) as { project_id: string }[]) {
         endorsed.add(row.project_id);
       }

--- a/src/app/api/endorsements/route.ts
+++ b/src/app/api/endorsements/route.ts
@@ -79,24 +79,31 @@ export async function GET(req: NextRequest) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sb = supabase as any;
 
-    // One row per endorsement across every requested project, tallied below.
-    // `head: true` counting can't group, so this reads the ids and counts them.
+    // Read the denormalised counter rather than tallying endorsement rows.
+    // Counting rows would return at most one PostgREST page, so a popular
+    // project — or a 50-id batch whose rows exceed the cap in total — would
+    // silently report a truncated count, and it materialises every endorsement
+    // just to discard it. This column is maintained by the POST/DELETE handlers
+    // below and is already what /api/v1/builders and the dashboard read.
+    // Bounded at one row per requested project, so it cannot be truncated.
     const { data: rows, error } = await sb
-      .from("project_endorsements")
-      .select("project_id")
-      .in("project_id", projectIds);
+      .from("projects")
+      .select("id, endorsement_count")
+      .in("id", projectIds);
 
     if (error) {
       return NextResponse.json({ error: "Failed to fetch endorsements" }, { status: 500 });
     }
 
     const counts = new Map<string, number>();
-    for (const row of (rows ?? []) as { project_id: string }[]) {
-      counts.set(row.project_id, (counts.get(row.project_id) ?? 0) + 1);
+    for (const row of (rows ?? []) as { id: string; endorsement_count: number | null }[]) {
+      counts.set(row.id, row.endorsement_count ?? 0);
     }
 
     // Which of these the caller has already endorsed — one query, not one per
-    // project, and only when there is a session to check.
+    // project, and only when there is a session to check. Unlike a raw count
+    // this is safe to read as rows: it is one endorsement per user per project,
+    // so the result is bounded by the batch size.
     const endorsed = new Set<string>();
     const { data: { user } } = await supabase.auth.getUser();
     if (user) {

--- a/src/app/api/endorsements/route.ts
+++ b/src/app/api/endorsements/route.ts
@@ -35,46 +35,96 @@ async function revalidateOwnerProfile(ownerId: string) {
  *   - Endorsements from higher-scored users weigh more (computed at read time)
  */
 
-// GET /api/endorsements?project_id=xxx — Get endorsement count + whether current user endorsed
+// Upper bound on a single batch. A page renders at most a few dozen cards, and
+// this keeps one request from turning into an unbounded `IN (...)` scan.
+const MAX_BATCH_PROJECT_IDS = 50;
+
+/**
+ * GET /api/endorsements
+ *
+ * Accepts either:
+ *   ?project_id=xxx    -> { count, user_endorsed }
+ *   ?project_ids=a,b,c -> { results: { a: { count, user_endorsed }, ... } }
+ *
+ * The batch form exists because every card mounts its own EndorseButton. One
+ * request per card meant a page of 12 projects fired 12 round trips, each a
+ * separate Worker invocation and each re-running `auth.getUser()`. Batched, any
+ * number of cards costs two queries and one auth check.
+ */
 export async function GET(req: NextRequest) {
   try {
     const { searchParams } = new URL(req.url);
-    const projectId = searchParams.get("project_id");
+    const singleId = searchParams.get("project_id");
+    const batchParam = searchParams.get("project_ids");
 
-    if (!projectId) {
+    if (!singleId && !batchParam) {
       return NextResponse.json({ error: "project_id is required" }, { status: 400 });
+    }
+
+    const projectIds = batchParam
+      ? [...new Set(batchParam.split(",").map((id) => id.trim()).filter(Boolean))]
+      : [singleId as string];
+
+    if (projectIds.length === 0) {
+      return NextResponse.json({ error: "project_ids is empty" }, { status: 400 });
+    }
+    if (projectIds.length > MAX_BATCH_PROJECT_IDS) {
+      return NextResponse.json(
+        { error: `project_ids accepts at most ${MAX_BATCH_PROJECT_IDS} ids` },
+        { status: 400 },
+      );
     }
 
     const supabase = await createServerSupabaseClient();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sb = supabase as any;
 
-    // Get count
-    const { count, error } = await sb
+    // One row per endorsement across every requested project, tallied below.
+    // `head: true` counting can't group, so this reads the ids and counts them.
+    const { data: rows, error } = await sb
       .from("project_endorsements")
-      .select("id", { count: "exact", head: true })
-      .eq("project_id", projectId);
+      .select("project_id")
+      .in("project_id", projectIds);
 
     if (error) {
       return NextResponse.json({ error: "Failed to fetch endorsements" }, { status: 500 });
     }
 
-    // Check if current user endorsed
-    let userEndorsed = false;
+    const counts = new Map<string, number>();
+    for (const row of (rows ?? []) as { project_id: string }[]) {
+      counts.set(row.project_id, (counts.get(row.project_id) ?? 0) + 1);
+    }
+
+    // Which of these the caller has already endorsed — one query, not one per
+    // project, and only when there is a session to check.
+    const endorsed = new Set<string>();
     const { data: { user } } = await supabase.auth.getUser();
     if (user) {
-      const { data: existing } = await sb
+      const { data: mine } = await sb
         .from("project_endorsements")
-        .select("id")
-        .eq("project_id", projectId)
-        .eq("user_id", user.id)
-        .single();
-      userEndorsed = !!existing;
+        .select("project_id")
+        .in("project_id", projectIds)
+        .eq("user_id", user.id);
+      for (const row of (mine ?? []) as { project_id: string }[]) {
+        endorsed.add(row.project_id);
+      }
+    }
+
+    // Preserve the original single-project response shape for existing callers.
+    if (!batchParam) {
+      return NextResponse.json({
+        count: counts.get(projectIds[0]) ?? 0,
+        user_endorsed: endorsed.has(projectIds[0]),
+      });
     }
 
     return NextResponse.json({
-      count: count || 0,
-      user_endorsed: userEndorsed,
+      results: Object.fromEntries(
+        projectIds.map((id) => [
+          id,
+          { count: counts.get(id) ?? 0, user_endorsed: endorsed.has(id) },
+        ]),
+      ),
     });
   } catch {
     return NextResponse.json({ error: "Server error" }, { status: 500 });

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -25,7 +25,10 @@ export const metadata: Metadata = {
   },
 };
 
-export const revalidate = 60;
+// Browse/ranking data moves on the order of hours (vibe score is recomputed
+// daily), so a 5-minute window is generous while cutting background re-renders
+// — and their Supabase fan-out — fivefold.
+export const revalidate = 300;
 
 export default async function ExplorePage() {
   let users: Awaited<ReturnType<typeof fetchAllUsersCached>>;

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -19,7 +19,9 @@ import type { FeedItem } from "@/components/feed/feed-types";
  * feed (separate keys so a stat-query failure can't poison the feed cache
  * and vice versa) — once warm, the page renders in single-digit ms.
  */
-export const revalidate = 60;
+// See the homepage: widened to 3 minutes to cut background re-renders. The feed
+// itself polls on the client, so this only affects the first painted snapshot.
+export const revalidate = 180;
 
 export default async function FeedPage() {
   // Run feed + stats in parallel. allSettled means a stats failure can't

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -26,7 +26,9 @@ export const metadata: Metadata = {
   },
 };
 
-export const revalidate = 60;
+// See /explore: rankings shift slowly, so 5 minutes trades no real freshness
+// for five times fewer background re-renders.
+export const revalidate = 300;
 
 export default async function LeaderboardPage() {
   let users: Awaited<ReturnType<typeof fetchAllUsersCached>>;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,7 +23,11 @@ import { Flame, Trophy, GitCommitHorizontal, Zap, ArrowRight } from "lucide-reac
 const HOMEPAGE_FEED_V2_ENABLED =
   process.env.NEXT_PUBLIC_ENABLE_HOMEPAGE_FEED_V2 === "true";
 
-export const revalidate = 60;
+// 3 minutes rather than 1: every expiry schedules a background re-render that
+// fans out to Supabase, and the live parts of this page (activity feed, network
+// feed) poll on the client anyway — so a wider server window costs no freshness
+// a visitor can perceive.
+export const revalidate = 180;
 
 const FAQ_ITEMS = [
   {

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -25,7 +25,10 @@ export const metadata: Metadata = {
   },
 };
 
-export const revalidate = 60;
+// See /explore. Note this is the outer window only — `fetchAllProjectsCached`
+// keeps its own 60s `unstable_cache` entry, so widening here changes how often
+// the page re-renders, not how fresh the data is when it does.
+export const revalidate = 300;
 
 export default async function ProjectsPage() {
   let projects: Awaited<ReturnType<typeof fetchAllProjectsCached>>;

--- a/src/components/layout/navbar-client.tsx
+++ b/src/components/layout/navbar-client.tsx
@@ -589,6 +589,12 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
                   key={link.href}
                   href={link.href}
                   role="menuitem"
+                  // Dropdown contents are `display:none` until opened, so they
+                  // all become visible at once — prefetching would fire the
+                  // whole menu's RSC payloads as a burst the moment a pointer
+                  // grazes the trigger. Every one of those is a Worker
+                  // invocation, and the click that follows is a single route.
+                  prefetch={false}
                   onClick={() => setExploreOpen(false)}
                   className="px-4 py-2.5 text-sm font-bold uppercase tracking-wide transition-colors hover:bg-[var(--accent)]/10"
                   style={{
@@ -657,6 +663,8 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
                 <Link
                   key={link.href}
                   href={link.href}
+                  // See the Explore dropdown above.
+                  prefetch={false}
                   onClick={() => setMoreOpen(false)}
                   className="px-4 py-2.5 text-sm font-bold uppercase tracking-wide transition-colors hover:bg-[var(--accent)]/10"
                   style={{
@@ -758,6 +766,10 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
                   <Link
                     href={`/profile/${userProfile?.username || ""}`}
                     role="menuitem"
+                    // Profile dropdown, same reasoning as the Explore menu: the
+                    // whole panel unhides at once, so prefetch turns one hover
+                    // into four Worker invocations.
+                    prefetch={false}
                     onClick={() => setProfileDropdownOpen(false)}
                     className="flex items-center gap-2 px-4 py-3 text-sm font-bold uppercase tracking-wide transition-colors"
                     style={{ color: "var(--foreground)" }}
@@ -768,6 +780,7 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
                   <Link
                     href={`/profile/${userProfile?.username || ""}/achievements`}
                     role="menuitem"
+                    prefetch={false}
                     onClick={() => setProfileDropdownOpen(false)}
                     className="flex items-center gap-2 px-4 py-3 text-sm font-bold uppercase tracking-wide transition-colors"
                     style={{ color: "var(--foreground)" }}
@@ -778,6 +791,7 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
                   <Link
                     href={userProfile && !userProfile.display_name ? "/settings?complete=name" : "/settings"}
                     role="menuitem"
+                    prefetch={false}
                     onClick={() => setProfileDropdownOpen(false)}
                     className="flex items-center gap-2 px-4 py-3 text-sm font-bold uppercase tracking-wide transition-colors"
                     style={{ color: "var(--foreground)" }}
@@ -805,6 +819,7 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
                   <Link
                     href="/settings#referral"
                     role="menuitem"
+                    prefetch={false}
                     onClick={() => setProfileDropdownOpen(false)}
                     className="flex items-center gap-2 px-4 py-3 text-sm font-bold uppercase tracking-wide transition-colors"
                     style={{ color: "var(--foreground)" }}
@@ -947,6 +962,10 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
             <Link
               key={link.href}
               href={link.href}
+              // The mobile sheet renders every route at once, so prefetching
+              // here would fan out the entire menu on open — worst case on the
+              // connections least able to absorb it.
+              prefetch={false}
               onClick={() => setMobileOpen(false)}
               className="relative inline-block px-4 py-3 text-sm font-bold uppercase tracking-wide"
               style={{
@@ -960,6 +979,7 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
             <Link
               key={link.href}
               href={link.href}
+              prefetch={false}
               onClick={() => setMobileOpen(false)}
               className="relative inline-block px-4 py-3 text-sm font-bold uppercase tracking-wide"
               style={{
@@ -991,6 +1011,7 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
               <Link
                 key={link.href}
                 href={link.href}
+                prefetch={false}
                 onClick={() => setMobileOpen(false)}
                 className="relative inline-block px-4 py-3 text-sm font-bold uppercase tracking-wide"
                 style={{
@@ -1017,6 +1038,7 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
               <>
                 <Link
                   href={`/profile/${userProfile.username}`}
+                  prefetch={false}
                   onClick={() => setMobileOpen(false)}
                   className="block px-4 py-3 mt-1 text-sm font-bold uppercase tracking-wide text-[var(--foreground)]"
                 >
@@ -1024,6 +1046,7 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
                 </Link>
                 <Link
                   href={`/profile/${userProfile.username}/achievements`}
+                  prefetch={false}
                   onClick={() => setMobileOpen(false)}
                   className="block px-4 py-3 text-sm font-bold uppercase tracking-wide text-[var(--foreground)]"
                 >
@@ -1031,6 +1054,7 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
                 </Link>
                 <Link
                   href="/settings"
+                  prefetch={false}
                   onClick={() => setMobileOpen(false)}
                   className="block px-4 py-3 text-sm font-bold uppercase tracking-wide text-[var(--foreground)]"
                 >
@@ -1038,6 +1062,7 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
                 </Link>
                 <Link
                   href="/settings#referral"
+                  prefetch={false}
                   onClick={() => setMobileOpen(false)}
                   className="block px-4 py-3 text-sm font-bold uppercase tracking-wide text-[var(--foreground)]"
                 >

--- a/src/components/ui/endorse-button.tsx
+++ b/src/components/ui/endorse-button.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import { ThumbsUp } from "lucide-react";
+import { fetchEndorsementState } from "@/lib/endorsement-batch";
 
 interface EndorseButtonProps {
   projectId: string;
@@ -21,22 +22,21 @@ export function EndorseButton({ projectId, initialCount, isOwner = false }: Endo
   // their optimistic toggle with stale pre-click values.
   const interacted = useRef(false);
 
-  // Check endorsement state on mount so button shows correct state after refresh
+  // Check endorsement state on mount so button shows correct state after refresh.
+  // Goes through the batcher: every card on the page mounts in the same tick, so
+  // they share one request instead of one Worker invocation each.
   useEffect(() => {
     if (isOwner) return;
-    const controller = new AbortController();
-    fetch(`/api/endorsements?project_id=${projectId}`, { signal: controller.signal })
-      .then((res) => (res.ok ? res.json() : null))
+    let cancelled = false;
+    fetchEndorsementState(projectId)
       .then((data) => {
-        if (data && !interacted.current) {
+        if (!cancelled && !interacted.current) {
           setEndorsed(data.user_endorsed);
           setCount(data.count);
         }
       })
-      .catch((err) => {
-        if (err.name !== "AbortError") { /* silent */ }
-      });
-    return () => { controller.abort(); };
+      .catch(() => { /* silent — the card keeps its server-rendered count */ });
+    return () => { cancelled = true; };
   }, [projectId, isOwner]);
 
   async function handleToggle() {

--- a/src/lib/__tests__/endorsement-batch.test.ts
+++ b/src/lib/__tests__/endorsement-batch.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fetchEndorsementState } from "../endorsement-batch";
+
+/** Reads the `project_ids` a stubbed fetch call was made with. */
+function idsFrom(call: string) {
+  const query = new URL(call, "http://localhost").searchParams.get("project_ids");
+  return (query ?? "").split(",").filter(Boolean);
+}
+
+function jsonResponse(results: Record<string, { count: number; user_endorsed: boolean }>) {
+  return { ok: true, status: 200, json: async () => ({ results }) } as unknown as Response;
+}
+
+describe("fetchEndorsementState", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("coalesces concurrent lookups into a single request", async () => {
+    const states = {
+      a: { count: 3, user_endorsed: true },
+      b: { count: 0, user_endorsed: false },
+      c: { count: 7, user_endorsed: false },
+    };
+    // Answer only what was asked for, the way the route handler does.
+    const fetchMock = vi.fn(async (url: string) =>
+      jsonResponse(
+        Object.fromEntries(idsFrom(url).map((id) => [id, states[id as keyof typeof states]])),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    // Three cards mounting in the same tick, exactly as a project grid does.
+    const pending = Promise.all([
+      fetchEndorsementState("a"),
+      fetchEndorsementState("b"),
+      fetchEndorsementState("c"),
+    ]);
+
+    await vi.runAllTimersAsync();
+    const results = await pending;
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(idsFrom(fetchMock.mock.calls[0][0] as unknown as string)).toEqual(["a", "b", "c"]);
+    expect(results).toEqual([
+      { count: 3, user_endorsed: true },
+      { count: 0, user_endorsed: false },
+      { count: 7, user_endorsed: false },
+    ]);
+  });
+
+  it("dedupes a project requested by more than one card but settles both", async () => {
+    const fetchMock = vi.fn(async (url: string) =>
+      jsonResponse(
+        Object.fromEntries(idsFrom(url).map((id) => [id, { count: 2, user_endorsed: false }])),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pending = Promise.all([fetchEndorsementState("dup"), fetchEndorsementState("dup")]);
+    await vi.runAllTimersAsync();
+    const results = await pending;
+
+    expect(idsFrom(fetchMock.mock.calls[0][0] as unknown as string)).toEqual(["dup"]);
+    expect(results).toEqual([
+      { count: 2, user_endorsed: false },
+      { count: 2, user_endorsed: false },
+    ]);
+  });
+
+  it("splits batches larger than the route handler's 50-id cap", async () => {
+    const ids = Array.from({ length: 60 }, (_, i) => `p${i}`);
+    const fetchMock = vi.fn(async (url: string) =>
+      jsonResponse(
+        Object.fromEntries(idsFrom(url).map((id) => [id, { count: 1, user_endorsed: false }])),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pending = Promise.all(ids.map((id) => fetchEndorsementState(id)));
+    await vi.runAllTimersAsync();
+    const results = await pending;
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(idsFrom(fetchMock.mock.calls[0][0] as unknown as string)).toHaveLength(50);
+    expect(idsFrom(fetchMock.mock.calls[1][0] as unknown as string)).toHaveLength(10);
+    expect(results).toHaveLength(60);
+  });
+
+  it("rejects every waiter when the request fails, rather than hanging", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 500 }) as Response));
+
+    const settled = Promise.allSettled([fetchEndorsementState("x"), fetchEndorsementState("y")]);
+    await vi.runAllTimersAsync();
+
+    expect((await settled).map((r) => r.status)).toEqual(["rejected", "rejected"]);
+  });
+
+  it("starts a fresh batch after the previous one has flushed", async () => {
+    const fetchMock = vi.fn(async (url: string) =>
+      jsonResponse(
+        Object.fromEntries(idsFrom(url).map((id) => [id, { count: 0, user_endorsed: false }])),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const first = fetchEndorsementState("first");
+    await vi.runAllTimersAsync();
+    await first;
+
+    const second = fetchEndorsementState("second");
+    await vi.runAllTimersAsync();
+    await second;
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(idsFrom(fetchMock.mock.calls[1][0] as unknown as string)).toEqual(["second"]);
+  });
+});

--- a/src/lib/__tests__/endorsement-batch.test.ts
+++ b/src/lib/__tests__/endorsement-batch.test.ts
@@ -101,6 +101,28 @@ describe("fetchEndorsementState", () => {
     expect((await settled).map((r) => r.status)).toEqual(["rejected", "rejected"]);
   });
 
+  it("rejects only the waiter a successful response left out", async () => {
+    // The route answers 200 but omits one id — a project deleted between render
+    // and lookup, say. The present one must still resolve.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ present: { count: 4, user_endorsed: false } })),
+    );
+
+    const settled = Promise.allSettled([
+      fetchEndorsementState("present"),
+      fetchEndorsementState("absent"),
+    ]);
+    await vi.runAllTimersAsync();
+    const [present, absent] = await settled;
+
+    expect(present).toEqual({
+      status: "fulfilled",
+      value: { count: 4, user_endorsed: false },
+    });
+    expect(absent.status).toBe("rejected");
+  });
+
   it("starts a fresh batch after the previous one has flushed", async () => {
     const fetchMock = vi.fn(async (url: string) =>
       jsonResponse(

--- a/src/lib/endorsement-batch.ts
+++ b/src/lib/endorsement-batch.ts
@@ -1,0 +1,72 @@
+/**
+ * Coalesces the per-card endorsement lookups into one request.
+ *
+ * Every `<EndorseButton>` checks its own state on mount. On a grid of project
+ * cards that meant one `/api/endorsements` call per card — each a separate
+ * Cloudflare Worker invocation that re-ran `auth.getUser()` against Supabase.
+ * A homepage load was measurably spending ~800ms per card on this.
+ *
+ * All those effects run in the same tick, so a zero-delay timer is enough to
+ * gather them into a single `?project_ids=` request. Callers keep a plain
+ * promise-returning API and don't need to know they were batched.
+ */
+
+export type EndorsementState = { count: number; user_endorsed: boolean };
+
+type Waiter = {
+  id: string;
+  resolve: (state: EndorsementState) => void;
+  reject: (reason: unknown) => void;
+};
+
+// Mirrors MAX_BATCH_PROJECT_IDS in the route handler — larger requests are
+// rejected there, so split before sending rather than after being refused.
+const MAX_BATCH = 50;
+
+let queue: Waiter[] = [];
+let timer: ReturnType<typeof setTimeout> | null = null;
+
+async function flushChunk(waiters: Waiter[], ids: string[]) {
+  try {
+    const res = await fetch(
+      `/api/endorsements?project_ids=${ids.map(encodeURIComponent).join(",")}`,
+    );
+    if (!res.ok) throw new Error(`Endorsements request failed: ${res.status}`);
+
+    const body = (await res.json()) as { results?: Record<string, EndorsementState> };
+    for (const waiter of waiters) {
+      const state = body.results?.[waiter.id];
+      if (state) waiter.resolve(state);
+      else waiter.reject(new Error(`No endorsement state for project ${waiter.id}`));
+    }
+  } catch (err) {
+    for (const waiter of waiters) waiter.reject(err);
+  }
+}
+
+function flush() {
+  const batch = queue;
+  queue = [];
+  timer = null;
+
+  // Several buttons can ask for the same project (a builder's project appearing
+  // in two sections), so dedupe the ids while still settling every waiter.
+  const uniqueIds = [...new Set(batch.map((w) => w.id))];
+
+  for (let i = 0; i < uniqueIds.length; i += MAX_BATCH) {
+    const ids = uniqueIds.slice(i, i + MAX_BATCH);
+    const inChunk = new Set(ids);
+    void flushChunk(
+      batch.filter((w) => inChunk.has(w.id)),
+      ids,
+    );
+  }
+}
+
+/** Resolves this project's endorsement state, batched with any concurrent asks. */
+export function fetchEndorsementState(projectId: string): Promise<EndorsementState> {
+  return new Promise((resolve, reject) => {
+    queue.push({ id: projectId, resolve, reject });
+    timer ??= setTimeout(flush, 0);
+  });
+}

--- a/worker.ts
+++ b/worker.ts
@@ -177,15 +177,35 @@ function hasAuthCookie(request: Request): boolean {
  * which Cloudflare does not do for Worker responses on its own.
  */
 function sharedCacheTtl(response: Response): number {
-  const cc = response.headers.get("cache-control");
-  if (!cc) return 0;
-  const lower = cc.toLowerCase();
-  if (lower.includes("private") || lower.includes("no-store") || lower.includes("no-cache")) {
+  const header = response.headers.get("cache-control");
+  if (!header) return 0;
+
+  // Parse directive names rather than substring-matching the raw header. A
+  // substring test reads `s-maxage` out of a longer token such as
+  // `x-s-maxage=300` and would cache a response the origin never marked
+  // shareable — the one failure direction that matters here. (`no-cache=
+  // "set-cookie"` and vendor extensions like `x-no-store` fail the safe way,
+  // but are handled correctly by the same parse.)
+  const directives = new Map<string, string>();
+  for (const part of header.split(",")) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    const eq = trimmed.indexOf("=");
+    const name = (eq === -1 ? trimmed : trimmed.slice(0, eq)).trim().toLowerCase();
+    if (name) directives.set(name, eq === -1 ? "" : trimmed.slice(eq + 1).trim());
+  }
+
+  if (directives.has("private") || directives.has("no-store") || directives.has("no-cache")) {
     return 0;
   }
-  const match = /s-maxage=(\d+)/.exec(lower);
-  if (!match) return 0;
-  return Math.min(Number(match[1]), MAX_DOCUMENT_EDGE_TTL_SECONDS);
+
+  const sMaxAge = directives.get("s-maxage");
+  // Strict digits: `Number.parseInt` would happily read 60 out of "60junk".
+  if (!sMaxAge || !/^\d+$/.test(sMaxAge)) return 0;
+
+  const seconds = Number(sMaxAge);
+  if (seconds <= 0) return 0;
+  return Math.min(seconds, MAX_DOCUMENT_EDGE_TTL_SECONDS);
 }
 
 /**

--- a/worker.ts
+++ b/worker.ts
@@ -112,6 +112,174 @@ async function serveOptimizedImage(
   return cached;
 }
 
+/**
+ * Ceiling on how long a document may sit in the colo cache, in seconds.
+ *
+ * The effective TTL is `min(the response's own s-maxage, this)`, so this never
+ * introduces staleness the origin hadn't already sanctioned — it only stops a
+ * long ISR window from pinning a document at the edge for minutes, which would
+ * blunt the `revalidateTag` calls that fire on project verification and
+ * endorsement.
+ */
+const MAX_DOCUMENT_EDGE_TTL_SECONDS = 60;
+
+/**
+ * Carry the origin's own Cache-Control and Vary across a cache round trip.
+ *
+ * Both are rewritten on the stored copy and restored on the way out, so what a
+ * client sees is byte-identical to an uncached response. `Vary` in particular
+ * has to come off: Cloudflare's Cache API only honours `Vary: Accept-Encoding`
+ * and can decline to store anything else, which would turn this whole path into
+ * a silent no-op. The RSC variant is already folded into the cache key by
+ * `documentCacheKey`, so dropping the header loses no correctness.
+ */
+const ORIGIN_CACHE_CONTROL_HEADER = "x-vt-origin-cache-control";
+const ORIGIN_VARY_HEADER = "x-vt-origin-vary";
+
+/** Restore the origin's Cache-Control/Vary onto a copy taken from the cache. */
+function restoreOriginHeaders(source: Headers, edgeState: "HIT" | "MISS"): Headers {
+  const headers = new Headers(source);
+  const cacheControl = headers.get(ORIGIN_CACHE_CONTROL_HEADER);
+  const vary = headers.get(ORIGIN_VARY_HEADER);
+
+  if (cacheControl) headers.set("cache-control", cacheControl);
+  else headers.delete("cache-control");
+  if (vary) headers.set("vary", vary);
+
+  headers.delete(ORIGIN_CACHE_CONTROL_HEADER);
+  headers.delete(ORIGIN_VARY_HEADER);
+  headers.set("x-vt-edge", edgeState);
+  return headers;
+}
+
+/**
+ * Does this request carry a logged-in Supabase session?
+ *
+ * Mirrors `hasAuthSessionCookie` in src/lib/supabase/middleware.ts, including
+ * chunked cookies (`sb-<ref>-auth-token.0`) and excluding the PKCE
+ * `-code-verifier` cookie a mid-OAuth visitor carries. Anything matching here
+ * is never read from, nor written to, the shared cache.
+ */
+function hasAuthCookie(request: Request): boolean {
+  const cookie = request.headers.get("cookie");
+  if (!cookie) return false;
+  return cookie
+    .split(";")
+    .some((part) => /^sb-.+-auth-token(\.\d+)?=.+$/.test(part.trim()));
+}
+
+/**
+ * Seconds this response may be shared-cached, or 0 when it must not be.
+ *
+ * `s-maxage` is precisely the directive for a shared cache like this one, and
+ * OpenNext already sets it on ISR output while marking everything dynamic or
+ * personalised `private`/`no-store`. So the origin decides; we just enforce it,
+ * which Cloudflare does not do for Worker responses on its own.
+ */
+function sharedCacheTtl(response: Response): number {
+  const cc = response.headers.get("cache-control");
+  if (!cc) return 0;
+  const lower = cc.toLowerCase();
+  if (lower.includes("private") || lower.includes("no-store") || lower.includes("no-cache")) {
+    return 0;
+  }
+  const match = /s-maxage=(\d+)/.exec(lower);
+  if (!match) return 0;
+  return Math.min(Number(match[1]), MAX_DOCUMENT_EDGE_TTL_SECONDS);
+}
+
+/**
+ * Cache key for a document request.
+ *
+ * The response varies on the RSC negotiation headers, and Cloudflare's Cache
+ * API does not honour `Vary` beyond `Accept-Encoding` — so the variant has to
+ * be folded into the key or a router prefetch and a full navigation would
+ * collide. Same trick as `negotiatedFormat` above.
+ */
+function documentCacheKey(request: Request, url: URL): Request {
+  const keyUrl = new URL(url);
+  const variant = [
+    request.headers.get("rsc") ? "rsc" : "html",
+    request.headers.get("next-router-prefetch") ? "pf" : "",
+    request.headers.get("next-router-state-tree") ? "st" : "",
+    request.headers.get("next-router-segment-prefetch") ?? "",
+  ]
+    .filter(Boolean)
+    .join("-");
+  keyUrl.searchParams.set("_vtvariant", variant);
+  return new Request(keyUrl.toString(), { method: "GET" });
+}
+
+/** Is this a path whose documents we are willing to share between visitors? */
+function isCacheableDocumentPath(pathname: string): boolean {
+  // Route handlers are excluded wholesale: several are per-user (notifications,
+  // streak, hire) and the image-ish ones (og, share-card, badge, receipt) pick
+  // deliberate TTLs of their own that this must not override.
+  if (pathname.startsWith("/api/")) return false;
+  // Served by the assets layer or the image branch above; never reaches here in
+  // practice, but keeps the intent explicit.
+  if (pathname.startsWith("/_next/")) return false;
+  return true;
+}
+
+/**
+ * Serve a document from the colo cache when the origin marked it shareable.
+ *
+ * Why this exists: Cloudflare does not cache Worker responses, so every HTML
+ * document and every RSC prefetch payload was reaching the Worker — measured at
+ * ~30 Worker invocations for a single homepage view, each paying the full
+ * OpenNext cache path. A hard refresh fires that whole set at once, which is
+ * exactly when the site felt slowest.
+ *
+ * Only anonymous requests participate, and only responses the origin already
+ * declared publicly shareable, so nothing user-specific can be served across
+ * sessions.
+ */
+async function serveDocument(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+  url: URL,
+): Promise<Response> {
+  const cache = (caches as unknown as WorkerCaches).default;
+  const cacheKey = documentCacheKey(request, url);
+
+  const hit = await cache.match(cacheKey);
+  if (hit) {
+    return new Response(hit.body, {
+      status: hit.status,
+      headers: restoreOriginHeaders(hit.headers, "HIT"),
+    });
+  }
+
+  const response = await handler.fetch(request, env, ctx);
+
+  const ttl = sharedCacheTtl(response);
+  // `Set-Cookie` means the response was personalised for this caller (the
+  // Supabase middleware refreshing a session, most often) and must never be
+  // shared, whatever its Cache-Control says.
+  if (response.status !== 200 || ttl <= 0 || response.headers.has("set-cookie")) {
+    return response;
+  }
+
+  const stored = new Response(response.body, response);
+  stored.headers.set(ORIGIN_CACHE_CONTROL_HEADER, response.headers.get("cache-control") ?? "");
+  const originVary = response.headers.get("vary");
+  if (originVary) stored.headers.set(ORIGIN_VARY_HEADER, originVary);
+  stored.headers.set("cache-control", `public, max-age=${ttl}`);
+  stored.headers.delete("vary");
+
+  // Best-effort, exactly as with images: a failed write costs one extra origin
+  // hit and must never surface on a request that already succeeded.
+  ctx.waitUntil(cache.put(cacheKey, stored.clone()).catch(() => {}));
+
+  // The caller gets the origin's own headers, not the edge TTL we stored under.
+  return new Response(stored.body, {
+    status: stored.status,
+    headers: restoreOriginHeaders(stored.headers, "MISS"),
+  });
+}
+
 /** Cloudflare cron expression -> internal cron route (mirrors vercel.json crons). */
 const CRON_ROUTES: Record<string, string> = {
   "0 6 * * *": "/api/cron/daily",
@@ -143,6 +311,13 @@ export default {
       !isAppGeneratedImage(url)
     ) {
       return serveOptimizedImage(request, env, ctx, url);
+    }
+    if (
+      request.method === "GET" &&
+      !hasAuthCookie(request) &&
+      isCacheableDocumentPath(url.pathname)
+    ) {
+      return serveDocument(request, env, ctx, url);
     }
     return handler.fetch(request, env, ctx);
   },

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -21,7 +21,31 @@
   "kv_namespaces": [
     { "binding": "NEXT_INC_CACHE_KV", "id": "2febea4c4d924795bc2825226b140456" }
   ],
+  // Tunes the ISR revalidation queue (see the DOQueueHandler in
+  // @opennextjs/cloudflare). Both values exist to break a revalidation storm:
+  // one homepage view used to trigger 28 background re-renders of `/` in 38s.
+  //
+  // TIMEOUT: the queue aborts a revalidation after 10s by default. A homepage
+  // re-render can exceed that (it fans out to Supabase in ap-northeast-2), and
+  // an aborted revalidation never records success — so the sync row that would
+  // dedupe the next enqueue is never written and the route enters a retrying
+  // failed state. 25s is comfortably above a normal render and still well under
+  // the queue's own concurrency ceiling.
+  //
+  // MAX_RETRIES: caps how hard the queue retries a genuinely failing route. The
+  // default 6 retries compound with the alarm loop; 1 is enough because, as
+  // OpenNext itself notes, subsequent ISR requests retry anyway.
+  "vars": {
+    "NEXT_CACHE_DO_QUEUE_REVALIDATION_TIMEOUT_MS": "25000",
+    "NEXT_CACHE_DO_QUEUE_MAX_RETRIES": "1"
+  },
   // revalidateTag / revalidatePath tag cache.
+  //
+  // NOTE: no longer read at runtime — the tag cache moved to the sharded
+  // Durable Object below because this D1 instance is pinned to ENAM (Newark)
+  // with read replication disabled, so every dynamic response paid a ~250ms
+  // cross-planet round trip for a 0.2ms query. The binding stays declared so
+  // reverting open-next.config.ts is a one-line rollback.
   "d1_databases": [
     {
       "binding": "NEXT_TAG_CACHE_D1",
@@ -29,11 +53,18 @@
       "database_id": "757f6a0f-ae69-4243-81f1-e24eaa2412d3"
     }
   ],
-  // Time-based ISR revalidation queue (Durable Object) + self-reference the queue uses.
+  // Time-based ISR revalidation queue + the sharded tag cache, both Durable
+  // Objects, plus the self-reference the queue uses to call back into the app.
   "durable_objects": {
-    "bindings": [{ "name": "NEXT_CACHE_DO_QUEUE", "class_name": "DOQueueHandler" }]
+    "bindings": [
+      { "name": "NEXT_CACHE_DO_QUEUE", "class_name": "DOQueueHandler" },
+      { "name": "NEXT_TAG_CACHE_DO_SHARDED", "class_name": "DOShardedTagCache" }
+    ]
   },
-  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["DOQueueHandler"] }],
+  "migrations": [
+    { "tag": "v1", "new_sqlite_classes": ["DOQueueHandler"] },
+    { "tag": "v2", "new_sqlite_classes": ["DOShardedTagCache"] }
+  ],
   "services": [{ "binding": "WORKER_SELF_REFERENCE", "service": "vibetalent" }]
 
   // Cron Triggers DISABLED — moved to GitHub Actions (.github/workflows/cron.yml).


### PR DESCRIPTION
## Why

Hard-refreshing the site a couple of times made every page crawl. Tailing the Worker while firing **exactly one** request to `/` showed why — that single page view triggered **28 background re-renders of `/`**, ~once a second for the entire 38s observation window:

```
offsets(s): 0.0 0.1 2.0 8.6 9.7 10.6 11.7 13.2 ... 37.2 38.3
28 revalidations · avg 1.6s wall · avg 127ms CPU each
```

That is ~3.5s of Worker CPU and 28 rounds of Supabase queries **per page view**. With zero traffic the Worker is completely idle (verified over a silent 100s window), so it is entirely request-driven amplification — and a hard refresh fires ~30 Worker-bound requests at once, restarting it from several directions.

**Mechanism.** The OpenNext DO queue aborts a revalidation after 10s. A homepage re-render can exceed that — one HEAD revalidation was measured hanging past **120s** — and an aborted revalidation never writes the `sync` row that dedupes the next enqueue. The route enters a retrying failed state while every new request piles on another attempt. Renders queue, the Worker saturates, renders slow down, more of them time out.

## Supporting measurements (all from production)

| Observation | Value |
|---|---|
| Bare Worker invocation (apex 301, runs before OpenNext) | **30ms** |
| Same Worker serving a cache **HIT** page | **330ms** |
| → cache-layer I/O per dynamic response | **~290ms** |
| D1 tag cache | `ENAM`/Newark, replication **disabled**, 8,290 reads/day, **0 writes/day**, 0.2ms actual SQL |
| `cf-cache-status` on HTML / RSC / API | **absent** — Cloudflare does not cache Worker responses |
| Requests per homepage load | **80**, of which 25 are RSC prefetches |
| Cold-start TTFBs observed | 8.9s, 10.3s, 11.0s, **13.1s** (vs ~330ms warm) |

## Changes

- **Queue (the actual storm fix)** — revalidation timeout 10s → 25s so a slow render completes and records success; retries capped at 1, since OpenNext re-triggers from the next ISR request anyway.
- **Incremental cache** — wrap KV in `withRegionalCache`. A regional hit is local *and* fresh, so it doesn't enqueue a revalidation, removing most remaining triggers. `long-lived` is safe here: a regional entry's max-age is the page's own `revalidate`.
- **Tag cache** — D1 → sharded Durable Object with `regionalCache`. OpenNext queries D1 with plain `prepare()` rather than the Sessions API, so read replicas would not have helped even if enabled.
- **`worker.ts` document edge cache** — see safety notes below.
- **`revalidate` widened** on the five hot ISR pages: 60s → 180s for `/` and `/feed`, → 300s for browse/ranking. The live surfaces on those pages poll client-side.
- **Endorsements N+1** — every card mounted its own `EndorseButton` and fired its own request. `/api/endorsements` now accepts `project_ids` and answers any number of cards in two queries and one auth check, with a client-side batcher coalescing the per-card asks. Single-project form unchanged.
- **Navbar prefetch** — `prefetch={false}` on dropdown and mobile-menu links, which unhide as a group and would fan out the whole menu on open. Primary nav still prefetches.

## Edge-cache safety

The document cache participates **only** when all of these hold:

- method is `GET`, and the request carries **no Supabase auth cookie** (chunked cookies included, PKCE verifier excluded — mirrors `hasAuthSessionCookie`)
- path is not `/api/*` or `/_next/*`
- status is 200 and there is **no `Set-Cookie`**
- the origin marked it shareable via `s-maxage`, and not `private` / `no-store` / `no-cache`

TTL is `min(s-maxage, 60s)`, so this introduces **no staleness the origin hadn't already sanctioned** — it just enforces the shared-cache semantics Cloudflare doesn't apply to Worker responses. The RSC variant is folded into the cache key because Cloudflare only honours `Vary: Accept-Encoding`; `Vary` is stripped on the stored copy for the same reason (it can otherwise refuse to store, silently no-op'ing the feature) and restored on the way out along with the origin's `Cache-Control`, so clients see an unchanged response.

## Verification

Against the built Worker (`wrangler dev`, real bindings):

- anonymous HTML → `MISS` then `HIT`, with `s-maxage=60, stale-while-revalidate=…` and the full `Vary` intact on the served response
- request with a Supabase auth cookie → **bypasses** the cache (no `x-vt-edge`)
- `/api/*` → **bypasses** the cache
- RSC vs HTML for the same path → separate entries, no collision
- batch endorsements return counts matching the database exactly (2/2/2 on three real project ids); single form agrees; 400 on no params and on >50 ids

`npx tsc --noEmit` clean (two pre-existing `TS2578` in `worker.ts` unchanged), eslint 0 errors (one pre-existing warning), **338 tests pass** including 5 new ones covering coalescing, dedupe, the 50-id split, failure propagation, and batch isolation. `opennextjs-cloudflare build` succeeds.

## Deploy notes

- Adds a **new Durable Object migration** (`v2`, `DOShardedTagCache`). The `NEXT_TAG_CACHE_D1` binding is intentionally left declared so reverting `open-next.config.ts` is a one-line rollback; it has 0 writes/day so nothing meaningful is lost in the switch.
- Not fixed here: the ~10s cold start itself. That is the 8.3MB / 2.07MB-gzipped bundle (86 routes, 223 SSR chunks) and is structural to OpenNext. The edge cache means most requests no longer reach the Worker at all, which is the practical mitigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batched endorsement loading for project lists, with deduplication and per-project status.
  * Added edge caching for eligible anonymous document and RSC requests.
* **Performance**
  * Reduced unnecessary navigation prefetching.
  * Improved cache and tag-cache handling for regional traffic.
  * Adjusted page refresh intervals to reduce background re-rendering.
* **Bug Fixes**
  * Endorsement buttons now use shared batched state loading and handle failed requests gracefully.
* **Configuration**
  * Tuned incremental revalidation retries and timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->