### PR TITLE
feat(bags): server-side client for resolving a wallet's Bags launches

### DIFF
--- a/src/lib/__tests__/bags.test.ts
+++ b/src/lib/__tests__/bags.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 
-import { bagsConfigured, fetchLaunchesForWallet } from "@/lib/bags";
+import {
+  bagsConfigured,
+  fetchLaunchesForWallet,
+  fetchCreatedLaunches,
+} from "@/lib/bags";
 
 const WALLET = "DYp2cUmgoBEYPxN9xPwiqKZoi5WR4SRAWJnLD1d5QAdT";
 const MINT = "FfDYT3WqimMw7itMxw4kYJ26GPG78RfpZmepQCFpBAGS";
@@ -125,5 +129,136 @@ describe("fetchLaunchesForWallet", () => {
 
     mockFetch({ success: true, response: { tokenMints: "nope" } });
     expect(await fetchLaunchesForWallet(WALLET)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchCreatedLaunches
+// ---------------------------------------------------------------------------
+// Regression suite for the bug this function exists to prevent.
+// fee-share/admin/list returns mints a wallet holds FEE AUTHORITY over, which
+// is not the same as mints it launched. Against production, wallet 4Evn…WwX9
+// returns three mints and has launched exactly one ($VIBE); the other two carry
+// no creator record. Reporting three would credit a builder with work they did
+// not do — the one failure a reputation product cannot ship.
+
+describe("fetchCreatedLaunches", () => {
+  const WALLET_A = "4EvnGaySWW6fhmQeTbjb7HXRbqzyCGWXPy8J8zziWwX9";
+  const MINT_REAL = "FfDYT3WqimMw7itMxw4kYJ26GPG78RfpZmepQCFpBAGS";
+  const MINT_EMPTY = "5BXaYHuS3FPxQMac9Zensi85XZ3tHo7YdzaxUqTBAGS";
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  /** Route each URL to a canned payload so one test can span both endpoints. */
+  function routeFetch(routes: { admin: unknown; creators: Record<string, unknown> }) {
+    const fn = vi.fn().mockImplementation((input: URL | string) => {
+      const url = String(input);
+      const body = url.includes("/fee-share/admin/list")
+        ? routes.admin
+        : routes.creators[new URL(url).searchParams.get("tokenMint") ?? ""] ?? {
+            success: true,
+            response: [],
+          };
+      return Promise.resolve({ ok: true, status: 200, json: async () => body });
+    });
+    vi.stubGlobal("fetch", fn);
+    return fn;
+  }
+
+  it("keeps only mints where this wallet is a confirmed creator", async () => {
+    vi.stubEnv("BAGS_API_KEY", "k");
+    routeFetch({
+      admin: { success: true, response: { tokenMints: [MINT_EMPTY, MINT_REAL] } },
+      creators: {
+        [MINT_EMPTY]: { success: true, response: [] },
+        [MINT_REAL]: {
+          success: true,
+          response: [
+            { wallet: WALLET_A, isCreator: true, twitterUsername: "abhiontwt", royaltyBps: 8000 },
+          ],
+        },
+      },
+    });
+
+    const out = await fetchCreatedLaunches(WALLET_A);
+    expect(out).toEqual([
+      { tokenMint: MINT_REAL, twitterUsername: "abhiontwt", royaltyBps: 8000 },
+    ]);
+  });
+
+  it("excludes a token where the wallet is listed but is not the creator", async () => {
+    vi.stubEnv("BAGS_API_KEY", "k");
+    routeFetch({
+      admin: { success: true, response: { tokenMints: [MINT_REAL] } },
+      creators: {
+        [MINT_REAL]: {
+          success: true,
+          // fee-share recipient on someone else's launch
+          response: [{ wallet: WALLET_A, isCreator: false, royaltyBps: 1000 }],
+        },
+      },
+    });
+    expect(await fetchCreatedLaunches(WALLET_A)).toEqual([]);
+  });
+
+  it("excludes a token created by a different wallet", async () => {
+    vi.stubEnv("BAGS_API_KEY", "k");
+    routeFetch({
+      admin: { success: true, response: { tokenMints: [MINT_REAL] } },
+      creators: {
+        [MINT_REAL]: {
+          success: true,
+          response: [{ wallet: "SomeOtherWalletEntirely1111111111111111111", isCreator: true },
+          ],
+        },
+      },
+    });
+    expect(await fetchCreatedLaunches(WALLET_A)).toEqual([]);
+  });
+
+  it("omits a mint whose creator record could not be fetched, rather than assuming", async () => {
+    vi.stubEnv("BAGS_API_KEY", "k");
+    const fn = vi.fn().mockImplementation((input: URL | string) => {
+      const url = String(input);
+      if (url.includes("/fee-share/admin/list")) {
+        return Promise.resolve({
+          ok: true, status: 200,
+          json: async () => ({ success: true, response: { tokenMints: [MINT_REAL] } }),
+        });
+      }
+      return Promise.reject(new Error("network"));
+    });
+    vi.stubGlobal("fetch", fn);
+    expect(await fetchCreatedLaunches(WALLET_A)).toEqual([]);
+  });
+
+  it("propagates null when the candidate list itself is unavailable", async () => {
+    vi.stubEnv("BAGS_API_KEY", "k");
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("down")));
+    expect(await fetchCreatedLaunches(WALLET_A)).toBeNull();
+  });
+
+  it("returns [] without a second call when the wallet has no candidates", async () => {
+    vi.stubEnv("BAGS_API_KEY", "k");
+    const fn = routeFetch({ admin: { success: true, response: { tokenMints: [] } }, creators: {} });
+    expect(await fetchCreatedLaunches(WALLET_A)).toEqual([]);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("defaults a missing twitter handle to null and missing royalty to 0", async () => {
+    vi.stubEnv("BAGS_API_KEY", "k");
+    routeFetch({
+      admin: { success: true, response: { tokenMints: [MINT_REAL] } },
+      creators: {
+        [MINT_REAL]: { success: true, response: [{ wallet: WALLET_A, isCreator: true }] },
+      },
+    });
+    expect(await fetchCreatedLaunches(WALLET_A)).toEqual([
+      { tokenMint: MINT_REAL, twitterUsername: null, royaltyBps: 0 },
+    ]);
   });
 });

--- a/src/lib/__tests__/bags.test.ts
+++ b/src/lib/__tests__/bags.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+import { bagsConfigured, fetchLaunchesForWallet } from "@/lib/bags";
+
+const WALLET = "DYp2cUmgoBEYPxN9xPwiqKZoi5WR4SRAWJnLD1d5QAdT";
+const MINT = "FfDYT3WqimMw7itMxw4kYJ26GPG78RfpZmepQCFpBAGS";
+
+function mockFetch(body: unknown, init: { ok?: boolean; status?: number } = {}) {
+  const fn = vi.fn().mockResolvedValue({
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    json: async () => body,
+  });
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+describe("bagsConfigured", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("is false when BAGS_API_KEY is unset", () => {
+    vi.stubEnv("BAGS_API_KEY", undefined);
+    expect(bagsConfigured()).toBe(false);
+  });
+
+  it("treats a blank key as unset", () => {
+    vi.stubEnv("BAGS_API_KEY", "   ");
+    expect(bagsConfigured()).toBe(false);
+  });
+
+  it("is true once a key is present", () => {
+    vi.stubEnv("BAGS_API_KEY", "test-key");
+    expect(bagsConfigured()).toBe(true);
+  });
+});
+
+describe("fetchLaunchesForWallet", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("returns null without a key, and never calls out", async () => {
+    vi.stubEnv("BAGS_API_KEY", undefined);
+    const f = mockFetch({});
+    expect(await fetchLaunchesForWallet(WALLET)).toBeNull();
+    expect(f).not.toHaveBeenCalled();
+  });
+
+  it("returns the mints on success", async () => {
+    vi.stubEnv("BAGS_API_KEY", "k");
+    mockFetch({ success: true, response: { tokenMints: [MINT] } });
+    expect(await fetchLaunchesForWallet(WALLET)).toEqual([MINT]);
+  });
+
+  it("sends the key as x-api-key", async () => {
+    vi.stubEnv("BAGS_API_KEY", "secret-key");
+    const f = mockFetch({ success: true, response: { tokenMints: [] } });
+    await fetchLaunchesForWallet(WALLET);
+    const headers = f.mock.calls[0][1].headers as Record<string, string>;
+    expect(headers["x-api-key"]).toBe("secret-key");
+  });
+
+  it("puts the wallet in the query string", async () => {
+    vi.stubEnv("BAGS_API_KEY", "k");
+    const f = mockFetch({ success: true, response: { tokenMints: [] } });
+    await fetchLaunchesForWallet(WALLET);
+    expect(String(f.mock.calls[0][0])).toContain(`wallet=${WALLET}`);
+  });
+
+  // [] and null mean different things to callers: one is "asked, none", the
+  // other "could not ask". Collapsing them would cache an outage as fact.
+  it("distinguishes an empty result from a failure", async () => {
+    vi.stubEnv("BAGS_API_KEY", "k");
+    mockFetch({ success: true, response: { tokenMints: [] } });
+    expect(await fetchLaunchesForWallet(WALLET)).toEqual([]);
+
+    mockFetch({ success: false, error: "nope" });
+    expect(await fetchLaunchesForWallet(WALLET)).toBeNull();
+  });
+
+  it("returns null on a non-ok response", async () => {
+    vi.stubEnv("BAGS_API_KEY", "k");
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    mockFetch({}, { ok: false, status: 401 });
+    expect(await fetchLaunchesForWallet(WALLET)).toBeNull();
+  });
+
+  it("logs when the key is rejected, so a dead key isn't mistaken for no launches", async () => {
+    vi.stubEnv("BAGS_API_KEY", "k");
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockFetch({}, { ok: false, status: 401 });
+    await fetchLaunchesForWallet(WALLET);
+    expect(err).toHaveBeenCalledOnce();
+  });
+
+  it("returns null when fetch throws", async () => {
+    vi.stubEnv("BAGS_API_KEY", "k");
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("timeout")));
+    expect(await fetchLaunchesForWallet(WALLET)).toBeNull();
+  });
+
+  it("rejects a malformed wallet without calling out", async () => {
+    vi.stubEnv("BAGS_API_KEY", "k");
+    const f = mockFetch({});
+    expect(await fetchLaunchesForWallet("not-a-wallet")).toBeNull();
+    expect(f).not.toHaveBeenCalled();
+  });
+
+  it("drops entries that are not plausible mints", async () => {
+    vi.stubEnv("BAGS_API_KEY", "k");
+    mockFetch({ success: true, response: { tokenMints: [MINT, "", null, 42, "short"] } });
+    expect(await fetchLaunchesForWallet(WALLET)).toEqual([MINT]);
+  });
+
+  it("returns null when tokenMints is missing or the wrong shape", async () => {
+    vi.stubEnv("BAGS_API_KEY", "k");
+    mockFetch({ success: true, response: {} });
+    expect(await fetchLaunchesForWallet(WALLET)).toBeNull();
+
+    mockFetch({ success: true, response: { tokenMints: "nope" } });
+    expect(await fetchLaunchesForWallet(WALLET)).toBeNull();
+  });
+});

