### PR TITLE
feat(vouch): tell a builder when someone burns $VIBE to back them

### DIFF
--- a/src/app/api/vouch/route.ts
+++ b/src/app/api/vouch/route.ts
@@ -2,6 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { revalidatePath, revalidateTag } from "next/cache";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { createNotification } from "@/lib/notifications";
+import { sendVouchNotificationEmail } from "@/lib/email";
+import { formatTokenCount } from "@/lib/token-stats";
 import { vouchLimiter, getIP, checkRateLimit } from "@/lib/rate-limit";
 import { stagingOnlyResponse } from "@/lib/staging";
 import { verifyBurnTransaction } from "@/lib/vibe-burn-verify";
@@ -107,6 +110,53 @@ export async function POST(req: NextRequest) {
       console.error("Failed to record vouch:", insErr);
       return NextResponse.json({ error: "Couldn't record that vouch." }, { status: 500 });
     }
+
+    // Tell the builder. A vouch costs the sender real money and destroys the
+    // tokens permanently, so it was the one meaningful action on the platform
+    // whose recipient was never told it happened.
+    //
+    // Fire-and-forget, exactly like reviews: the burn is already confirmed
+    // on-chain and recorded, so a notification or mail failure must not turn a
+    // completed, irreversible action into an error for the backer.
+    // Resolved here rather than up front so a burn that fails verification
+    // never pays for the extra round trip. `username` is nullable, so fall
+    // back to a label that still reads correctly.
+    const { data: voucherRow } = await sb
+      .from("users")
+      .select("username")
+      .eq("id", user.id)
+      .single();
+    const backerLabel = voucherRow?.username ? `@${voucherRow.username}` : "Someone";
+    const vibeDisplay = formatTokenCount(Number(verdict.burned) / 1e9);
+    createNotification({
+      user_id: builder.id,
+      type: "vouch_received",
+      title: "Someone backed you",
+      message: `${backerLabel} burned ${vibeDisplay} $VIBE to back you`,
+      metadata: {
+        voucher_username: voucherRow?.username ?? null,
+        vibe_burned: verdict.burned.toString(),
+        usd: usdAmount,
+        tx_ref: signature,
+      },
+    }).catch(console.error);
+
+    (async () => {
+      try {
+        const { data: userData } = await sb.auth.admin.getUserById(builder.id);
+        const builderEmail = userData?.user?.email;
+        if (!builderEmail) return;
+        await sendVouchNotificationEmail({
+          email: builderEmail,
+          username: builder.username,
+          backerLabel,
+          vibeDisplay,
+          usd: usdAmount,
+        });
+      } catch (err) {
+        console.error("Failed to send vouch email:", err);
+      }
+    })();
 
     // Recompute the builder's score. Without this the vouch has no effect on
     // vibe_score until their next activity fires the streak_logs trigger.

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -992,3 +992,65 @@ ${cta(`${siteUrl}/dashboard`, "View dashboard")}
 
   return samples;
 }
+
+/**
+ * Someone burned $VIBE to back this builder.
+ *
+ * Unlike a review or an endorsement, a vouch costs the sender real money and
+ * destroys the tokens permanently, so the email leads with the amount — that
+ * is the part which carries the signal.
+ */
+export async function sendVouchNotificationEmail({
+  email,
+  username,
+  backerLabel,
+  vibeDisplay,
+  usd,
+}: {
+  email: string;
+  username: string;
+  /** Display label for the backer, already "@handle" or "Someone". */
+  backerLabel: string;
+  /** Pre-formatted token count, e.g. "832.3K". */
+  vibeDisplay: string;
+  usd: number;
+}): Promise<void> {
+  const client = getResend();
+  if (!client) return;
+
+  const siteUrl = getSiteUrl();
+  const safeBacker = escapeHtml(backerLabel);
+  const safeVibe = escapeHtml(vibeDisplay);
+  const usdText = `$${usd.toFixed(2)}`;
+
+  const burnBlock = `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 28px;background:${BRAND.bgSoft};">
+<tr><td style="padding:18px 22px;border-left:2px solid ${BRAND.accent};">
+<p style="margin:0 0 10px;font-family:${BRAND.fontMono};font-size:22px;font-weight:700;color:${BRAND.accent};">${safeVibe} $VIBE</p>
+<p style="margin:0;font-family:${BRAND.fontSans};font-size:15px;line-height:1.6;color:${BRAND.textBody};">burned permanently by <strong>${safeBacker}</strong> (~${escapeHtml(usdText)}) to back you.</p>
+</td></tr>
+</table>`;
+
+  const body = `
+${eyebrow("Backed")}
+${headline(`${safeBacker} backed you with $VIBE`)}
+${paragraph(`Hey <strong>@${escapeHtml(username)}</strong>, someone put real conviction behind your work. These tokens are destroyed forever &mdash; they cannot be sold or reclaimed.`)}
+${burnBlock}
+${cta(`${siteUrl}/profile/${encodeURIComponent(username)}`, "See who backed you")}
+`;
+
+  try {
+    await sendEmail(client, {
+      to: email,
+      subject: `${backerLabel} burned ${vibeDisplay} $VIBE to back you`,
+      text: `Hey @${username}, ${backerLabel} backed you on VibeTalent.\n\n${vibeDisplay} $VIBE (~${usdText}) burned permanently.\n\nSee your profile: ${siteUrl}/profile/${username}\n\nUnsubscribe: ${unsubUrl(email)}`,
+      html: renderEmail({
+        preheader: `${vibeDisplay} $VIBE (~${usdText}) burned permanently to back you.`,
+        body,
+        footerContext: "You received this because someone backed you on VibeTalent.",
+        unsubLink: unsubUrl(email),
+      }),
+    });
+  } catch (error) {
+    console.error("Failed to send vouch notification email:", error);
+  }
+}

