### PR TITLE
chore(verify): add Orynth ownership verification (file + meta tag)

### DIFF
--- a/public/.well-known/ory-verify.txt
+++ b/public/.well-known/ory-verify.txt
@@ -1,0 +1,1 @@
+ory-verify=orynth-91ed1e7813df4209a5816a96a2ae9172

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -58,6 +58,13 @@ export const metadata: Metadata = {
   alternates: {
     canonical: siteUrl,
   },
+  // Orynth directory listing ownership check. Duplicated at
+  // /.well-known/ory-verify.txt — the file is the method Orynth recommends,
+  // this tag is the belt-and-braces copy that can't be dropped by the static
+  // asset pipeline. Safe to remove once the listing is approved.
+  verification: {
+    other: { "ory-verify": "orynth-91ed1e7813df4209a5816a96a2ae9172" },
+  },
   robots: {
     index: true,
     follow: true,


### PR DESCRIPTION
Orynth's directory listing needs proof we control `vibetalent.work` before the submission is approved. This is blocking a live launch submission, so it wants to land as soon as CI is green.

## What's in it

Both of Orynth's supported methods, in one deploy:

| Method | Where |
|---|---|
| File (Orynth's recommended) | `public/.well-known/ory-verify.txt`, copied verbatim from their generated file |
| Meta tag | `verification.other` in the root layout → `<meta name="ory-verify" ...>` |

## Why both, rather than just the recommended one

`.well-known` is a dot-directory. Whether Wrangler's asset uploader carries dot-directories into the Workers asset bundle isn't something I could confirm without deploying, and a failed verification click costs another full deploy cycle to retry. The meta tag is server-rendered by the Worker, so it can't be dropped by the static asset pipeline regardless of how the assets resolve.

Whichever path Orynth checks, one of them is there.

## Verified

Against the local dev server:

- `GET /.well-known/ory-verify.txt` → `200`, `text/plain`, correct token
- `<meta name="ory-verify" content="orynth-...">` renders into `<head>` on `/`

Production behaviour of the `.well-known` path is the open question this PR exists to answer — I'll curl both URLs on prod once the deploy lands and report which are live.

## Note on the apex

`worker.ts` 301s the apex to `www`. If the Orynth listing registered the bare `vibetalent.work` and their checker doesn't follow redirects, the file fetch returns a 301 rather than the token — worth pointing the listing at `https://www.vibetalent.work`.

## Cleanup

Both are safe to revert once the listing is approved. Nothing else depends on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added directory ownership verification for Orynth.
  * Added the required verification token to the site’s metadata and well-known verification file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->