--- a/src/lib/bags.ts
+++ b/src/lib/bags.ts
@@ -104,3 +104,73 @@ export async function fetchLaunchesForWallet(wallet: string): Promise<string[] |
   // Drop anything that isn't a plausible mint rather than trusting the payload.
   return mints.filter((m): m is string => typeof m === "string" && SOLANA_ADDRESS_RE.test(m));
 }
+
+/** A launch this wallet genuinely created, as confirmed by the creator record. */
+export type BagsLaunch = {
+  tokenMint: string;
+  /** Verified X handle Bags holds for the creator, when it has one. */
+  twitterUsername: string | null;
+  /** Creator's share of fees, in basis points. */
+  royaltyBps: number;
+};
+
+type CreatorEntry = {
+  wallet?: unknown;
+  isCreator?: unknown;
+  twitterUsername?: unknown;
+  royaltyBps?: unknown;
+};
+
+/**
+ * Creator records for one token, or null when Bags could not answer.
+ *
+ * An empty array is a real answer: Bags knows the mint but holds no creator
+ * record for it.
+ */
+export async function fetchTokenCreators(tokenMint: string): Promise<CreatorEntry[] | null> {
+  if (!SOLANA_ADDRESS_RE.test(tokenMint)) return null;
+  const response = await bagsGet("/token-launch/creator/v3", { tokenMint });
+  return Array.isArray(response) ? (response as CreatorEntry[]) : null;
+}
+
+/**
+ * The launches a wallet actually created.
+ *
+ * Two steps, deliberately. `fee-share/admin/list` answers "which mints does
+ * this wallet hold fee-share authority over", which is NOT the same question as
+ * "what did this wallet launch" — it also returns tokens carrying no creator
+ * record at all. Reporting those as launches would credit a builder with work
+ * they did not do, which is the one failure this product cannot afford.
+ *
+ * So each candidate is confirmed against its creator record, and only mints
+ * listing this wallet with `isCreator: true` survive.
+ *
+ * Verified against production data: wallet 4Evn…WwX9 has three fee-share mints
+ * and exactly one real launch ($VIBE); the other two return no creators.
+ */
+export async function fetchCreatedLaunches(wallet: string): Promise<BagsLaunch[] | null> {
+  const candidates = await fetchLaunchesForWallet(wallet);
+  if (candidates === null) return null;
+  if (candidates.length === 0) return [];
+
+  const launches: BagsLaunch[] = [];
+  for (const tokenMint of candidates) {
+    const creators = await fetchTokenCreators(tokenMint);
+    if (!creators) continue; // couldn't confirm — omit rather than guess
+
+    const mine = creators.find(
+      (c) => typeof c.wallet === "string" && c.wallet === wallet && c.isCreator === true,
+    );
+    if (!mine) continue;
+
+    launches.push({
+      tokenMint,
+      twitterUsername:
+        typeof mine.twitterUsername === "string" && mine.twitterUsername.trim()
+          ? mine.twitterUsername.trim()
+          : null,
+      royaltyBps: typeof mine.royaltyBps === "number" ? mine.royaltyBps : 0,
+    });
+  }
+  return launches;
+}

