### PR TITLE
fix(ci): stop the backup hanging forever on the postgres client install

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -72,12 +72,30 @@ jobs:
           [ "$missing" -eq 0 ] || exit 1
 
       - name: Install postgresql-client 17
+        # 10 minutes is far longer than this needs; it exists so a step that
+        # stalls fails the run instead of burning the job's whole budget.
+        timeout-minutes: 10
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
           set -euo pipefail
-          # The runner image ships an older client; pg_dump must be >= the
-          # server (Postgres 17.6) or it refuses to dump.
+          # pg_dump must be >= the server (Postgres 17.6) or it refuses to dump.
+
+          # The runner image already ships a pg_dump, and it is periodically
+          # bumped. When it is already 17+, adding the pgdg repo is pure risk
+          # for no gain, so check first.
+          if command -v pg_dump >/dev/null && pg_dump --version | grep -qE '\b1[7-9]\.|\b[2-9][0-9]\.'; then
+            echo "Runner already has a new enough client:"
+            pg_dump --version
+            exit 0
+          fi
+
+          # --batch --yes: without them gpg PROMPTS "File exists. Overwrite?"
+          # when the image already carries the pgdg keyring, and a prompt on a
+          # runner never gets an answer — the step hangs until it is killed.
+          # That is exactly what happened on 2026-08-19.
           curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
-            | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/pgdg.gpg
+            | sudo gpg --batch --yes --dearmor -o /etc/apt/trusted.gpg.d/pgdg.gpg
           echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
             | sudo tee /etc/apt/sources.list.d/pgdg.list > /dev/null
           sudo apt-get update -qq


### PR DESCRIPTION
The nightly backup hung twice today at **step 3, "Install postgresql-client 17"** — ~8 minutes each, dump never started, run ended cancelled rather than failed.

## Cause

```bash
sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/pgdg.gpg
```

`gpg` prompts `File exists. Overwrite? (y/N)` when that path already exists — and GitHub's `ubuntu-latest` image now ships the pgdg keyring. A prompt on a runner never receives an answer, so the step blocks until something kills it.

It worked yesterday because the image didn't carry that file yet, which is exactly what made it look like a transient apt hiccup on the first occurrence.

## Fix

- **`--batch --yes`** so `gpg` can never wait for input
- **Skip the repo setup entirely** when the runner already has `pg_dump` 17+ — removes the failure mode rather than just silencing the prompt, and the runner image is periodically bumped anyway
- **`timeout-minutes: 10`** on the step, so a future stall fails fast instead of eating the job's 20-minute budget
- **`DEBIAN_FRONTEND=noninteractive`** so apt can't introduce a prompt of its own

## Note

This is orthogonal to the earlier connection-string failure, which was a genuine misconfiguration (direct IPv6 endpoint instead of the IPv4 session pooler) and is already corrected in the `SUPABASE_DB_URL` secret.

Workflow-only change. Verified all six steps intact and the file free of tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database backup reliability by preventing installation steps from hanging.
  * Added a timeout and noninteractive configuration for PostgreSQL client setup.
  * Reuses an existing compatible PostgreSQL client when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->