### PR TITLE
fix(ci): call the versioned pg_dump binary, not Debian's wrapper

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -80,37 +80,46 @@ jobs:
         run: |
           set -euo pipefail
           # pg_dump must be >= the server (Postgres 17.6) or it refuses to dump.
+          #
+          # /usr/bin/pg_dump is NOT the binary — it is a wrapper shipped by
+          # postgresql-client-common that dispatches to a versioned binary under
+          # /usr/lib/postgresql/<major>/bin. On the runner it keeps selecting 16
+          # even once 17 is installed, so `pg_dump --version` still reports
+          # 16.14 and the dump aborts on a version mismatch. Installing alone
+          # never fixes this; the dump step has to call the versioned binary.
 
-          # The runner image already ships a pg_dump, and it is periodically
-          # bumped. When it is already 17+, adding the pgdg repo is pure risk
-          # for no gain, so check first.
-          # Parse the major version as an integer. Do NOT pattern-match the
-          # raw string: `pg_dump (PostgreSQL) 16.14 (Ubuntu 16.14-1.pgdg24.04+1)`
-          # contains "24." in the packaging suffix, which a naive version regex
-          # reads as Postgres 24 and wrongly skips this install — that shipped
-          # once and cost a run.
-          HAVE=""
-          if command -v pg_dump >/dev/null; then
-            HAVE=$(pg_dump --version | sed -nE 's/^pg_dump \(PostgreSQL\) ([0-9]+).*/\1/p')
-          fi
-          if [ -n "$HAVE" ] && [ "$HAVE" -ge 17 ]; then
-            echo "Runner already has pg_dump major version $HAVE:"
-            pg_dump --version
-            exit 0
-          fi
-          echo "Runner pg_dump major version: ${HAVE:-none} - installing 17"
+          find_pg_dump() {
+            local d v
+            for d in $(ls -d /usr/lib/postgresql/*/bin 2>/dev/null | sort -Vr); do
+              [ -x "$d/pg_dump" ] || continue
+              v=$("$d/pg_dump" --version | sed -nE 's/^pg_dump \(PostgreSQL\) ([0-9]+).*/\1/p')
+              if [ -n "$v" ] && [ "$v" -ge 17 ]; then echo "$d/pg_dump"; return 0; fi
+            done
+            return 1
+          }
 
-          # --batch --yes: without them gpg PROMPTS "File exists. Overwrite?"
-          # when the image already carries the pgdg keyring, and a prompt on a
-          # runner never gets an answer — the step hangs until it is killed.
-          # That is exactly what happened on 2026-08-19.
-          curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
-            | sudo gpg --batch --yes --dearmor -o /etc/apt/trusted.gpg.d/pgdg.gpg
-          echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
-            | sudo tee /etc/apt/sources.list.d/pgdg.list > /dev/null
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq postgresql-client-17
-          pg_dump --version
+          if PGDUMP=$(find_pg_dump); then
+            echo "Found a suitable client already installed."
+          else
+            echo "No pg_dump >= 17 present - installing."
+            # --batch --yes: without them gpg PROMPTS "File exists. Overwrite?"
+            # when the image already carries the pgdg keyring, and a prompt on a
+            # runner never gets an answer - the step hangs until it is killed.
+            curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+              | sudo gpg --batch --yes --dearmor -o /etc/apt/trusted.gpg.d/pgdg.gpg
+            echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+              | sudo tee /etc/apt/sources.list.d/pgdg.list > /dev/null
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq postgresql-client-17
+            PGDUMP=$(find_pg_dump) || {
+              echo "::error::postgresql-client-17 installed but no pg_dump >= 17 found"
+              exit 1
+            }
+          fi
+
+          echo "PG_DUMP=$PGDUMP" >> "$GITHUB_ENV"
+          echo "Using: $PGDUMP"
+          "$PGDUMP" --version
 
       - name: Dump and encrypt
         env:
@@ -128,7 +137,7 @@ jobs:
           # --clean --if-exists: the dump is replayable onto a non-empty DB.
           # Piped straight into gzip → openssl so the plaintext dump is never
           # written to the runner's disk.
-          pg_dump "$DB_URL" \
+          "$PG_DUMP" "$DB_URL" \
             --schema=public \
             --schema=auth \
             --no-owner \


### PR DESCRIPTION
`postgresql-client-17` installs correctly, and the dump *still* aborts:

```
Runner pg_dump major version: 16 - installing 17
Setting up postgresql-client-17 (17.11-1.pgdg24.04+2) ...
pg_dump (PostgreSQL) 16.14 (Ubuntu 16.14-1.pgdg24.04+1)   ← still 16
```

## Cause

`/usr/bin/pg_dump` is not the binary. It's a wrapper from `postgresql-client-common` that dispatches to `/usr/lib/postgresql/<major>/bin/pg_dump`, and on the runner it keeps selecting 16 even with 17 installed. So installing 17 was never going to change what `pg_dump` resolves to.

## Fix

Find the highest installed versioned binary reporting major ≥ 17, export it as `PG_DUMP`, and have the dump step call that path directly. The install is skipped when a suitable binary already exists, and the search re-runs after installing so an apt success that still yields nothing usable fails loudly instead of hitting the same mismatch.

## Third attempt at this step — worth stating plainly

| PR | Fixed | Why it wasn't enough |
|---|---|---|
| #248 | `gpg` prompt hanging the runner | real bug, but not the version problem |
| #249 | version regex matching `pgdg24.04` | real bug I introduced in #248 |
| this | wrapper resolves to 16 | the actual root cause |

The first two were genuine defects, but both rested on the assumption that `pg_dump` on `PATH` was the thing being installed. It never was. Checking what `pg_dump --version` reported *after* the install would have caught this two PRs ago.

Workflow-only. Six steps intact, no tabs, `PG_DUMP` exported and consumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)