--- a/src/lib/bags.ts
+++ b/src/lib/bags.ts
@@ -1,0 +1,106 @@
+// Server-only client for the Bags public API (https://public-api-v2.bags.fm).
+//
+// WHY THIS EXISTS: VibeTalent knows which GitHub-verified builder owns a Solana
+// wallet, because linking one requires an ed25519 signature over a server-issued
+// nonce. Bags knows which wallets launched which tokens. Neither side can join
+// those alone, and the join is the interesting part: it lets a Bags launch carry
+// a builder's real shipping history instead of being an anonymous wallet.
+//
+// SERVER-ONLY. The key travels in the x-api-key header; it must never reach the
+// browser bundle. Import this from route handlers, crons and server components
+// only — never from a "use client" module.
+//
+// Every call FAILS SOFT and returns null. Bags being down must never break a
+// profile page: the builder's own reputation data is the primary content and
+// their launches are enrichment on top of it.
+
+const BAGS_API_BASE = "https://public-api-v2.bags.fm/api/v1";
+
+/** How long to wait before giving up on Bags. Their API is not on our critical path. */
+const REQUEST_TIMEOUT_MS = 8_000;
+
+/** Solana base58 public key. Same shape the wallet-link flow validates against. */
+const SOLANA_ADDRESS_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+
+/**
+ * Is a Bags key configured?
+ *
+ * Read at call time, not module scope: on Workers the environment is bound per
+ * request, so a module-level read can run before the value exists and would
+ * then cache that miss for the life of the isolate.
+ */
+export function bagsConfigured(): boolean {
+  return Boolean(process.env.BAGS_API_KEY?.trim());
+}
+
+/** Narrow an unknown value to a plain object. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * GET a Bags endpoint and return the unwrapped `response` payload.
+ *
+ * Bags wraps everything as `{ success, response }` and uses `success: false`
+ * for application-level failures alongside a 200, so the flag is checked
+ * explicitly rather than trusting the status code.
+ */
+async function bagsGet(path: string, params: Record<string, string>): Promise<unknown | null> {
+  const apiKey = process.env.BAGS_API_KEY?.trim();
+  if (!apiKey) return null;
+
+  const url = new URL(`${BAGS_API_BASE}${path}`);
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: { "x-api-key": apiKey, Accept: "application/json" },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+  } catch {
+    // Network failure or timeout. Nothing here is worth surfacing to a user.
+    return null;
+  }
+
+  if (!res.ok) {
+    // 401 means the key is wrong or revoked — worth naming, because the
+    // symptom otherwise is "no builder ever has launches", which reads as
+    // nobody using Bags rather than as a broken credential.
+    if (res.status === 401 || res.status === 403) {
+      console.error(`Bags API rejected the key (HTTP ${res.status}) on ${path}`);
+    }
+    return null;
+  }
+
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch {
+    return null;
+  }
+
+  if (!isRecord(body) || body.success !== true) return null;
+  return body.response ?? null;
+}
+
+/**
+ * Token mints where `wallet` holds fee-share admin authority — in practice, the
+ * launches that wallet is behind.
+ *
+ * Returns null when Bags is unreachable or unconfigured, and an empty array
+ * when the wallet simply has no launches. Callers must distinguish the two:
+ * null means "unknown, try later", [] means "asked, genuinely none".
+ */
+export async function fetchLaunchesForWallet(wallet: string): Promise<string[] | null> {
+  if (!SOLANA_ADDRESS_RE.test(wallet)) return null;
+
+  const response = await bagsGet("/fee-share/admin/list", { wallet });
+  if (!isRecord(response)) return null;
+
+  const mints = response.tokenMints;
+  if (!Array.isArray(mints)) return null;
+
+  // Drop anything that isn't a plausible mint rather than trusting the payload.
+  return mints.filter((m): m is string => typeof m === "string" && SOLANA_ADDRESS_RE.test(m));
+}


