### PR TITLE
fix(ci): compare pg_dump's major version as a number, not a regex

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -84,11 +84,21 @@ jobs:
           # The runner image already ships a pg_dump, and it is periodically
           # bumped. When it is already 17+, adding the pgdg repo is pure risk
           # for no gain, so check first.
-          if command -v pg_dump >/dev/null && pg_dump --version | grep -qE '\b1[7-9]\.|\b[2-9][0-9]\.'; then
-            echo "Runner already has a new enough client:"
+          # Parse the major version as an integer. Do NOT pattern-match the
+          # raw string: `pg_dump (PostgreSQL) 16.14 (Ubuntu 16.14-1.pgdg24.04+1)`
+          # contains "24." in the packaging suffix, which a naive version regex
+          # reads as Postgres 24 and wrongly skips this install — that shipped
+          # once and cost a run.
+          HAVE=""
+          if command -v pg_dump >/dev/null; then
+            HAVE=$(pg_dump --version | sed -nE 's/^pg_dump \(PostgreSQL\) ([0-9]+).*/\1/p')
+          fi
+          if [ -n "$HAVE" ] && [ "$HAVE" -ge 17 ]; then
+            echo "Runner already has pg_dump major version $HAVE:"
             pg_dump --version
             exit 0
           fi
+          echo "Runner pg_dump major version: ${HAVE:-none} - installing 17"
 
           # --batch --yes: without them gpg PROMPTS "File exists. Overwrite?"
           # when the image already carries the pgdg keyring, and a prompt on a


### PR DESCRIPTION
Follow-up to #248. The skip-if-new-enough guard I added there had a bug of its own.

## What happened

It pattern-matched the raw `--version` output, and the real string is:

```
pg_dump (PostgreSQL) 16.14 (Ubuntu 16.14-1.pgdg24.04+1)
```

That contains **`24.`** in the packaging suffix. The regex `\b[2-9][0-9]\.` matched it, concluded "Postgres 24", skipped the install, and left the runner on 16.14 against a 17.6 server:

```
pg_dump: error: aborting because of server version mismatch
detail: server version: 17.6; pg_dump version: 16.14
```

So #248 fixed the hang and introduced a version-detection failure in its place.

## Fix

Extract the major version with `sed` and compare it as an integer:

```bash
HAVE=$(pg_dump --version | sed -nE 's/^pg_dump \(PostgreSQL\) ([0-9]+).*/\1/p')
if [ -n "$HAVE" ] && [ "$HAVE" -ge 17 ]; then ... fi
```

Verified against all three real strings:

| Version output | Major | Result |
|---|---|---|
| `16.14 (Ubuntu 16.14-1.pgdg24.04+1)` | 16 | installs 17 ✅ |
| `17.6 (Ubuntu 17.6-1.pgdg24.04+1)` | 17 | skips ✅ |
| `18.1` | 18 | skips ✅ |

The lesson worth keeping: don't regex version numbers out of a string that also carries a distro version.

Workflow-only. Six steps intact, no tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)