### PR TITLE
feat(solana): read the RPC endpoint from SOLANA_RPC_URL

### DIFF
--- a/src/app/api/solana/verify/route.ts
+++ b/src/app/api/solana/verify/route.ts
@@ -3,6 +3,7 @@ import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { validateUUID } from "@/lib/validation";
 import { CHAIN_CONFIGS, isSolanaChain } from "@/lib/chains-config";
+import { solanaRpcUrl } from "@/lib/solana-rpc";
 import {
   isValidPackageId,
   expiresAtFor,
@@ -85,7 +86,7 @@ export async function POST(req: NextRequest) {
     }
 
     // 5. Fetch the finalized transaction.
-    const txRes = await fetch(solana.rpc, {
+    const txRes = await fetch(solanaRpcUrl(), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/src/app/api/vibe/preflight/route.ts
+++ b/src/app/api/vibe/preflight/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { CHAIN_CONFIGS, isSolanaChain } from "@/lib/chains-config";
+import { solanaRpcUrl } from "@/lib/solana-rpc";
 import { stagingOnlyResponse } from "@/lib/staging";
 
 // POST /api/vibe/preflight
@@ -168,7 +169,7 @@ export async function POST(req: NextRequest) {
   let blockhashRes: Response;
   try {
     [accountsRes, blockhashRes] = await Promise.all([
-      fetch(solana.rpc, {
+      fetch(solanaRpcUrl(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -182,7 +183,7 @@ export async function POST(req: NextRequest) {
           ],
         }),
       }),
-      fetch(solana.rpc, {
+      fetch(solanaRpcUrl(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/src/lib/__tests__/solana-rpc.test.ts
+++ b/src/lib/__tests__/solana-rpc.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+import { solanaRpcUrl } from "@/lib/solana-rpc";
+import { CHAIN_CONFIGS, isSolanaChain } from "@/lib/chains-config";
+
+const solana = CHAIN_CONFIGS.solana;
+const PUBLIC_DEFAULT = isSolanaChain(solana) ? solana.rpc : "";
+
+describe("solanaRpcUrl", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("falls back to the public endpoint when SOLANA_RPC_URL is unset", () => {
+    vi.stubEnv("SOLANA_RPC_URL", undefined);
+    expect(solanaRpcUrl()).toBe(PUBLIC_DEFAULT);
+  });
+
+  it("prefers SOLANA_RPC_URL when it is set", () => {
+    vi.stubEnv("SOLANA_RPC_URL", "https://example-rpc.test/?api-key=abc");
+    expect(solanaRpcUrl()).toBe("https://example-rpc.test/?api-key=abc");
+  });
+
+  it("trims surrounding whitespace", () => {
+    vi.stubEnv("SOLANA_RPC_URL", "  https://example-rpc.test  ");
+    expect(solanaRpcUrl()).toBe("https://example-rpc.test");
+  });
+
+  it("treats a blank value as unset rather than returning an empty URL", () => {
+    vi.stubEnv("SOLANA_RPC_URL", "   ");
+    expect(solanaRpcUrl()).toBe(PUBLIC_DEFAULT);
+  });
+
+  // The point of the helper: Workers bind the environment per request, so a
+  // value captured at module scope would be frozen for the isolate's lifetime.
+  it("re-reads the environment on every call", () => {
+    vi.stubEnv("SOLANA_RPC_URL", undefined);
+    expect(solanaRpcUrl()).toBe(PUBLIC_DEFAULT);
+
+    vi.stubEnv("SOLANA_RPC_URL", "https://later-bound.test");
+    expect(solanaRpcUrl()).toBe("https://later-bound.test");
+  });
+
+  it("never returns an empty string while Solana is configured", () => {
+    vi.stubEnv("SOLANA_RPC_URL", undefined);
+    expect(solanaRpcUrl().length).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/__tests__/solana-rpc.test.ts
+++ b/src/lib/__tests__/solana-rpc.test.ts
@@ -9,6 +9,7 @@ const PUBLIC_DEFAULT = isSolanaChain(solana) ? solana.rpc : "";
 describe("solanaRpcUrl", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
+    vi.restoreAllMocks();
   });
 
   it("falls back to the public endpoint when SOLANA_RPC_URL is unset", () => {
@@ -39,6 +40,30 @@ describe("solanaRpcUrl", () => {
 
     vi.stubEnv("SOLANA_RPC_URL", "https://later-bound.test");
     expect(solanaRpcUrl()).toBe("https://later-bound.test");
+  });
+
+  // Regression: the first real deploy set this to the bare Helius API key
+  // rather than the endpoint URL. fetch() threw on it and every caller
+  // reported the same opaque 503 the variable was added to fix.
+  it("ignores a bare API key and falls back, rather than returning it", () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubEnv("SOLANA_RPC_URL", "77046988-b68d-41c2-9570-013c70abcdef");
+
+    expect(solanaRpcUrl()).toBe(PUBLIC_DEFAULT);
+    expect(err).toHaveBeenCalledOnce();
+  });
+
+  it("ignores any non-http scheme", () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubEnv("SOLANA_RPC_URL", "ftp://example-rpc.test");
+
+    expect(solanaRpcUrl()).toBe(PUBLIC_DEFAULT);
+    expect(err).toHaveBeenCalledOnce();
+  });
+
+  it("accepts a plain http endpoint for local validators", () => {
+    vi.stubEnv("SOLANA_RPC_URL", "http://127.0.0.1:8899");
+    expect(solanaRpcUrl()).toBe("http://127.0.0.1:8899");
   });
 
   it("never returns an empty string while Solana is configured", () => {

--- a/src/lib/solana-rpc.ts
+++ b/src/lib/solana-rpc.ts
@@ -1,0 +1,32 @@
+// Server-side Solana RPC endpoint.
+//
+// Solana's public endpoint — the CHAIN_CONFIGS default — refuses traffic from
+// datacenter IPs, which is exactly what a Cloudflare Worker is. Every server
+// call therefore failed in production: `fetchVibeBalance` returned null so
+// holder balances read as zero, /token showed no supply, and the burn
+// preflight 503'd on every attempt, meaning a burn could never be signed.
+//
+// SOLANA_RPC_URL points those calls at a provider that actually answers.
+// Unset, this falls back to the public endpoint, so local development and
+// tests keep working with no configuration.
+
+import { CHAIN_CONFIGS, isSolanaChain } from "@/lib/chains-config";
+
+/**
+ * The Solana JSON-RPC endpoint for server-side calls.
+ *
+ * Read at call time rather than module scope: on Workers the environment is
+ * bound per request, so a module-level read can execute before the value
+ * exists and would cache an empty string for the life of the isolate.
+ *
+ * Server-only by design. Provider URLs carry the API key in the path, so this
+ * must never reach the browser bundle — client code keeps using the public
+ * endpoint from CHAIN_CONFIGS, which works from a residential IP.
+ */
+export function solanaRpcUrl(): string {
+  const configured = process.env.SOLANA_RPC_URL?.trim();
+  if (configured) return configured;
+
+  const solana = CHAIN_CONFIGS.solana;
+  return isSolanaChain(solana) ? solana.rpc : "";
+}

--- a/src/lib/solana-rpc.ts
+++ b/src/lib/solana-rpc.ts
@@ -12,6 +12,20 @@
 
 import { CHAIN_CONFIGS, isSolanaChain } from "@/lib/chains-config";
 
+function publicFallback(): string {
+  const solana = CHAIN_CONFIGS.solana;
+  return isSolanaChain(solana) ? solana.rpc : "";
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const { protocol } = new URL(value);
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 /**
  * The Solana JSON-RPC endpoint for server-side calls.
  *
@@ -25,8 +39,21 @@ import { CHAIN_CONFIGS, isSolanaChain } from "@/lib/chains-config";
  */
 export function solanaRpcUrl(): string {
   const configured = process.env.SOLANA_RPC_URL?.trim();
-  if (configured) return configured;
 
-  const solana = CHAIN_CONFIGS.solana;
-  return isSolanaChain(solana) ? solana.rpc : "";
+  if (configured) {
+    if (isHttpUrl(configured)) return configured;
+
+    // Pasting the bare API key is the easy mistake: providers show the key and
+    // the endpoint as separate fields. `fetch()` would throw on it and the
+    // caller would report the same opaque "Solana unavailable" 503 this
+    // variable exists to fix, so name the misconfiguration instead of
+    // failing over in silence.
+    console.error(
+      "SOLANA_RPC_URL is set but is not an http(s) URL, so it was ignored. " +
+        "Expected the provider's full endpoint, e.g. " +
+        "https://mainnet.helius-rpc.com/?api-key=<key> — not the key alone.",
+    );
+  }
+
+  return publicFallback();
 }

--- a/src/lib/token-stats.ts
+++ b/src/lib/token-stats.ts
@@ -6,6 +6,7 @@
 
 import { fetchVibeUsdCached } from "@/lib/promotion-pricing";
 import { CHAIN_CONFIGS, isSolanaChain } from "@/lib/chains-config";
+import { solanaRpcUrl } from "@/lib/solana-rpc";
 import { VIBE_MINT, VIBE_DECIMALS } from "@/lib/vibe-config";
 
 export type TokenStats = {
@@ -22,7 +23,7 @@ export async function fetchSupply(): Promise<number | null> {
   const solana = CHAIN_CONFIGS.solana;
   if (!isSolanaChain(solana)) return null;
   try {
-    const res = await fetch(solana.rpc, {
+    const res = await fetch(solanaRpcUrl(), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/src/lib/vibe-balance.ts
+++ b/src/lib/vibe-balance.ts
@@ -4,6 +4,7 @@
 // renders must never depend on a live RPC round trip.
 
 import { CHAIN_CONFIGS, isSolanaChain } from "@/lib/chains-config";
+import { solanaRpcUrl } from "@/lib/solana-rpc";
 import { VIBE_MINT, VIBE_DECIMALS } from "@/lib/vibe-config";
 
 const REFRESH_COOLDOWN_MS = 60_000;
@@ -25,7 +26,7 @@ export async function fetchVibeBalance(wallet: string): Promise<bigint | null> {
   const solana = CHAIN_CONFIGS.solana;
   if (!isSolanaChain(solana)) return null;
   try {
-    const res = await fetch(solana.rpc, {
+    const res = await fetch(solanaRpcUrl(), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/src/lib/vibe-burn-verify.ts
+++ b/src/lib/vibe-burn-verify.ts
@@ -9,6 +9,7 @@
 // surfaces everything else immediately.
 
 import { CHAIN_CONFIGS, isSolanaChain } from "@/lib/chains-config";
+import { solanaRpcUrl } from "@/lib/solana-rpc";
 import {
   expectedTokenAmount,
   extractMemos,
@@ -68,7 +69,7 @@ export async function verifyBurnTransaction(
   //    reorgs are vanishingly rare on Solana.
   let txJson: { error?: unknown; result?: SolanaTx };
   try {
-    const res = await fetch(solana.rpc, {
+    const res = await fetch(solanaRpcUrl(), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({


### PR DESCRIPTION
Unblocks wallet linking, holder tiers, streak protect and burn-to-vouch in one change. **Code-only — inert until the secret is set.**

## The problem

Solana's public endpoint refuses datacenter traffic, and a Cloudflare Worker *is* datacenter traffic. Verified against the deployed staging Worker:

```
$ curl -X POST https://staging.vibetalent.work/api/vibe/preflight -d '{...}'
{"code":"SOLANA_UNAVAILABLE", ...}   HTTP 503
```

…while the identical `getTokenSupply` call from a residential IP returns `uiAmount: 998079152.6`.

Consequences, all silent:

- `fetchVibeBalance()` returns `null` → every holder's balance reads **0** → `holderTierFor(0)` grants no tier, so linking a wallet gives a holder nothing
- `/token` shows no Supply or Market Cap
- `/api/vibe/preflight` 503s on every attempt — and `use-burn-flow` preflights *before* requesting a signature, so **a burn can never be signed**
- `/api/cron/reset-freezes` writes the same null balance monthly

## The change

Five server call sites resolve the endpoint via `solanaRpcUrl()`. Unset, it falls back to the current public endpoint — local dev and CI behave exactly as before.

Two deliberate design points:

**Read at call time, not module scope.** Workers bind the environment per request; a module-level read can execute before the value exists and would cache that miss for the isolate's lifetime.

**Server-only.** Provider URLs carry the API key in the path, so this must never reach the browser bundle — a leaked key is a drainable quota. Client code keeps the public endpoint, which answers fine from a residential IP. Audited: every `solana.rpc` consumer was already server-side; the client `.rpc` uses are all Base/EVM.

## Deploying

Inert until the secret exists:

```
npx wrangler secret put SOLANA_RPC_URL
npx wrangler secret put SOLANA_RPC_URL --config wrangler.beta.jsonc
```

## Verification

`npm run lint` 0 errors · `npx tsc --noEmit` clean · `npm test` **491 passed** (6 new)

New tests cover the fallback, the override, whitespace handling, blank-as-unset, and specifically that the value is re-read on every call rather than captured once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the Solana network endpoint through an environment setting.
  * Valid HTTP and HTTPS endpoints are accepted, with automatic fallback to the default Solana endpoint when configuration is missing or invalid.
  * Solana transaction verification, balance checks, token statistics, and preflight checks now use the selected endpoint consistently.

* **Tests**
  * Added coverage for endpoint configuration, validation, fallback behavior, and API-key handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->