### PR DESCRIPTION
First half of the Bags integration. **Inert until `BAGS_API_KEY` is set** — with no key it returns `null` without making a request, so this is safe to merge before you have one.

## Why this is the interesting join

VibeTalent knows which **GitHub-verified builder owns a Solana wallet** — linking one requires an ed25519 signature over a server-issued nonce. Bags knows **which wallets launched which tokens**. Neither platform can make that connection alone.

`fee-share/admin/list` is the join: given a wallet, it returns the mints that wallet holds fee-share authority over.

What it unlocks: a Bags launch stops being an anonymous wallet and starts carrying a builder's real shipping history. That's their buyers' single biggest trust problem, answered with data only we have.

## Contract verified against the live API

Not just the docs — an unauthenticated call returns:

```
HTTP 401  {"success":false,"error":"API key is required. Please provide x-api-key header."}
```

Same `{ success, ... }` envelope as the success path, which is why `success` is checked explicitly rather than trusting the status code.

## Design decisions

**Server-only.** The key travels in `x-api-key`; it must never reach the browser bundle.

**Fails soft, always returns null.** Bags being down must not break a profile page — the builder's own reputation is the primary content, launches are enrichment.

**`null` ≠ `[]`.** `null` means "could not ask", `[]` means "asked, genuinely none". Collapsing them would let an outage be cached as fact and shown as "this builder has never launched anything".

**401/403 is logged.** Otherwise a revoked key looks identical to nobody using Bags.

## Verification

`npm run lint` 0 errors · `npx tsc --noEmit` clean · `npm test` **508 passed** (14 new)

Tests cover: no key → no request; header and query construction; empty vs failed distinction; non-ok responses; thrown fetch; malformed wallet rejected without calling out; junk entries filtered from `tokenMints`.

## Next

A resolver cron writing per-builder launches, then the profile badge and a `/bags` board. Both need the key, and realistically need more than one linked wallet — that push to existing builders is the bigger lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-side integration with the Bags API.
  * Added wallet launch lookups with Solana address validation and token mint filtering.
  * Added creator verification and launch details, including social handles and royalty information.
  * Added handling for unavailable data, empty results, request timeouts, and API failures.

* **Tests**
  * Added coverage for API configuration, authentication, wallet validation, response handling, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->