### PR TITLE
feat(bags): show a builder's verified Bags launches on their profile

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -15,10 +15,11 @@ on:
     - cron: "0 4 * * *" # quality-rescore
     - cron: "30 5 * * *" # verify-backfill
     - cron: "0 15 * * 1,2" # weekly-digest (Mon + Tue)
+    - cron: "30 7 * * *" # bags-sync — after the 06:00 daily fan-out has settled
   workflow_dispatch:
     inputs:
       route:
-        description: "Cron route to run now (daily | check-live-urls | quality-rescore | verify-backfill | weekly-digest)"
+        description: "Cron route to run now (daily | check-live-urls | quality-rescore | verify-backfill | weekly-digest | bags-sync)"
         required: true
         default: "verify-backfill"
 
@@ -40,6 +41,7 @@ jobs:
             "0 4 * * *")    ROUTE=quality-rescore ;;
             "30 5 * * *")   ROUTE=verify-backfill ;;
             "0 15 * * 1,2") ROUTE=weekly-digest ;;
+            "30 7 * * *")   ROUTE=bags-sync ;;
             *)              ROUTE="${{ github.event.inputs.route }}" ;;
           esac
           echo "route=$ROUTE" >> "$GITHUB_OUTPUT"

--- a/src/app/api/cron/bags-sync/route.ts
+++ b/src/app/api/cron/bags-sync/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { bagsConfigured, fetchCreatedLaunches } from "@/lib/bags";
+
+/**
+ * Cron job: resolve each verified builder's Bags launches into bags_launches.
+ *
+ * Bags is an upstream we do not control, so profile pages must never call it
+ * live. This is the only thing that talks to Bags; profiles read the table.
+ *
+ * Only wallets that were cryptographically linked are used — binding one
+ * requires an ed25519 signature over a server-issued nonce, so a row here means
+ * the same person controls both the GitHub-verified profile and the launching
+ * wallet. That chain is the entire product claim; nothing self-reported (a
+ * typed-in X handle, say) may ever produce a row.
+ *
+ * Protected by CRON_SECRET.
+ */
+export async function GET(req: NextRequest) {
+  const cronSecret = process.env.CRON_SECRET;
+  // Fail closed: without a secret in production this route would be open, and
+  // it writes the table that backs a public credibility claim.
+  if (!cronSecret && process.env.NODE_ENV === "production") {
+    console.error("CRON_SECRET is not configured");
+    return NextResponse.json({ error: "Cron secret not configured" }, { status: 500 });
+  }
+  if (cronSecret) {
+    const authHeader = req.headers.get("authorization");
+    if (authHeader !== `Bearer ${cronSecret}`) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+  }
+
+  if (!bagsConfigured()) {
+    // Not an error: the integration is simply not switched on yet.
+    return NextResponse.json({ skipped: "BAGS_API_KEY not configured" });
+  }
+
+  const sb = createAdminClient();
+
+  const { data: builders, error } = await sb
+    .from("users")
+    .select("id, solana_wallet")
+    .not("solana_wallet", "is", null)
+    .not("solana_wallet_verified_at", "is", null);
+
+  if (error) {
+    console.error("bags-sync: failed to load builders:", error.message);
+    return NextResponse.json({ error: "Failed to load builders" }, { status: 500 });
+  }
+
+  let checked = 0;
+  let upserted = 0;
+  let unreachable = 0;
+
+  for (const builder of builders ?? []) {
+    const wallet = (builder as { solana_wallet: string }).solana_wallet;
+    const userId = (builder as { id: string }).id;
+
+    const launches = await fetchCreatedLaunches(wallet);
+    checked += 1;
+
+    // null means Bags could not answer. Leave existing rows untouched: a
+    // builder's launches must not disappear from their profile because an
+    // upstream had a bad minute.
+    if (launches === null) {
+      unreachable += 1;
+      continue;
+    }
+
+    for (const launch of launches) {
+      const { error: upsertError } = await sb
+        .from("bags_launches")
+        .upsert(
+          {
+            token_mint: launch.tokenMint,
+            user_id: userId,
+            creator_wallet: wallet,
+            twitter_username: launch.twitterUsername,
+            royalty_bps: launch.royaltyBps,
+            last_verified_at: new Date().toISOString(),
+          },
+          { onConflict: "token_mint" },
+        );
+      if (upsertError) {
+        console.error(`bags-sync: upsert failed for ${launch.tokenMint}:`, upsertError.message);
+        continue;
+      }
+      upserted += 1;
+    }
+  }
+
+  return NextResponse.json({ checked, upserted, unreachable });
+}

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -14,6 +14,7 @@ import { extractSocialHandle } from "@/lib/social-handles";
 import { ProfileProjectCard } from "@/components/profile/profile-project-card";
 import ReviewsSection from "@/components/profile/reviews-section";
 import { BackedBy } from "@/components/profile/backed-by";
