### PR TITLE
feat(vibe): release wallet linking and the $VIBE burn features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# CLAUDE.md
+
+Guidance for Claude Code working in this repo. Keep it current; prefer fixing this file over re-explaining things each session.
+
+## What this is
+
+VibeTalent — a reputation + hiring marketplace for "vibe coders" (AI-assisted developers). Builders have public profiles with a **vibe_score** (reputation), GitHub-verified **projects** with automated quality scoring, **endorsements**, **reviews**, daily **streaks** ("vibed"), a **leaderboard**, a **hire** flow, and paid **featured promotions** (USDC). Heavy SEO/AEO surface (sitemap, `llms.txt`, JSON-LD, glossary, `vs/` comparison pages). Live at vibetalent.work.
+
+## Stack
+
+Next.js 16 (App Router) · React 19 · TypeScript · Tailwind v4 · Supabase (Postgres + Auth + RLS) · Privy (wallet/social auth) · Solana (`@solana/kit`, web3.js) + Base/EVM (`viem`) for USDC · Upstash Redis (rate limit) · Resend (email) · Vitest. Hosted on **Cloudflare Workers** (OpenNext adapter); push-to-deploy via GitHub Actions.
+
+## Commands
+
+```bash
+npm run dev          # next dev
+npm run build        # next build
+npm run lint         # eslint (see gotcha: scope to src/ for clean signal)
+npm run test         # vitest run
+npx tsc --noEmit     # type-check
+./node_modules/.bin/eslint src   # CI-faithful lint — src/ only, skips the vibecoders/ noise
+```
+
+## Where things live
+
+- `src/app/` — routes (App Router): `dashboard`, `explore`, `profile`, `projects`, `hire`, `leaderboard`, `pricing`, `roadmap`, `admin`, `feed`, `vs`, SEO files (`sitemap.ts`, `robots.ts`, `llms.txt`).
+- `src/app/api/` — route handlers: `projects`, `endorsements`, `reviews`, `streak`, `hire`, `promotions`, `github`, `notifications`, `leaderboard`, `og`, `v1/` (public API), `cron/` (scheduled jobs).
+- `src/lib/` — domain logic: scoring (`agent-scoring.ts`, `github-quality.ts`, `scoring-config.ts`), payments (`solana-payment.ts`, `chains-config.ts`, `featured-promotions.ts`, `pricing.ts`), `streak.ts`, `notifications.ts`, `email.ts`, `supabase/`, `rate-limit.ts`, `validation.ts`, `json-ld.ts`, `seo.ts`.
+- `src/components/` — by domain (`profile`, `projects`, `reviews`, `dashboard`, `homepage`, `ui`, …).
+- `supabase/` — `schema.sql` + `migrations/` (31). **`schema.sql` is not the live schema** — it declares 10 tables; prod has 19. Migrations are the source of truth; check the DB before assuming a table/column doesn't exist.
+- **Supabase Storage** — two public buckets, `avatars` and `project-images` (uploaded from `dashboard/page.tsx`). Files live in object storage; the DB stores only URL `TEXT` columns (`avatar_url`, `image_url`). No `bytea`/blob columns anywhere — keep it that way.
+- `src/middleware.ts` — auth/routing middleware.
+
+## Critical conventions & gotchas
+
+- **`vibecoders/` is a gitignored duplicate folder.** It pollutes full-repo eslint with ~10k noise errors. Lint/build/grep against root `src/` only.
+- **Two project-create paths exist.** Only `POST /api/projects` runs the GitHub auto-verify + quality-scoring pipeline. **Never insert a project directly** (DB or the other path) — it'll skip verification.
+- **Supabase empties `search_path` for functions.** Unqualified table refs in triggers/SECURITY DEFINER functions fail with "relation does not exist." Schema-qualify (e.g. `public.users`) inside DB functions.
+- **Security model: RLS is the only gate.** Don't rely on app-layer checks alone. Reputation columns (`vibe_score`, streaks) are locked — written only via SECURITY DEFINER functions (e.g. `update_user_streak`). `reviewer_email` is never exposed to clients; review deletion is session-only (IDOR-guarded). Render JSON-LD via the `jsonLdHtml` helper, never raw interpolation (stored-XSS).
+- **Never run `supabase db push`.** The local migration history is out of sync with the remote one: 33 files in `supabase/migrations/`, 5 rows in the remote migration table, and the filename versions (`20260714_...`) don't match the recorded ones (`20260713195405`). `db push` would treat ~28 migrations as pending and replay them — including `recalculate_vibe_scores.sql`, which rewrites every user's score. Apply migrations **one at a time** via the Supabase SQL editor, and still commit the `.sql` file so the intent is reviewable. Migrations don't take effect until applied — review carefully; this is a small pre-revenue team (see infra notes).
+- **GitHub OAuth is public-only** (no `repo` scope — it's read+write+admin and triggers a scary consent). `provider_token` is not available server-side; private-repo support is deferred to a read-only GitHub App.
+- **OG/social previews cache by page URL** on Discord/Twitter. Renaming an image does **not** bust the cache — append `?v=N` to the URL.
+- **Dark mode uses warm greys** (hue ~14°), not neutral greys. Reserve pure white for primary elements only.
+- **Payments:** USDC, Base today; multichain (ETH/Solana) on the roadmap. `featured_promotions` is the on-chain-promotion registry (verify ownership before honoring). $VIBE token price comes from GeckoTerminal (not on Jupiter). Treat on-chain/payment changes as high-risk — confirm before touching.
+
+## Infra / deploy
+
+- **Cloudflare Workers** (OpenNext adapter, `@opennextjs/cloudflare`), $0 on Workers Paid (startup credits). www + apex serve from the `vibetalent` Worker via Workers Routes; apex→www 301 lives in `worker.ts`.
+- **Deploy = push to `main`** → GitHub Actions (`.github/workflows/deploy-cloudflare.yml`) runs `opennextjs-cloudflare build` + `wrangler deploy`. Needs the `CLOUDFLARE_API_TOKEN` repo secret + the public `NEXT_PUBLIC_*` values as repo Actions **variables** (inlined at build). The deploy step temporarily hides `open-next.config.ts` to bypass OpenNext's flaky KV/D1 cache-populate (`10021`/`10000`); the cache warms lazily at runtime. Runtime secrets live on the Worker and persist across deploys.
+- **5 crons run on GitHub Actions** (`.github/workflows/cron.yml`), **NOT** Cloudflare Worker triggers — CF's `scheduled()` handler fires but its in-process fetch to `/api/cron/*` never runs the OpenNext route (jobs silently no-op), so `wrangler.jsonc` `triggers.crons` stay disabled. GH Actions `curl`s each route over real external HTTPS with the `CRON_SECRET` bearer token (repo secret); `workflow_dispatch` input `route=<name>` runs one manually. Schedules mirror the old `vercel.json` (daily `0 6 * * *` = 11:30 AM IST, etc.); GH Actions cron is UTC + best-effort (may fire a few min late).
+- **The `daily` orchestrator fans out to its 8 children via the `WORKER_SELF_REFERENCE` service binding, not a self-`fetch()`.** On Cloudflare a Worker→own-hostname call is an edge loopback that **strips the `Authorization` header**, so every child 401s (feed/streaks/lifecycle-emails silently die) while `daily` itself returns 200. Use the binding (`getCloudflareContext().env`) for any Worker-to-self cron fan-out; fall back to `fetch()` off Cloudflare. Directly-scheduled crons (quality-rescore, verify-backfill) are unaffected — they're called externally, not through the loopback.
+- **`NEXT_PUBLIC_SITE_URL`** is inlined at build (drives emails/API/manifests via `getSiteUrl()` in `seo.ts`; canonical/OG use a separate hardcoded const). Must be `https://www.vibetalent.work` at build — `.env.local` holds the localhost dev value, `.env.production.local` (gitignored) overrides local prod builds, a GH Actions var overrides in CI. A wrong value leaks `localhost` into emails + `/api/v1/builders`.
+- **Cloudflare Bot Fight Mode is OFF** for this site — it was 403-ing server-to-server cron fanouts.
+- **Vercel** is a dormant standby: git auto-deploy off (`vercel.json`), and its runtime Supabase is dead (legacy keys disabled). Safe to delete once CF is proven stable.
+- **Pre-revenue, hackathon runway:** minimize infra cost; avoid risky migrations/large refactors close to demo day.
+
+## Working style
+
+- Find the **root cause** before fixing UI/behavior bugs; don't patch symptoms.
+- **Clarify short/ambiguous reports** before diagnosing — don't guess what a pronoun or "it" refers to.
+- Ship **clean, production-quality code on the first pass** — no placeholder logic or leftover TODOs. Self-review as if it had to pass code review; run `/simplify` after significant code.
+- **Verify before claiming done** (run the build/tests/app); evidence before assertions.
+- **Check a PR is still open before pushing** to it — if merged, branch off and open a new PR.

--- a/src/app/api/streak/protect/route.ts
+++ b/src/app/api/streak/protect/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
-import { stagingOnlyResponse } from "@/lib/staging";
 import { verifyBurnTransaction } from "@/lib/vibe-burn-verify";
 import { STREAK_PROTECT } from "@/lib/vibe-config";
 
@@ -19,9 +18,6 @@ function ymd(d: Date): string {
 }
 
 export async function POST(req: NextRequest) {
-  const gate = stagingOnlyResponse();
-  if (gate) return gate;
-
   try {
     const authClient = await createServerSupabaseClient();
     const {

--- a/src/app/api/vibe/preflight/route.ts
+++ b/src/app/api/vibe/preflight/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { CHAIN_CONFIGS, isSolanaChain } from "@/lib/chains-config";
 import { solanaRpcUrl } from "@/lib/solana-rpc";
-import { stagingOnlyResponse } from "@/lib/staging";
 
 // POST /api/vibe/preflight
 //
@@ -101,9 +100,6 @@ function extractBlockhash(data: unknown): string | null {
 }
 
 export async function POST(req: NextRequest) {
-  const gate = stagingOnlyResponse();
-  if (gate) return gate;
-
   const solana = CHAIN_CONFIGS.solana;
   if (!isSolanaChain(solana)) {
     return NextResponse.json(

--- a/src/app/api/vibe/quote/route.ts
+++ b/src/app/api/vibe/quote/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { CHAIN_CONFIGS, isSolanaChain } from "@/lib/chains-config";
 import { expectedTokenAmount, fetchVibeUsdCached } from "@/lib/promotion-pricing";
-import { stagingOnlyResponse } from "@/lib/staging";
 import { VOUCH } from "@/lib/vibe-config";
 
 // GET /api/vibe/quote?usd=5
@@ -18,9 +17,6 @@ import { VOUCH } from "@/lib/vibe-config";
 const MAX_QUOTE_USD = 500;
 
 export async function GET(req: NextRequest) {
-  const gate = stagingOnlyResponse();
-  if (gate) return gate;
-
   try {
     const usd = Number(new URL(req.url).searchParams.get("usd"));
     if (!Number.isFinite(usd) || usd < VOUCH.minUsd) {

--- a/src/app/api/vouch/route.ts
+++ b/src/app/api/vouch/route.ts
@@ -6,7 +6,6 @@ import { createNotification } from "@/lib/notifications";
 import { sendVouchNotificationEmail } from "@/lib/email";
 import { formatTokenCount } from "@/lib/token-stats";
 import { vouchLimiter, getIP, checkRateLimit } from "@/lib/rate-limit";
-import { stagingOnlyResponse } from "@/lib/staging";
 import { verifyBurnTransaction } from "@/lib/vibe-burn-verify";
 import { VOUCH } from "@/lib/vibe-config";
 
@@ -19,9 +18,6 @@ import { VOUCH } from "@/lib/vibe-config";
 const SIGNATURE_RE = /^[1-9A-HJ-NP-Za-km-z]{64,100}$/;
 
 export async function POST(req: NextRequest) {
-  const gate = stagingOnlyResponse();
-  if (gate) return gate;
-
   try {
     const authClient = await createServerSupabaseClient();
     const {

--- a/src/app/api/wallet/balance/route.ts
+++ b/src/app/api/wallet/balance/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
-import { stagingOnlyResponse } from "@/lib/staging";
 import { fetchVibeUsdCached } from "@/lib/promotion-pricing";
 import { fetchVibeBalance, isBalanceStale, toWholeVibe, balanceUsd } from "@/lib/vibe-balance";
 import { freezeAllowanceFor, BASE_FREEZES } from "@/lib/vibe-config";
@@ -12,9 +11,6 @@ import { freezeAllowanceFor, BASE_FREEZES } from "@/lib/vibe-config";
 // balance current between grants, so it is deliberately cheap and cached.
 
 export async function POST() {
-  const gate = stagingOnlyResponse();
-  if (gate) return gate;
-
   try {
     const authClient = await createServerSupabaseClient();
     const {

--- a/src/app/api/wallet/link/route.ts
+++ b/src/app/api/wallet/link/route.ts
@@ -4,7 +4,6 @@ import bs58 from "bs58";
 import { Redis } from "@upstash/redis";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
-import { stagingOnlyResponse } from "@/lib/staging";
 import {
   nonceKey,
   nonceMessage,
@@ -17,9 +16,6 @@ import {
 // signature over a server-issued nonce.
 
 export async function POST(req: NextRequest) {
-  const gate = stagingOnlyResponse();
-  if (gate) return gate;
-
   try {
     const authClient = await createServerSupabaseClient();
     const {
@@ -148,9 +144,6 @@ export async function POST(req: NextRequest) {
 
 /** Unlink the current wallet. */
 export async function DELETE() {
-  const gate = stagingOnlyResponse();
-  if (gate) return gate;
-
   const authClient = await createServerSupabaseClient();
   const {
     data: { user },

--- a/src/app/api/wallet/nonce/route.ts
+++ b/src/app/api/wallet/nonce/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { Redis } from "@upstash/redis";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
-import { stagingOnlyResponse } from "@/lib/staging";
 import {
   nonceKey,
   nonceMessage,
@@ -15,9 +14,6 @@ import {
 // same wallet again later.
 
 export async function GET() {
-  const gate = stagingOnlyResponse();
-  if (gate) return gate;
-
   try {
     const authClient = await createServerSupabaseClient();
     const {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -12,7 +12,6 @@ import { BadgeDisplay } from "@/components/ui/badge-display";
 import type { UserWithSocials } from "@/lib/types/database";
 import { StreakCounter } from "@/components/ui/streak-counter";
 import { ActivityHeatmap } from "@/components/ui/activity-heatmap";
-import { IS_STAGING_CLIENT } from "@/lib/staging-client";
 
 // Web3 stack — only pulled in when a restorable break actually exists.
 const LinkWallet = dynamic(
@@ -1419,8 +1418,7 @@ export default function DashboardPage() {
         }}
       >
         <h2 className="text-lg font-bold text-[var(--foreground)] mb-4">Your Activity</h2>
-        {IS_STAGING_CLIENT &&
-        (user as unknown as { streak_broken_at?: string | null })?.streak_broken_at &&
+        {(user as unknown as { streak_broken_at?: string | null })?.streak_broken_at &&
         ((user as unknown as { streak_before_break?: number | null })?.streak_before_break ?? 0) >= 3 ? (
           <div className="mb-4">
             <StreakProtectCard
@@ -1788,19 +1786,17 @@ export default function DashboardPage() {
         </div>
         {/* $VIBE wallet — sits with the freeze counter because holding is what
             raises it, and it's the wallet vouching burns from. */}
-        {IS_STAGING_CLIENT && (
-          <div className="mt-4 pt-4 border-t border-[var(--border-subtle)]">
-            <div className="flex items-center gap-2 mb-2">
-              <Fire weight="fill" size={16} style={{ color: "var(--accent)" }} />
-              <span className="text-sm font-bold text-[var(--text-secondary)]">$VIBE Wallet</span>
-            </div>
-            <LinkWallet
-              initialAddress={
-                (user as unknown as { solana_wallet?: string | null })?.solana_wallet ?? null
-              }
-            />
+        <div className="mt-4 pt-4 border-t border-[var(--border-subtle)]">
+          <div className="flex items-center gap-2 mb-2">
+            <Fire weight="fill" size={16} style={{ color: "var(--accent)" }} />
+            <span className="text-sm font-bold text-[var(--text-secondary)]">$VIBE Wallet</span>
           </div>
-        )}
+          <LinkWallet
+            initialAddress={
+              (user as unknown as { solana_wallet?: string | null })?.solana_wallet ?? null
+            }
+          />
+        </div>
         {/* GitHub Sync */}
         {user.social_links?.github && (
           <div className="mt-4 pt-4 border-t border-[var(--border-subtle)]">

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -14,7 +14,6 @@ import { extractSocialHandle } from "@/lib/social-handles";
 import { ProfileProjectCard } from "@/components/profile/profile-project-card";
 import ReviewsSection from "@/components/profile/reviews-section";
 import { BackedBy } from "@/components/profile/backed-by";
-import { IS_STAGING_CLIENT } from "@/lib/staging-client";
 import { ProfileViewTracker } from "@/components/profile/profile-view-tracker";
 import { ShareButton } from "@/components/share/share-button";
 import Link from "next/link";
@@ -287,7 +286,6 @@ export default async function ProfilePage({
             builderId={user.id}
             builderUsername={user.username}
             viewer={viewer}
-            enabled={IS_STAGING_CLIENT}
           />
 
           {/* Projects Section */}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -13,7 +13,6 @@ import { EmailPreferences } from "@/components/dashboard/email-preferences";
 import { PrivacyPreferences } from "@/components/dashboard/privacy-preferences";
 import { GithubConnection } from "@/components/dashboard/github-connection";
 import dynamic from "next/dynamic";
-import { IS_STAGING_CLIENT } from "@/lib/staging-client";
 
 // ~60 web3 chunks; only load them when the wallet section actually renders.
 const LinkWallet = dynamic(
@@ -615,20 +614,18 @@ export default function SettingsPage() {
         <PrivacyPreferences />
       </div>
 
-      {/* $VIBE wallet — staging only until the burn features ship. */}
-      {IS_STAGING_CLIENT && (
-        <div className="mb-8 p-6 rounded-2xl" style={{ backgroundColor: "var(--bg-surface)", border: "1px solid var(--border-subtle)" }}>
-          <h2 className="text-lg font-bold text-[var(--foreground)] mb-1">$VIBE Wallet</h2>
-          <p className="text-xs mb-4" style={{ color: "var(--text-muted)" }}>
-            Link a Solana wallet to earn extra free streak freezes for holding $VIBE.
-          </p>
-          <LinkWallet
-            initialAddress={
-              (user as unknown as { solana_wallet?: string | null })?.solana_wallet ?? null
-            }
-          />
-        </div>
-      )}
+      {/* $VIBE wallet */}
+      <div className="mb-8 p-6 rounded-2xl" style={{ backgroundColor: "var(--bg-surface)", border: "1px solid var(--border-subtle)" }}>
+        <h2 className="text-lg font-bold text-[var(--foreground)] mb-1">$VIBE Wallet</h2>
+        <p className="text-xs mb-4" style={{ color: "var(--text-muted)" }}>
+          Link a Solana wallet to earn extra free streak freezes for holding $VIBE.
+        </p>
+        <LinkWallet
+          initialAddress={
+            (user as unknown as { solana_wallet?: string | null })?.solana_wallet ?? null
+          }
+        />
+      </div>
 
       {/* Referral */}
       <div

--- a/src/components/profile/backed-by.tsx
+++ b/src/components/profile/backed-by.tsx
@@ -43,13 +43,10 @@ export async function BackedBy({
   builderId,
   builderUsername,
   viewer,
-  enabled,
 }: {
   builderId: string;
   builderUsername: string;
   viewer: BackedByViewer;
-  /** Staging gate — the burn flow isn't released in production yet. */
-  enabled: boolean;
 }) {
   let backers: Backer[] = [];
   let totalTokens = 0;
@@ -114,7 +111,7 @@ export async function BackedBy({
 
   // Nobody can vouch for themselves, so the owner sees the block only once it
   // has content worth showing.
-  const canVouch = enabled && viewer !== null && viewer.id !== builderId;
+  const canVouch = viewer !== null && viewer.id !== builderId;
   if (backers.length === 0 && !canVouch) return null;
 
   return (


### PR DESCRIPTION
Takes the staging gate off wallet linking, burn-to-vouch, streak protect and holder tiers. **Real users spending real money on an irreversible action** — worth reading the verification section.

## Gates removed (10 sites)

| | |
|---|---|
| API | `vouch` · `streak/protect` · `wallet/{balance,link,nonce}` · `vibe/{quote,preflight}` |
| UI | settings wallet card · dashboard wallet + streak protect · profile `BackedBy` |

## Verified end to end on the deployed staging Worker

Not locally — against `staging.vibetalent.work`, which shares the production database:

- Nonce issued, ed25519 signature verified, wallet bound (`solana_wallet_verified_at` set)
- Balance resolving live from the RPC: **79,222.53 $VIBE**, cache refreshed
- Holder tier evaluated (~$0.19 → below the $10 Backer threshold → base 2 freezes, correct)
- Preflight returning a real blockhash, **and** the 409 shortfall path exercised with exact `required`/`available`/`shortfall`
- A genuine on-chain burn: **832,301.468 $VIBE ($2.00)** destroyed, recorded against the right builder, `tx_ref` stored, profile card rendering it

## One path deliberately unproven

The **vouch notification** has never run — `vouch_received` was added to the CHECK constraint *after* the test burn, so the table holds 1 vouch and 0 notifications.

It fails soft by construction: `createNotification` swallows its own errors, so a failure there costs a notification, not a burn. Flagged and accepted rather than discovered.

## One deliberate design change

`BackedBy` loses its `enabled` prop instead of having it hardcoded `true`. With the gate gone it had one caller and one value — and the card already rendered existing backers regardless of it, so keeping the parameter implied a control that wasn't really there.

## Known, not blocking

- **Thin liquidity.** ~$2,277 in the pool against a $2,353 market cap. A $2 vouch is ~0.1% of it; a few $40 Patron buys move the price. Tiers are evaluated once monthly precisely because of this.
- **Linked vs connected wallet.** Holder tiers read `solana_wallet`; burns come from whatever wallet Privy has connected. Both need a signature the user controls, so it isn't a hole — but they can differ, and that will confuse people eventually.

## Verification

`npm run lint` 0 errors · `npx tsc --noEmit` clean · `npm test` 494 passed · `npm run build` succeeded under CI conditions (`.open-next` absent)

## Rollback

Revert this commit. The gate helpers (`lib/staging.ts`, `lib/staging-client.ts`) are untouched and still used by `worker.ts` for the staging noindex header, so reverting restores the gate exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled wallet linking, unlinking, balance checks, nonce generation, and VIBE transaction flows across all environments.
  * Made the `$VIBE Wallet` section available in dashboard and settings.
  * Enabled eligible users to vouch for profiles in production.
  * Enabled streak protection and restoration outside staging.

* **Documentation**
  * Added repository guidance covering development, deployment, security, payments, and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->