--- a/src/lib/notification-display.ts
+++ b/src/lib/notification-display.ts
@@ -26,6 +26,7 @@ export const NOTIFICATION_ICONS: Record<string, Icon> = {
   vibe_score_milestone: Lightning,
   project_missing_links: LinkSimple,
   referral_prompt: UsersThree,
+  vouch_received: Fire,
 };
 
 export const NOTIFICATION_COLORS: Record<string, string> = {
@@ -41,6 +42,7 @@ export const NOTIFICATION_COLORS: Record<string, string> = {
   vibe_score_milestone: "#FF3A00",
   project_missing_links: "#F59E0B",
   referral_prompt: "#FF3A00",
+  vouch_received: "#FF3A00",
 };
 
 /**
@@ -60,6 +62,7 @@ export const NOTIFICATION_TAGS: Record<string, string> = {
   vibe_score_milestone: "Score",
   project_missing_links: "Project",
   referral_prompt: "Referral",
+  vouch_received: "Backing",
 };
 
 /**

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -147,7 +147,7 @@ export interface Referral {
   created_at: string;
 }
 
-export type NotificationType = "hire_request" | "streak_milestone" | "streak_warning" | "badge_earned" | "project_verified" | "project_flagged" | "new_review" | "profile_view_summary" | "weekly_digest" | "vibe_score_milestone" | "project_missing_links" | "referral_prompt";
+export type NotificationType = "hire_request" | "streak_milestone" | "streak_warning" | "badge_earned" | "project_verified" | "project_flagged" | "new_review" | "profile_view_summary" | "weekly_digest" | "vibe_score_milestone" | "project_missing_links" | "referral_prompt" | "vouch_received";
 
 export interface ProfileView {
   id: string;

--- a/supabase/migrations/20260818_vouch_notification_type.sql
+++ b/supabase/migrations/20260818_vouch_notification_type.sql
@@ -1,0 +1,28 @@
+-- Allow the `vouch_received` notification type.
+--
+-- Backing a builder burns real money, and until now it was the only meaningful
+-- action on the platform that told its recipient nothing: reviews, hire
+-- requests and project verification all notify, a vouch did not. The insert
+-- would have failed the CHECK constraint below, so widening it comes first.
+--
+-- Purely additive: no existing row changes, and nothing reads the constraint
+-- other than INSERT validation.
+
+ALTER TABLE public.notifications DROP CONSTRAINT IF EXISTS notifications_type_check;
+
+ALTER TABLE public.notifications ADD CONSTRAINT notifications_type_check
+  CHECK (type = ANY (ARRAY[
+    'hire_request'::text,
+    'streak_milestone'::text,
+    'streak_warning'::text,
+    'badge_earned'::text,
+    'project_verified'::text,
+    'project_flagged'::text,
+    'new_review'::text,
+    'profile_view_summary'::text,
+    'weekly_digest'::text,
+    'vibe_score_milestone'::text,
+    'project_missing_links'::text,
+    'referral_prompt'::text,
+    'vouch_received'::text
+  ]));


### PR DESCRIPTION
Backing someone burns real money permanently — and it was the only meaningful action on the platform whose recipient was never told. Reviews, hire requests, project verification and streak warnings all notify. A vouch didn't.

Confirmed against production: `/api/vouch/route.ts` had zero references to `createNotification` or any email sender.

## What's added

- **In-app notification** — `vouch_received`, with a Fire icon and "Backing" label in the notifications list
- **Email** — leads with the burned amount, since that's the part carrying the signal

Both fire-and-forget, in the same shape `reviews` uses. The burn is already confirmed on-chain and written to `vouches` by this point, so a notification or mail failure must never turn a completed, irreversible action into an error for the backer.

## ⚠️ Migration required

`notifications.type` is a CHECK constraint, so the new value must be allowed before any insert is accepted:

```bash
npx supabase db push
```

**Nothing breaks if you merge before applying it** — `createNotification` swallows its own errors, so the vouch still succeeds and only the notification is skipped. But no builder gets notified until it lands.

The migration is purely additive: it widens the allowed-values list from 12 to 13. At 7,810 rows / 3.6 MB the constraint revalidation is instant.

## Two details worth noting

**The backer's handle is resolved on the success path only** — after burn verification, not before — so a burn that fails verification doesn't pay for the extra round trip.

**`users.username` is nullable**, so the label falls back to `"Someone"` rather than rendering `"@null"`. That's why the email takes a ready-made `backerLabel` instead of a raw handle it would have to prefix itself.

## Verification

`npm run lint` 0 errors · `npx tsc --noEmit` clean · `npm test` 494 passed

Not verifiable from here: the actual email render and the live insert, both of which need the migration applied. Worth doing one more staging vouch afterwards to confirm end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Builders now receive an in-app notification when someone vouches for them.
  - Email notifications are sent when a builder’s email address is available, including the burned `$VIBE` amount and USD value.
  - Vouch notifications include the backer’s identity, profile access, and unsubscribe options.
- **Enhancements**
  - Vouch notifications use a dedicated fire icon, orange styling, and “Backing” label.
  - Notification and email delivery issues no longer prevent a completed vouch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->