### PR TITLE
fix(ui): make the GitHub-verified tick visible in light mode

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -48,6 +48,10 @@
   --accent-vibe: #FF3A00;
   --accent-soft: rgba(255, 58, 0, 0.08);
 
+  /* GitHub-verified tick. Darkened from the dark-mode blue so the glyph clears
+     3:1 against white cards — #1D9BF0 lands at exactly 3.00:1 there. */
+  --verified: #1A8CD8;
+
   --badge-bronze: #D97706;
   --badge-silver: #71717A;
   --badge-gold: #CA8A04;
@@ -111,6 +115,7 @@
   --text-tertiary: hsl(14, 6%, 78%);
 
   --accent-soft: rgba(255, 58, 0, 0.12);
+  --verified: #1D9BF0;
 
   --badge-bronze: #A0522D;
   --badge-silver: #A9A9A9;

--- a/src/components/feed/feed-row.tsx
+++ b/src/components/feed/feed-row.tsx
@@ -147,7 +147,7 @@ export function FeedRow({ item, compact = false, nowMs = null }: FeedRowProps) {
           >
             {item.display_name || item.username}
             {item.github_verified && (
-              <SealCheck weight="fill" size={14} className="text-white shrink-0" aria-label="GitHub verified" />
+              <SealCheck weight="fill" size={14} className="text-[var(--verified)] shrink-0" aria-label="GitHub verified" />
             )}
           </Link>
           {item.display_name && (

--- a/src/components/layout/navbar-client.tsx
+++ b/src/components/layout/navbar-client.tsx
@@ -736,7 +736,7 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
                 />
               </button>
               {userProfile?.github_username && (
-                <SealCheck size={18} weight="fill" className="text-[#1D9BF0] absolute -bottom-0.5 -right-0.5 pointer-events-none"
+                <SealCheck size={18} weight="fill" className="text-[var(--verified)] absolute -bottom-0.5 -right-0.5 pointer-events-none"
                   style={{ filter: "drop-shadow(0 0 2px var(--bg-base))" }}
                   aria-label="GitHub verified"
                 />
@@ -950,7 +950,7 @@ export function NavbarClient({ initialIsLoggedIn, initialProfile }: NavbarClient
               <span className="text-sm font-extrabold text-[var(--foreground)] flex items-center gap-1">
                 {userProfile.username}
                 {userProfile.github_username && (
-                  <SealCheck size={14} weight="fill" className="text-[#1D9BF0] shrink-0"
+                  <SealCheck size={14} weight="fill" className="text-[var(--verified)] shrink-0"
                     aria-label="GitHub verified"
                   />
                 )}

--- a/src/components/leaderboard/leaderboard-content.tsx
+++ b/src/components/leaderboard/leaderboard-content.tsx
@@ -138,7 +138,7 @@ export function LeaderboardContent({ users }: { users: UserWithSocials[] }) {
               <div className="font-bold uppercase text-[var(--foreground)] text-sm flex items-center justify-center gap-1">
                 {user.display_name || `@${user.username}`}
                 {user.github_username && (
-                  <SealCheck weight="fill" size={14} className="text-white shrink-0" aria-label="GitHub verified" />
+                  <SealCheck weight="fill" size={14} className="text-[var(--verified)] shrink-0" aria-label="GitHub verified" />
                 )}
               </div>
               {user.display_name && (
@@ -201,7 +201,7 @@ export function LeaderboardContent({ users }: { users: UserWithSocials[] }) {
                         <span className="font-bold text-sm flex items-center gap-1 truncate">
                           {user.display_name || `@${user.username}`}
                           {user.github_username && (
-                            <SealCheck weight="fill" size={14} className="text-white shrink-0" aria-label="GitHub verified" />
+                            <SealCheck weight="fill" size={14} className="text-[var(--verified)] shrink-0" aria-label="GitHub verified" />
                           )}
                         </span>
                         {user.display_name && (

--- a/src/components/profile/profile-sidebar.tsx
+++ b/src/components/profile/profile-sidebar.tsx
@@ -160,7 +160,7 @@ export function ProfileSidebar({ user }: ProfileSidebarProps) {
                 title={`GitHub ownership verified: @${user.github_username}`}
                 aria-label={`GitHub verified as @${user.github_username}`}
               >
-                <SealCheck weight="fill" size={20} className="text-white" />
+                <SealCheck weight="fill" size={20} className="text-[var(--verified)]" />
               </span>
             )}
           </h1>

--- a/src/components/ui/vibecoder-card.tsx
+++ b/src/components/ui/vibecoder-card.tsx
@@ -76,7 +76,7 @@ export function VibecoderCard({ user, rank }: VibecoderCardProps) {
                     <SealCheck
                       size={16}
                       weight="fill"
-                      className="text-[#1D9BF0] shrink-0"
+                      className="text-[var(--verified)] shrink-0"
                       aria-label={`GitHub verified as @${user.github_username}`}
                     />
                   )}


### PR DESCRIPTION
## The bug

The GitHub-verified tick on a builder's profile is invisible in light mode.

It was hardcoded `text-white`:

```tsx
// src/components/profile/profile-sidebar.tsx
<SealCheck weight="fill" size={20} className="text-white" />
```

That sits inside the `<h1>` on a `--bg-surface` card, which is `#FFFFFF` in light mode. White glyph, white card. It only ever read correctly because dark mode's `--foreground` is also white — a holdover from when the app was dark-only.

**Three other call sites had the identical bug**, all invisible in light mode:

- leaderboard podium card (`leaderboard-content.tsx:141`)
- leaderboard table row (`leaderboard-content.tsx:204`)
- every feed row (`feed-row.tsx:150`) — 50 invisible ticks on `/feed` alone

## The fix

There was already a de-facto tick colour — `#1D9BF0`, hardcoded in the navbar and the vibecoder card — but no token, which is why the other call sites reached for `text-white` instead. This adds one and points all seven usages at it:

```css
--verified: #1A8CD8;   /* light */
--verified: #1D9BF0;   /* dark  */
```

Light mode gets a slightly darker blue on purpose: `#1D9BF0` on white lands at exactly **3.00:1**, right on the WCAG non-text contrast threshold. `#1A8CD8` clears it at **3.63:1**. Dark mode keeps `#1D9BF0` unchanged, so the two call sites that were already correct don't shift.

## Verification

Checked against the dev server in both themes, reading computed colour rather than eyeballing:

| Surface | Light | Dark |
|---|---|---|
| Profile sidebar | `rgb(26,140,216)` ✓ | `rgb(29,155,240)` ✓ |
| Feed (50 ticks) | `rgb(26,140,216)` ✓ | — |
| Leaderboard all-time (18) | `rgb(26,140,216)` ✓ | — |
| Explore cards (15) | `rgb(26,140,216)` ✓ | — |

`eslint src` clean · 515 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated GitHub verification badges with a consistent verified color across feeds, profiles, leaderboards, navigation, and cards.
  * Added theme-aware verified colors for both light and dark modes.
  * Improved badge visibility and visual consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->