+import { BagsLaunches } from "@/components/profile/bags-launches";
 import { ProfileViewTracker } from "@/components/profile/profile-view-tracker";
 import { ShareButton } from "@/components/share/share-button";
 import Link from "next/link";
@@ -287,6 +288,11 @@ export default async function ProfilePage({
             builderUsername={user.username}
             viewer={viewer}
           />
+
+          {/* Sits directly under Backed by: both answer "has anyone put
+              something real behind this person", one in burned tokens and one
+              in shipped launches. */}
+          <BagsLaunches builderId={user.id} />
 
           {/* Projects Section */}
           {(() => {

--- a/src/components/profile/bags-launches.tsx
+++ b/src/components/profile/bags-launches.tsx
@@ -1,0 +1,85 @@
+import { Rocket, ArrowSquareOut } from "@phosphor-icons/react/dist/ssr";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+type LaunchRow = {
+  token_mint: string;
+  twitter_username: string | null;
+  royalty_bps: number | null;
+  first_seen_at: string;
+};
+
+/**
+ * "Launched on Bags" — tokens this builder verifiably created.
+ *
+ * The point of the section is the pairing: a GitHub-verified shipping record
+ * sitting next to a real token launch. On Bags a launch is a wallet and an X
+ * handle, neither of which shows whether that person actually builds. This does.
+ *
+ * Reads the cached table only, never Bags directly, so an upstream outage
+ * cannot slow or break a profile. Renders nothing when the builder has no
+ * launches — an empty "no launches" card would imply a shortcoming on a
+ * platform where most builders have never launched a token at all.
+ */
+export async function BagsLaunches({ builderId }: { builderId: string }) {
+  let launches: LaunchRow[] = [];
+
+  try {
+    const sb = createAdminClient();
+    const { data } = await sb
+      .from("bags_launches")
+      .select("token_mint, twitter_username, royalty_bps, first_seen_at")
+      .eq("user_id", builderId)
+      .order("first_seen_at", { ascending: false });
+    launches = (data as LaunchRow[] | null) ?? [];
+  } catch {
+    // The table may not exist yet in an environment where the migration has
+    // not been applied. A profile must still render.
+    return null;
+  }
+
+  if (launches.length === 0) return null;
+
+  return (
+    <section className="card-brutal p-5" aria-labelledby="bags-launches-heading">
+      <div className="flex items-center gap-2">
+        <Rocket weight="fill" size={18} style={{ color: "var(--accent)" }} />
+        <h2
+          id="bags-launches-heading"
+          className="text-sm font-extrabold uppercase tracking-wide text-[var(--foreground)]"
+        >
+          {launches.length === 1 ? "Launched on Bags" : `${launches.length} launches on Bags`}
+        </h2>
+      </div>
+
+      <p className="mt-2 text-xs" style={{ color: "var(--text-muted)" }}>
+        Verified against the Bags creator record for this builder&apos;s linked wallet.
+      </p>
+
+      <ul className="mt-4 flex flex-col gap-2">
+        {launches.map((launch) => (
+          <li key={launch.token_mint}>
+            <a
+              href={`https://bags.fm/${launch.token_mint}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center justify-between gap-3 rounded-xl px-3 py-2 transition-colors hover:bg-[var(--bg-surface-light)]"
+              style={{ border: "1px solid var(--border-subtle)" }}
+            >
+              <span className="flex min-w-0 flex-col">
+                <span className="truncate font-mono text-xs font-bold text-[var(--foreground)]">
+                  {launch.token_mint.slice(0, 6)}…{launch.token_mint.slice(-4)}
+                </span>
+                {launch.royalty_bps ? (
+                  <span className="text-[11px]" style={{ color: "var(--text-muted)" }}>
+                    {launch.royalty_bps / 100}% creator fee share
+                  </span>
+                ) : null}
+              </span>
+              <ArrowSquareOut size={14} className="shrink-0 text-[var(--text-muted)]" />
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/supabase/migrations/20260819_bags_launches.sql
+++ b/supabase/migrations/20260819_bags_launches.sql
@@ -1,0 +1,39 @@
+-- Bags launches, cached per builder.
+--
+-- Bags is an upstream we do not control, so profile rendering must never depend
+-- on a live call to it. The resolver writes here; the profile reads only this
+-- table.
+--
+-- Rows are only ever written for launches CONFIRMED by the Bags creator record
+-- (see fetchCreatedLaunches in lib/bags.ts). Holding fee-share authority over a
+-- token is not the same as having launched it, and crediting a builder with a
+-- launch they did not make would undermine the one thing this product sells.
+
+CREATE TABLE IF NOT EXISTS public.bags_launches (
+  token_mint       text PRIMARY KEY,
+  user_id          uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  -- The wallet Bags names as creator. Kept so a later audit can re-verify
+  -- without guessing which of a user's wallets was responsible.
+  creator_wallet   text NOT NULL,
+  -- Verified X handle Bags holds for the creator; null when it has none.
+  twitter_username text,
+  -- Creator's fee share in basis points, as Bags reports it.
+  royalty_bps      integer NOT NULL DEFAULT 0,
+  first_seen_at    timestamptz NOT NULL DEFAULT now(),
+  last_verified_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- The profile query is "every launch by this builder".
+CREATE INDEX IF NOT EXISTS bags_launches_user_id_idx
+  ON public.bags_launches (user_id);
+
+ALTER TABLE public.bags_launches ENABLE ROW LEVEL SECURITY;
+
+-- Public read: this is a credibility signal, it is meant to be seen.
+DROP POLICY IF EXISTS "bags_launches_public_read" ON public.bags_launches;
+CREATE POLICY "bags_launches_public_read"
+  ON public.bags_launches FOR SELECT USING (true);
+
+-- No client write policy at all. Only the resolver, running with the service
+-- role, may write — a client-writable row here would let anyone award
+-- themselves a launch, which is precisely the claim being verified.


### PR DESCRIPTION
The visible half of the Bags integration. Builds on the client from #251.

## What it does

Puts a **GitHub-verified shipping record next to a real token launch**. On Bags, a launch is a wallet and an X handle — neither shows whether that person actually builds. This does, and it's the half only VibeTalent can supply.

## Three pieces

| | |
|---|---|
| `bags_launches` | cached table, public read, **no client write policy** |
| `/api/cron/bags-sync` | daily at 07:30 UTC, resolves verified builders' wallets |
| `BagsLaunches` | profile section, reads the cache only |

## Trust decisions

**Only cryptographically linked wallets are used.** Binding one requires an ed25519 signature over a server-issued nonce, so a row means the same person controls both the GitHub-verified profile *and* the launching wallet.

**Nothing self-reported can produce a row.** The X handle on a VibeTalent profile is free text (the data has entries like `https://x.com/…` and literally `hello`). Joining on it would let anyone claim another builder's launches — the exact attack this feature must not enable, even though it would raise coverage from 1 builder to 131.

**No client write policy on the table.** Only the service-role resolver writes. A client-writable row would let a user award themselves the claim being verified.

**Only creator-confirmed launches**, via `fetchCreatedLaunches` from #251 — fee-share authority is not authorship.

## Failure behaviour

- Bags unreachable → **existing rows left alone**, not cleared. A builder's launches must not vanish because an upstream had a bad minute.
- Table missing (migration not yet applied) → section returns null, profile renders fine.
- No launches → renders nothing. An empty "no launches" card would read as a shortcoming on a platform where most builders have never launched a token.

## ⚠️ Migration required

Apply via the Supabase SQL editor — **not** `supabase db push` (see CLAUDE.md):

```
supabase/migrations/20260819_bags_launches.sql
```

Safe to merge first: the profile section catches the missing table and renders nothing.

## Verification

`npm run lint` 0 errors · `npx tsc --noEmit` clean · `npm test` 515 passed · `npm run build` succeeded, `/api/cron/bags-sync` registered

Not verifiable until the migration is applied and a launch wallet is linked — **the owner's currently-linked wallet is the treasury, not the wallet that launched `$VIBE`**, so this shows zero launches until that's changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)