### PR TITLE
fix(home): lead the hero with hiring, calm the light palette

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -20,7 +20,13 @@
    ─────────────────────────────────────────────────────────────────────────── */
 
 :root {
-  --background: #F6F4F2;
+  /* Deeper than it looks like it should be, on purpose. Cards are pure white
+     (--bg-surface), so at the old #F6F4F2 the page and its cards differed by
+     1.10:1 — visually one sheet, with 8%-opacity borders carrying all the
+     structure. ~80% of painted area sat above 0.75 luminance and the UI read
+     as glaring in light mode. This drops the field and lets white cards
+     actually advance off it. Dark mode already layers warm greys this way. */
+  --background: #EDE7E1;
   --foreground: #141110;
 
   --bg-surface: #FFFFFF;
@@ -47,7 +53,11 @@
   --badge-gold: #CA8A04;
   --badge-diamond: #0891B2;
 
-  --hm-0: #ECE8E5;
+  /* Tracks --background. The empty cell must stay legible as absence: the
+     homepage proof wall sits directly on the page, so at the old #ECE8E5 it
+     disappeared once the background deepened. This holds the original
+     empty-cell-to-page ratio (1.12:1) against the new background. */
+  --hm-0: #E2DBD4;
   --hm-1: #FFD4C4;
   --hm-2: #FFA07A;
   --hm-3: #FF6B3A;

--- a/src/components/homepage/fork-hero.tsx
+++ b/src/components/homepage/fork-hero.tsx
@@ -8,12 +8,16 @@ import { HeroSceneStyles, BuilderScene, HirerScene } from "@/components/homepage
  * the headline moved into ProofWallHero and the stat strip died with it, so
  * this is now purely the self-select section that follows the wall.
  *
- * Hiring leads. The wall above already argues the builder case and its CTA is
- * "Start your streak", so a second equally-loud builder pitch here was the
- * page repeating itself. Hirers, who never get a pitch above the fold and may
- * never sign up at all (browsing and hiring are free), get the primary card:
- * listed first, accent CTA, brighter surface. The builder card stays as the
- * quieter second option for anyone who scrolled past the hero CTA.
+ * Hiring leads, matching the hero. VibeTalent is sold as a hiring platform and
+ * demand is the scarce side, so hirers get the primary card here — listed
+ * first, accent CTA, brighter surface — exactly as they get the accent button
+ * above. The builder card stays the quieter second option.
+ *
+ * This section expands a choice the hero has already offered: its primary
+ * "Hire builders" button points at the same /explore route as this card, and
+ * its secondary at the same signup as the other. Keep the two in sync — if the
+ * hero loses that pairing, this stops being the detailed version of a question
+ * already asked and goes back to interrupting the page with "who are you?".
  */
 export function ForkHero() {
   return (

--- a/src/components/homepage/proof-wall-hero.tsx
+++ b/src/components/homepage/proof-wall-hero.tsx
@@ -45,10 +45,15 @@ export function ProofWallHero({
   // Every figure here is a live count. Deliberately absent: the old
   // "Top Vibers" tile, which rendered topVibecoders.length against an array
   // hardcoded to .slice(0, 3) — it read "3" no matter what the data did.
+  //
+  // Also deliberate: no stat is accent-coloured. The hero is single-colour
+  // text by design, so the only accent above the fold is the primary button.
+  // "Builders tracked" used to carry an `accent: true` flag; don't put it back
+  // without changing that rule too.
   const stats = [
     { label: "GitHub-verified days", value: totalBuilderDays.toLocaleString("en-US") },
     { label: "Longest streak", value: longestStreak, suffix: "days" },
-    { label: "Builders tracked", value: buildersTracked, accent: true },
+    { label: "Builders tracked", value: buildersTracked },
     { label: "Projects shipped", value: totalProjects },
     { label: "Avg. streak", value: avgStreak, suffix: avgStreak === 1 ? "day" : "days" },
   ];
@@ -60,11 +65,12 @@ export function ProofWallHero({
         <h1 className="normal-case text-4xl sm:text-5xl lg:text-6xl font-extrabold tracking-tight leading-[1.05] text-[var(--foreground)]">
           The resume is dead.
           <br />
-          <span className="text-[var(--accent)]">the proof of work isn&apos;t</span>
+          The proof of work isn&apos;t.
         </h1>
         <p className="text-sm sm:text-base text-[var(--text-secondary)] font-medium leading-relaxed lg:pb-2">
           Every square below is a day a builder shipped, read straight from GitHub. Hover any square
-          for the builder, the day, and the commits.
+          for the builder, the day, and the commits. This is what you build here. It&apos;s also what
+          you hire on.
         </p>
       </div>
 
@@ -107,7 +113,7 @@ export function ProofWallHero({
         </p>
       </div>
 
-      {/* Real totals + the one CTA */}
+      {/* Real totals + the builder/hirer CTAs */}
       <div className="mt-8 flex flex-wrap items-end justify-between gap-x-10 gap-y-8">
         {/* Wording matters on the first tile. Roughly half of streak_logs
             predates the platform (the github-sync backfill reads a year of
@@ -121,11 +127,7 @@ export function ProofWallHero({
               <div className="text-[11px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
                 {s.label}
               </div>
-              <div
-                className={`mt-1 text-3xl sm:text-4xl font-extrabold tracking-tight ${
-                  s.accent ? "text-[var(--accent)]" : "text-[var(--foreground)]"
-                }`}
-              >
+              <div className="mt-1 text-3xl sm:text-4xl font-extrabold tracking-tight text-[var(--foreground)]">
                 {s.value}
                 {s.suffix && (
                   <span className="ml-1.5 text-base font-bold text-[var(--text-muted)]">{s.suffix}</span>
@@ -134,13 +136,37 @@ export function ProofWallHero({
             </div>
           ))}
         </div>
-        <Link
-          href="/auth/signup"
-          className="inline-flex h-12 items-center justify-center rounded-xl px-6 text-sm font-semibold text-white transition-[background-color,transform] hover:bg-[var(--accent-hover)] active:scale-[0.98]"
-          style={{ backgroundColor: "var(--accent)" }}
-        >
-          Start your streak
-        </Link>
+        {/* Two doors, and hiring is the primary one. VibeTalent is sold as a
+            hiring platform: demand is the scarce side, builder supply is not,
+            so the accent goes to /explore and builder signup takes the quieter
+            slot. Keeping both here is what stops the builder/hirer fork below
+            from reading as an abrupt "who are you?" — that section is now the
+            detailed version of a choice the hero already offered.
+
+            "Hire builders" is deliberately unqualified and names the intent
+            rather than the mechanic. The old label led with "Hiring?", which
+            suits a secondary aside but makes a primary CTA hedge. "Start your
+            streak" needs no qualifier either — only builders have streaks, so
+            it self-selects on its own. */}
+        <div className="flex flex-wrap items-center gap-3 w-full sm:w-auto">
+          <Link
+            href="/explore"
+            className="inline-flex h-12 w-full sm:w-auto items-center justify-center rounded-xl px-6 text-sm font-semibold text-white transition-[background-color,transform] hover:bg-[var(--accent-hover)] active:scale-[0.98]"
+            style={{ backgroundColor: "var(--accent)" }}
+          >
+            Hire builders
+          </Link>
+          <Link
+            href="/auth/signup"
+            className="inline-flex h-12 w-full sm:w-auto items-center justify-center rounded-xl px-6 text-sm font-semibold text-[var(--foreground)] transition-[background-color,transform] hover:bg-[var(--bg-surface-light)] active:scale-[0.98]"
+            style={{
+              backgroundColor: "var(--bg-surface)",
+              border: "1px solid var(--border-subtle)",
+            }}
+          >
+            Start your streak
+          </Link>
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
Design feedback on the live homepage surfaced two separate problems.

## The hero offered one door

Its only CTA was **Start your streak**, so a visitor here to hire had no move above the fold. That made the builder/hirer fork below read as an abrupt *"who are you?"* rather than the detailed version of a choice the hero had already offered. `ForkHero`'s own comment had already diagnosed this — *"Hirers, who never get a pitch above the fold"* — without fixing it.

The hero now offers both doors, **hiring primary**:

| | before | after |
|---|---|---|
| primary CTA | Start your streak → `/auth/signup` | **Hire builders** → `/explore` |
| secondary | — | Start your streak → `/auth/signup` |

VibeTalent is sold as a hiring platform and demand is the scarce side, so this matches `ForkHero`, which already led with hiring. Both components' comments now say so, to stop the two drifting apart.

Also single-colour text throughout the hero: the headline drops its accent `<span>`, and the stats row drops its lone accent figure (`accent: true` on Builders tracked, plus the now-dead ternary). The only accent above the fold is the primary button.

## Light mode read as glaring

Root cause: `--background` (`#F6F4F2`) sat under pure-white cards — a **1.10:1** separation, visually one sheet, with 8%-opacity borders carrying all the structure. Measured ~80% of painted area above 0.75 luminance on the homepage, **87.5%** on `/explore`.

| | before | after |
|---|---|---|
| card vs page | 1.10:1 | **1.23:1** |
| page field luminance | 0.907 | **0.806** (−11%) |
| empty heatmap cell vs page | 1.12:1 | 1.12:1 (held) |

Dark mode already layered warm greys this way and is **untouched** — changes are confined to `:root`.

### One necessary companion change

Deepening the background swallowed `--hm-0` (`#ECE8E5`), whose cells sit directly on the page in the hero wall, so *"didn't ship"* became indistinguishable from *"no cell"*. Retuned to `#E2DBD4`, chosen to hold the original empty-cell-to-page ratio of 1.12:1 exactly rather than by eye. Both tokens carry comments noting they move together.

## Verification

- `./node_modules/.bin/eslint src` — 0 errors
- `npx vitest run` — 494 passed / 38 files
- `npm run build` — clean under CI conditions (`.open-next` moved aside, as on a fresh runner)
- No mobile horizontal scroll; light and dark both checked in-browser

## Known, deliberately out of scope

`--accent` `#FF3A00` against its white label text is **3.59:1**, below the 4.5:1 WCAG AA needs at that size. Pre-existing on every primary button on the site, and fixing it means changing the brand colour — worth its own PR, but note this PR makes that button more prominent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Hire builders” and “Start your streak” calls to action to the homepage hero.
  * Expanded homepage messaging to highlight hiring and builder discovery.

* **Style**
  * Refined light-mode page and heatmap colors.
  * Updated hero stat and headline styling for improved visual consistency.

* **Documentation**
  * Clarified homepage audience, CTA behavior, and synchronization details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->