### PR TITLE
feat(bags): a public board of verified Bags launches and who made them

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,7 +4,10 @@ const securityHeaders = [
   { key: "X-Frame-Options", value: "DENY" },
   { key: "X-Content-Type-Options", value: "nosniff" },
   { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
-  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=()",
+  },
   {
     key: "Strict-Transport-Security",
     value: "max-age=63072000; includeSubDomains; preload",
@@ -44,6 +47,12 @@ const nextConfig: NextConfig = {
       {
         protocol: "https",
         hostname: "unavatar.io",
+      },
+      {
+        // Token artwork on /bags, proxied through /_next/image so the strict
+        // img-src CSP still only has to allow our own origin.
+        protocol: "https",
+        hostname: "assets.geckoterminal.com",
       },
     ],
   },

--- a/src/app/bags/[username]/page.tsx
+++ b/src/app/bags/[username]/page.tsx
@@ -88,6 +88,11 @@ const loadBuilder = cache(
 
       if (!builder) return null;
 
+      // Same bar as the board: this page states the builder is GitHub-verified,
+      // and wallet linking does not require GitHub. Without a handle there is no
+      // verified identity to show, so there is no page.
+      if (!(builder as Builder).github_username?.trim()) return null;
+
       const { data: launches } = await sb
         .from("bags_launches")
         .select("token_mint, creator_wallet, royalty_bps, first_seen_at")
@@ -215,9 +220,14 @@ export default async function BagsBuilderPage({
   }));
   const cards = [...enriched, ...remaining];
 
-  // Bags' own record of who this is. Read from the first launch: the wallet is
-  // the same across their rows, so one call answers it. Fails soft — the page
-  // is about verified launches, and the handle is a nice-to-have on top.
+  // A builder can relink a different wallet later, and old rows keep the wallet
+  // that actually made them. So nothing here may assume one wallet made
+  // everything: identity is read from the newest launch's own (mint, wallet)
+  // pair, and the footer counts the wallets it really found.
+  const creatorWallets = [...new Set(launches.map((l) => l.creator_wallet))];
+
+  // Bags' own record of who this is. Fails soft — the page is about verified
+  // launches, and the handle is a nice-to-have on top.
   let creator: BagsCreatorProfile | null = null;
   const firstLaunch = launches[0];
   if (firstLaunch) {
@@ -380,14 +390,24 @@ export default async function BagsBuilderPage({
         </section>
 
         <p className="mt-8 text-xs leading-relaxed text-[var(--bags-text-faint)]">
-          Launched from{" "}
-          <span className="font-mono text-[var(--bags-text-muted)]">
-            {shortMint(launches[0]!.creator_wallet)}
-          </span>
-          , a wallet bound to this profile by signature and confirmed as the
-          creator of each coin above by the Bags creator record. Prices and
-          charts come from GeckoTerminal and are indicative only. Nothing here
-          is financial advice or an endorsement of any token.
+          {creatorWallets.length === 1 ? (
+            <>
+              Launched from{" "}
+              <span className="font-mono text-[var(--bags-text-muted)]">
+                {shortMint(creatorWallets[0]!)}
+              </span>
+              , a wallet bound to this profile by signature.
+            </>
+          ) : (
+            <>
+              Launched from {creatorWallets.length} wallets bound to this
+              profile by signature over time.
+            </>
+          )}{" "}
+          Each coin is confirmed against the Bags creator record for the wallet
+          that made it. Prices and charts come from GeckoTerminal and are
+          indicative only. Nothing here is financial advice or an endorsement of
+          any token.
         </p>
       </div>
     </div>

--- a/src/app/bags/[username]/page.tsx
+++ b/src/app/bags/[username]/page.tsx
@@ -1,0 +1,395 @@
+import { cache } from "react";
+import type { Metadata } from "next";
+import Link from "next/link";
+import Image from "next/image";
+import { notFound } from "next/navigation";
+import { createClient } from "@supabase/supabase-js";
+import {
+  ArrowLeft,
+  ArrowRight,
+  GithubLogo,
+  Flame,
+  XLogo,
+} from "@phosphor-icons/react/dist/ssr";
+
+import { shortMint } from "@/lib/bags-board";
+import { fetchCreatorProfile, type BagsCreatorProfile } from "@/lib/bags";
+import { assessBuilderTrust } from "@/lib/builder-trust";
+import { BuilderTrustCard } from "@/components/bags/builder-trust-card";
+import {
+  fetchTokenMarket,
+  fetchDailyCloses,
+  type TokenMarket,
+} from "@/lib/token-market";
+import { TokenCard } from "@/components/bags/token-card";
+import { jsonLdHtml } from "@/lib/json-ld";
+import { siteUrl, buildBreadcrumbList } from "@/lib/seo";
+
+// Market data is cached for the same five minutes upstream; matching it here
+// keeps the page and its numbers on one clock.
+export const revalidate = 300;
+
+/**
+ * Cap on how many launches get live market data in one render. Each costs two
+ * GeckoTerminal calls, and their free tier is rate-limited per minute; past
+ * this the remaining coins still render, just without price or chart.
+ */
+const MAX_TOKENS_WITH_MARKET = 12;
+
+const BUILDER_FIELDS =
+  "id, username, display_name, avatar_url, github_username, vibe_score, streak, longest_streak, lifetime_contributions, created_at";
+
+type Builder = {
+  id: string;
+  username: string;
+  display_name: string | null;
+  avatar_url: string | null;
+  github_username: string | null;
+  vibe_score: number | null;
+  streak: number | null;
+  longest_streak: number | null;
+  lifetime_contributions: number | null;
+  created_at: string;
+};
+
+type Launch = {
+  token_mint: string;
+  creator_wallet: string;
+  royalty_bps: number | null;
+  first_seen_at: string;
+};
+
+function getPublicClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  );
+}
+
+/**
+ * The builder and their verified launches, or null when either is missing.
+ *
+ * Wrapped in React's cache so generateMetadata and the page body share one
+ * result: without it every request runs the same two queries twice, and this
+ * database is egress-bound rather than CPU-bound.
+ */
+const loadBuilder = cache(
+  async (
+    username: string,
+  ): Promise<{ builder: Builder; launches: Launch[] } | null> => {
+    try {
+      const sb = getPublicClient();
+
+      const { data: builder } = await sb
+        .from("users")
+        .select(BUILDER_FIELDS)
+        .eq("username", username)
+        .maybeSingle();
+
+      if (!builder) return null;
+
+      const { data: launches } = await sb
+        .from("bags_launches")
+        .select("token_mint, creator_wallet, royalty_bps, first_seen_at")
+        .eq("user_id", (builder as Builder).id)
+        .order("first_seen_at", { ascending: false });
+
+      if (!launches?.length) return null;
+
+      return { builder: builder as Builder, launches: launches as Launch[] };
+    } catch {
+      return null;
+    }
+  },
+);
+
+/**
+ * The two extra reads a trust assessment needs: how much of this builder's work
+ * is GitHub-verified, and the score distribution to rank them against.
+ *
+ * Both fail soft to a zero-evidence assessment, which withholds the rank rather
+ * than inventing one.
+ */
+async function loadTrustInputs(userId: string): Promise<{
+  verifiedProjects: number;
+  allScores: number[];
+}> {
+  try {
+    const sb = getPublicClient();
+    const [projects, scores] = await Promise.all([
+      sb
+        .from("projects")
+        .select("id", { count: "exact", head: true })
+        .eq("user_id", userId)
+        .eq("verified", true),
+      sb.from("users").select("vibe_score"),
+    ]);
+
+    return {
+      verifiedProjects: projects.count ?? 0,
+      allScores: (
+        (scores.data as { vibe_score: number | null }[] | null) ?? []
+      ).map((row) => row.vibe_score ?? 0),
+    };
+  } catch {
+    return { verifiedProjects: 0, allScores: [] };
+  }
+}
+
+/** Price, artwork and chart for one launch. Every part of this may be absent. */
+async function loadMarket(
+  mint: string,
+): Promise<{ market: TokenMarket | null; closes: number[] }> {
+  const market = await fetchTokenMarket(mint);
+  const closes = market?.poolAddress
+    ? await fetchDailyCloses(market.poolAddress)
+    : [];
+  return { market, closes };
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ username: string }>;
+}): Promise<Metadata> {
+  const { username } = await params;
+  const data = await loadBuilder(username);
+
+  if (!data) {
+    return {
+      title: "Builder not found",
+      robots: { index: false, follow: false },
+    };
+  }
+
+  const count = data.launches.length;
+  const title = `@${username}'s Bags launches: ${count} verified ${count === 1 ? "coin" : "coins"}`;
+  const description = `Every token @${username} launched on Bags, verified against the Bags creator record for their signature-linked wallet, with live price and their VibeTalent vibe score.`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: `${siteUrl}/bags/${username}` },
+    openGraph: {
+      title,
+      description,
+      url: `${siteUrl}/bags/${username}`,
+      type: "profile",
+    },
+    twitter: { card: "summary_large_image", title, description },
+  };
+}
+
+export default async function BagsBuilderPage({
+  params,
+}: {
+  params: Promise<{ username: string }>;
+}) {
+  const { username } = await params;
+  const data = await loadBuilder(username);
+  if (!data) notFound();
+
+  const { builder, launches } = data;
+
+  const { verifiedProjects, allScores } = await loadTrustInputs(builder.id);
+  const trust = assessBuilderTrust(
+    {
+      vibeScore: builder.vibe_score ?? 0,
+      verifiedProjects,
+      lifetimeContributions: builder.lifetime_contributions ?? 0,
+      longestStreak: builder.longest_streak ?? 0,
+    },
+    allScores,
+  );
+
+  const enriched = await Promise.all(
+    launches.slice(0, MAX_TOKENS_WITH_MARKET).map(async (launch) => ({
+      launch,
+      ...(await loadMarket(launch.token_mint)),
+    })),
+  );
+  const remaining = launches.slice(MAX_TOKENS_WITH_MARKET).map((launch) => ({
+    launch,
+    market: null as TokenMarket | null,
+    closes: [] as number[],
+  }));
+  const cards = [...enriched, ...remaining];
+
+  // Bags' own record of who this is. Read from the first launch: the wallet is
+  // the same across their rows, so one call answers it. Fails soft — the page
+  // is about verified launches, and the handle is a nice-to-have on top.
+  let creator: BagsCreatorProfile | null = null;
+  const firstLaunch = launches[0];
+  if (firstLaunch) {
+    creator = await fetchCreatorProfile(
+      firstLaunch.token_mint,
+      firstLaunch.creator_wallet,
+    );
+  }
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@graph": [
+      buildBreadcrumbList([
+        { name: "Home", path: "/" },
+        { name: "Bags Builders", path: "/bags" },
+        { name: `@${builder.username}`, path: `/bags/${builder.username}` },
+      ]),
+      {
+        "@type": "ItemList",
+        name: `Bags launches by @${builder.username}`,
+        numberOfItems: launches.length,
+        itemListElement: launches.slice(0, 25).map((launch, i) => ({
+          "@type": "ListItem",
+          position: i + 1,
+          name: launch.token_mint,
+          url: `https://bags.fm/${launch.token_mint}`,
+        })),
+      },
+    ],
+  };
+
+  return (
+    <div className="bags-theme min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(jsonLd) }}
+      />
+
+      <div className="mx-auto max-w-4xl px-4 py-12 sm:px-6">
+        <Link
+          href="/bags"
+          className="inline-flex items-center gap-1.5 text-[13px] font-semibold text-[var(--bags-text-muted)] transition-colors hover:text-[var(--bags-green)]"
+        >
+          <ArrowLeft size={14} weight="bold" />
+          All Bags builders
+        </Link>
+
+        <header className="mt-6 flex flex-wrap items-start justify-between gap-6">
+          <div className="flex min-w-0 items-center gap-4">
+            {builder.avatar_url ? (
+              <Image
+                src={builder.avatar_url}
+                alt=""
+                width={64}
+                height={64}
+                className="h-16 w-16 shrink-0 rounded-full object-cover"
+                style={{ border: "1px solid var(--bags-border)" }}
+              />
+            ) : (
+              <div
+                className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full text-xl font-bold text-[var(--bags-bg)]"
+                style={{ backgroundColor: "var(--bags-green)" }}
+              >
+                {builder.username[0]?.toUpperCase()}
+              </div>
+            )}
+            <div className="min-w-0">
+              <h1 className="truncate text-3xl font-bold tracking-[-0.03em] text-[var(--bags-text)]">
+                @{builder.username}
+              </h1>
+              {builder.display_name ? (
+                <p className="mt-0.5 truncate text-sm text-[var(--bags-text-muted)]">
+                  {builder.display_name}
+                </p>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="text-right">
+            <div
+              className="font-mono text-4xl font-extrabold leading-none tracking-[-0.03em]"
+              style={{ color: "var(--bags-green)" }}
+            >
+              {builder.vibe_score ?? 0}
+            </div>
+            <div className="bags-label mt-1.5 text-[10px] font-semibold text-[var(--bags-text-faint)]">
+              vibe score
+            </div>
+          </div>
+        </header>
+
+        <div className="mt-5 flex flex-wrap items-center gap-x-4 gap-y-2 text-[13px] text-[var(--bags-text-muted)]">
+          {builder.github_username ? (
+            <span className="inline-flex items-center gap-1.5">
+              <GithubLogo size={14} weight="fill" />
+              {builder.github_username}
+            </span>
+          ) : null}
+          {builder.streak ? (
+            <span className="inline-flex items-center gap-1.5">
+              <Flame size={14} weight="fill" />
+              {builder.streak}-day streak
+            </span>
+          ) : null}
+          {creator?.twitterUsername ? (
+            <span className="inline-flex items-center gap-1.5">
+              <XLogo size={13} weight="fill" />
+              {creator.twitterUsername}
+            </span>
+          ) : null}
+          {creator?.bagsUsername ? (
+            <span className="inline-flex items-center gap-1.5">
+              <span className="bags-label text-[10px] font-semibold text-[var(--bags-text-faint)]">
+                bags
+              </span>
+              {creator.bagsUsername}
+            </span>
+          ) : null}
+        </div>
+
+        <BuilderTrustCard
+          trust={trust}
+          verifiedProjects={verifiedProjects}
+          lifetimeContributions={builder.lifetime_contributions ?? 0}
+          longestStreak={builder.longest_streak ?? 0}
+          memberSince={builder.created_at}
+        />
+
+        <Link
+          href={`/profile/${builder.username}`}
+          className="mt-6 inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-bold transition-opacity hover:opacity-85"
+          style={{
+            backgroundColor: "var(--bags-green)",
+            color: "var(--bags-bg)",
+          }}
+        >
+          view full profile
+          <ArrowRight size={14} weight="bold" />
+        </Link>
+
+        <section className="mt-10" aria-labelledby="launches-heading">
+          <h2
+            id="launches-heading"
+            className="bags-label mb-4 text-[11px] font-semibold text-[var(--bags-text-faint)]"
+          >
+            {launches.length} verified{" "}
+            {launches.length === 1 ? "launch" : "launches"}
+          </h2>
+          <ul className="flex flex-col gap-4">
+            {cards.map(({ launch, market, closes }) => (
+              <TokenCard
+                key={launch.token_mint}
+                mint={launch.token_mint}
+                royaltyBps={launch.royalty_bps}
+                market={market}
+                closes={closes}
+              />
+            ))}
+          </ul>
+        </section>
+
+        <p className="mt-8 text-xs leading-relaxed text-[var(--bags-text-faint)]">
+          Launched from{" "}
+          <span className="font-mono text-[var(--bags-text-muted)]">
+            {shortMint(launches[0]!.creator_wallet)}
+          </span>
+          , a wallet bound to this profile by signature and confirmed as the
+          creator of each coin above by the Bags creator record. Prices and
+          charts come from GeckoTerminal and are indicative only. Nothing here
+          is financial advice or an endorsement of any token.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/bags/page.tsx
+++ b/src/app/bags/page.tsx
@@ -37,12 +37,16 @@ export const metadata: Metadata = {
 // an hour of staleness costs nothing and keeps this page off the ISR treadmill.
 export const revalidate = 3600;
 
+/** PostgREST caps a response anyway; this is the page size we read in. */
+const LAUNCH_PAGE_SIZE = 1000;
+
 /**
- * Guard against an unbounded scan as the table grows. Far above the current row
- * count; when the board approaches it, this page needs pagination rather than a
- * bigger number.
+ * Absolute ceiling on rows read for one board render, so a runaway table cannot
+ * hang the page. Truncating BELOW this would be worse than a slow page: the
+ * board groups and ranks after reading, so a cut-off read silently drops whole
+ * builders and understates the launch counts of the ones that survive.
  */
-const MAX_LAUNCHES = 500;
+const MAX_LAUNCHES = 20_000;
 
 const BUILDER_FIELDS =
   "id, username, display_name, avatar_url, github_username, vibe_score, streak";
@@ -55,21 +59,46 @@ function getPublicClient() {
   );
 }
 
+/**
+ * Every cached launch, read in pages.
+ *
+ * Ordered by token_mint as well as time so page boundaries stay deterministic
+ * when rows share a first_seen_at, which they do whenever one sync writes
+ * several launches at once.
+ */
+async function fetchAllLaunches(
+  sb: ReturnType<typeof getPublicClient>,
+): Promise<BagsLaunchRow[] | null> {
+  const rows: BagsLaunchRow[] = [];
+
+  for (let from = 0; from < MAX_LAUNCHES; from += LAUNCH_PAGE_SIZE) {
+    const { data, error } = await sb
+      .from("bags_launches")
+      .select("token_mint, user_id, royalty_bps, first_seen_at")
+      .order("first_seen_at", { ascending: false })
+      .order("token_mint", { ascending: true })
+      .range(from, from + LAUNCH_PAGE_SIZE - 1);
+
+    if (error) return null;
+    if (!data?.length) break;
+
+    rows.push(...(data as BagsLaunchRow[]));
+    if (data.length < LAUNCH_PAGE_SIZE) break;
+  }
+
+  return rows;
+}
+
 async function loadBoard() {
   try {
     const sb = getPublicClient();
 
-    const { data: launches, error } = await sb
-      .from("bags_launches")
-      .select("token_mint, user_id, royalty_bps, first_seen_at")
-      .order("first_seen_at", { ascending: false })
-      .limit(MAX_LAUNCHES);
+    const rows = await fetchAllLaunches(sb);
 
     // A missing table (migration not applied in this environment) must not take
     // the page down: the claim CTA below is useful even with no rows at all.
-    if (error || !launches?.length) return [];
+    if (!rows?.length) return [];
 
-    const rows = launches as BagsLaunchRow[];
     const userIds = [...new Set(rows.map((r) => r.user_id))];
 
     const { data: builders } = await sb
@@ -124,7 +153,7 @@ export default async function BagsPage() {
           "@type": "ListItem",
           position: i + 1,
           name: entry.username,
-          url: `${siteUrl}/profile/${entry.username}`,
+          url: `${siteUrl}/bags/${entry.username}`,
         })),
       },
     ],

--- a/src/app/bags/page.tsx
+++ b/src/app/bags/page.tsx
@@ -1,0 +1,290 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { createClient } from "@supabase/supabase-js";
+import { BagSimple, SealCheck } from "@phosphor-icons/react/dist/ssr";
+
+import {
+  buildBagsBoard,
+  type BagsBuilderRow,
+  type BagsLaunchRow,
+} from "@/lib/bags-board";
+import { BagsBuilderRow as BoardRow } from "@/components/bags/bags-builder-row";
+import { jsonLdHtml } from "@/lib/json-ld";
+import { siteUrl, buildBreadcrumbList } from "@/lib/seo";
+
+export const metadata: Metadata = {
+  title: "Bags Builders: Verified Token Launches by Vibe Coders",
+  description:
+    "Every Bags launch on VibeTalent, matched to the builder behind it. See who launched a token, how many they have shipped, and the vibe score their GitHub-verified building record earned them.",
+  alternates: { canonical: `${siteUrl}/bags` },
+  openGraph: {
+    title: "Bags Builders: Verified Token Launches by Vibe Coders",
+    description:
+      "Who is actually behind these token launches? Bags launches matched to GitHub-verified builders and their vibe scores.",
+    url: `${siteUrl}/bags`,
+    siteName: "VibeTalent",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Bags Builders: Verified Token Launches by Vibe Coders",
+    description:
+      "Who is actually behind these token launches? Bags launches matched to GitHub-verified builders and their vibe scores.",
+  },
+};
+
+// The board only changes when the daily bags-sync cron writes to the table, so
+// an hour of staleness costs nothing and keeps this page off the ISR treadmill.
+export const revalidate = 3600;
+
+/**
+ * Guard against an unbounded scan as the table grows. Far above the current row
+ * count; when the board approaches it, this page needs pagination rather than a
+ * bigger number.
+ */
+const MAX_LAUNCHES = 500;
+
+const BUILDER_FIELDS =
+  "id, username, display_name, avatar_url, github_username, vibe_score, streak";
+
+/** Cookie-free client: both tables read publicly, and there is no viewer context here. */
+function getPublicClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  );
+}
+
+async function loadBoard() {
+  try {
+    const sb = getPublicClient();
+
+    const { data: launches, error } = await sb
+      .from("bags_launches")
+      .select("token_mint, user_id, royalty_bps, first_seen_at")
+      .order("first_seen_at", { ascending: false })
+      .limit(MAX_LAUNCHES);
+
+    // A missing table (migration not applied in this environment) must not take
+    // the page down: the claim CTA below is useful even with no rows at all.
+    if (error || !launches?.length) return [];
+
+    const rows = launches as BagsLaunchRow[];
+    const userIds = [...new Set(rows.map((r) => r.user_id))];
+
+    const { data: builders } = await sb
+      .from("users")
+      .select(BUILDER_FIELDS)
+      .in("id", userIds);
+
+    return buildBagsBoard(rows, (builders as BagsBuilderRow[] | null) ?? []);
+  } catch {
+    return [];
+  }
+}
+
+/** Bags' own stat treatment: a small dimmed label over a big value. */
+function StatChip({ label, value }: { label: string; value: number }) {
+  return (
+    <div
+      className="rounded-2xl px-5 py-4"
+      style={{
+        backgroundColor: "var(--bags-surface)",
+        border: "1px solid var(--bags-border)",
+      }}
+    >
+      <div className="bags-label text-[10px] font-semibold text-[var(--bags-text-faint)]">
+        {label}
+      </div>
+      <div className="mt-1.5 font-mono text-3xl font-extrabold tracking-[-0.03em] text-[var(--bags-text)]">
+        {value}
+      </div>
+    </div>
+  );
+}
+
+export default async function BagsPage() {
+  const board = await loadBoard();
+  const launchCount = board.reduce((sum, entry) => sum + entry.launchCount, 0);
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@graph": [
+      buildBreadcrumbList([
+        { name: "Home", path: "/" },
+        { name: "Bags Builders", path: "/bags" },
+      ]),
+      {
+        "@type": "ItemList",
+        name: "Bags launches by VibeTalent builders",
+        description:
+          "Builders with a cryptographically linked Solana wallet that Bags confirms as the creator of a token launch, ranked by vibe score.",
+        numberOfItems: board.length,
+        itemListElement: board.slice(0, 25).map((entry, i) => ({
+          "@type": "ListItem",
+          position: i + 1,
+          name: entry.username,
+          url: `${siteUrl}/profile/${entry.username}`,
+        })),
+      },
+    ],
+  };
+
+  return (
+    <div className="bags-theme min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: jsonLdHtml(jsonLd) }}
+      />
+
+      <div className="mx-auto max-w-4xl px-4 py-14 sm:px-6">
+        <header className="mb-10">
+          <div
+            className="mb-5 inline-flex h-14 w-14 items-center justify-center rounded-2xl"
+            style={{ backgroundColor: "var(--bags-green-soft)" }}
+          >
+            <BagSimple
+              weight="fill"
+              size={28}
+              style={{ color: "var(--bags-green)" }}
+            />
+          </div>
+          <h1 className="text-4xl font-bold tracking-[-0.035em] text-[var(--bags-text)] sm:text-5xl">
+            Who&apos;s behind
+            <br />
+            the <span style={{ color: "var(--bags-green)" }}>bags</span>?
+          </h1>
+          <p className="mt-5 max-w-xl text-[15px] leading-relaxed text-[var(--bags-text-muted)]">
+            On Bags, a launch is a wallet and an X handle. Neither tells you
+            whether that person ships anything. These builders linked their
+            launching wallet to a GitHub-verified VibeTalent profile, so every
+            row carries a real shipping record: projects, streaks, and a vibe
+            score earned from work rather than from minting.
+          </p>
+        </header>
+
+        <div className="mb-8 grid grid-cols-2 gap-3 sm:gap-4">
+          <StatChip
+            label={launchCount === 1 ? "verified launch" : "verified launches"}
+            value={launchCount}
+          />
+          <StatChip
+            label={board.length === 1 ? "builder" : "builders"}
+            value={board.length}
+          />
+        </div>
+
+        {board.length > 0 ? (
+          <section aria-labelledby="board-heading">
+            <h2
+              id="board-heading"
+              className="bags-label mb-3 text-[11px] font-semibold text-[var(--bags-text-faint)]"
+            >
+              Ranked by vibe score
+            </h2>
+            <ul className="flex flex-col gap-3">
+              {board.map((entry, i) => (
+                <BoardRow key={entry.username} entry={entry} position={i + 1} />
+              ))}
+            </ul>
+          </section>
+        ) : (
+          <section
+            className="rounded-[20px] p-10 text-center"
+            style={{
+              backgroundColor: "var(--bags-surface)",
+              border: "1px solid var(--bags-border)",
+            }}
+          >
+            <h2 className="text-lg font-bold tracking-[-0.02em] text-[var(--bags-text)]">
+              No verified launches yet
+            </h2>
+            <p className="mx-auto mt-2 max-w-md text-sm text-[var(--bags-text-muted)]">
+              A launch only appears here once its wallet has been
+              signature-linked to a builder profile. Nothing is listed on trust.
+            </p>
+          </section>
+        )}
+
+        <section
+          className="mt-10 rounded-[20px] p-6 sm:p-8"
+          style={{
+            backgroundColor: "var(--bags-surface)",
+            border: "1px solid var(--bags-border)",
+          }}
+        >
+          <div className="flex items-start gap-3">
+            <SealCheck
+              weight="fill"
+              size={22}
+              className="mt-0.5 shrink-0"
+              style={{ color: "var(--bags-green)" }}
+            />
+            <div>
+              <h2 className="text-lg font-bold tracking-[-0.02em] text-[var(--bags-text)]">
+                Launched on Bags? Claim it
+              </h2>
+              <p className="mt-2 max-w-xl text-sm leading-relaxed text-[var(--bags-text-muted)]">
+                Link the wallet you launched from and your tokens show up here
+                and on your profile. Linking takes a signature in your wallet —
+                no transaction, no fee, and no permission to move anything.
+              </p>
+              <Link
+                href="/settings#wallet"
+                className="mt-5 inline-flex items-center rounded-xl px-6 py-3 text-sm font-bold transition-opacity hover:opacity-85"
+                style={{
+                  backgroundColor: "var(--bags-green)",
+                  color: "var(--bags-bg)",
+                }}
+              >
+                link your wallet
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <section className="mt-10">
+          <h2 className="bags-label text-[11px] font-semibold text-[var(--bags-text-faint)]">
+            How a row gets here
+          </h2>
+          <ol className="mt-4 flex flex-col gap-4">
+            {[
+              {
+                title: "The builder proves the wallet.",
+                body: "Linking requires signing a server-issued nonce, so only the keyholder can bind a wallet to a profile.",
+              },
+              {
+                title: "Bags confirms the launch.",
+                body: "Holding fee-share authority over a token is not the same as having launched it, so every mint is checked against the Bags creator record and only confirmed creators count.",
+              },
+              {
+                title: "The score comes from GitHub.",
+                body: "Vibe score is earned from verified projects, commit streaks and endorsements — it is unaffected by anything token-related.",
+              },
+            ].map((step, i) => (
+              <li key={step.title} className="flex gap-3">
+                <span
+                  className="mt-0.5 shrink-0 font-mono text-sm font-bold"
+                  style={{ color: "var(--bags-green)" }}
+                >
+                  {String(i + 1).padStart(2, "0")}
+                </span>
+                <p className="text-sm leading-relaxed text-[var(--bags-text-muted)]">
+                  <strong className="font-bold text-[var(--bags-text)]">
+                    {step.title}
+                  </strong>{" "}
+                  {step.body}
+                </p>
+              </li>
+            ))}
+          </ol>
+          <p className="mt-6 text-xs leading-relaxed text-[var(--bags-text-faint)]">
+            Self-reported X handles are never used to match a launch to a
+            builder. Nothing here is financial advice or an endorsement of any
+            token. VibeTalent is not affiliated with Bags.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -641,3 +641,44 @@ body:has(.chat-page-wrapper) main {
 .ntf-mention:hover {
   text-decoration: underline;
 }
+
+/* Bags takeover theme, scoped to /bags.
+   Bags is a dark, cool-toned product with a pure-lime accent, and VibeTalent is
+   warm greys with orange. Half-adopting either would look like a mistake, so
+   this scope pins Bags' own values and holds them in both site themes: the page
+   is a branded surface, not a themed one. Nothing inside it may read a
+   site palette token, or it would flip colour with the theme toggle and break
+   against this fixed dark canvas. */
+.bags-theme {
+  --bags-bg: #0c1014;
+  --bags-surface: #141a21;
+  --bags-surface-hover: #1b222b;
+  --bags-border: rgba(255, 255, 255, 0.08);
+  --bags-text: #ffffff;
+  --bags-text-muted: rgba(255, 255, 255, 0.56);
+  /* 0.5 is the floor that still clears 4.5:1 on this canvas; Bags runs its own
+     labels dimmer than that, and 10px uppercase text cannot afford it. */
+  --bags-text-faint: rgba(255, 255, 255, 0.5);
+  --bags-green: #00ff00;
+  --bags-green-soft: rgba(0, 255, 0, 0.1);
+
+  background-color: var(--bags-bg);
+  color: var(--bags-text);
+  letter-spacing: -0.011em;
+}
+
+/* Bags sets headings in sentence case; the site uppercases every h1-h3 from an
+   unlayered element rule, which outranks Tailwind's layered `normal-case`
+   utility. Undoing it needs a rule in the same unlayered cascade. */
+.bags-theme h1,
+.bags-theme h2,
+.bags-theme h3 {
+  text-transform: none;
+}
+
+/* Bags' micro-label: the dimmed uppercase caption that sits over a stat or a
+   list. Needs to be a class for the same cascade reason as the rule above. */
+.bags-theme .bags-label {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -67,6 +67,16 @@ This is the existing USDC-based featuring product. The $VIBE-token-based featuri
 - **Creator fee**: The creator receives a fee on $VIBE trades. That fee is reinvested directly into building VibeTalent: shipping new features, covering infrastructure, and growing the platform. Openly disclosed for transparency and not a reason to buy.
 - **Focus**: Utility and shipping, not price action or speculation.
 
+## Bags Builders (verified token launches)
+
+VibeTalent maintains a public trust layer over Bags launches at https://www.vibetalent.work/bags. Bags knows which wallet launched a token; VibeTalent knows which GitHub-verified builder controls that wallet. Joining the two answers a question neither side can answer alone: whether the person behind a launch actually ships software.
+
+- **How a launch is verified**: the builder links their Solana wallet by signing a server-issued nonce (a signature, not a transaction), then every mint that wallet holds fee-share authority over is checked against the Bags creator record. Only mints where Bags confirms the wallet as creator are listed.
+- **What is never used**: self-reported X handles or profile links. A launch is only ever matched to a builder through a cryptographic wallet signature, so nobody can claim another builder's launch.
+- **What each row shows**: the builder's VibeTalent profile, how many tokens they have launched, their vibe score, and their current coding streak. Vibe score is earned from GitHub-verified projects, streaks and endorsements, and is not affected by token activity.
+- **Ranking**: builders are ranked by vibe score, not by number of launches.
+- **Coverage**: opt-in. A builder who has launched on Bags but has not linked their wallet does not appear, so the board is a lower bound on Bags activity by VibeTalent builders, never a complete list.
+
 ## 2026 Roadmap Summary
 
 - **Q2 2026**: $VIBE token utility activates. $1 streak protect (burn $VIBE to save a missed-day streak) and $1 project featuring (promote a shipped project on the homepage/explore feed). Token is already live on Solana at FfDYT3WqimMw7itMxw4kYJ26GPG78RfpZmepQCFpBAGS.

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -186,6 +186,19 @@ export default function SettingsPage() {
     }
   }, [user, searchParams]);
 
+  // /bags sends launchers here with #wallet. The browser resolves that hash on
+  // first paint, while this page is still showing its loading state and the
+  // anchor does not exist yet, so the jump is silently dropped and the visitor
+  // lands at the top of a long settings page. Redo it once the form is mounted.
+  useEffect(() => {
+    if (!user) return;
+    if (window.location.hash !== "#wallet") return;
+    const timer = setTimeout(() => {
+      document.getElementById("wallet")?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 120);
+    return () => clearTimeout(timer);
+  }, [user]);
+
   const handleAvatarUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file || !user) return;

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -614,8 +614,8 @@ export default function SettingsPage() {
         <PrivacyPreferences />
       </div>
 
-      {/* $VIBE wallet */}
-      <div className="mb-8 p-6 rounded-2xl" style={{ backgroundColor: "var(--bg-surface)", border: "1px solid var(--border-subtle)" }}>
+      {/* $VIBE wallet. Anchored: /bags links here to convert a Bags launcher. */}
+      <div id="wallet" className="mb-8 p-6 rounded-2xl scroll-mt-24" style={{ backgroundColor: "var(--bg-surface)", border: "1px solid var(--border-subtle)" }}>
         <h2 className="text-lg font-bold text-[var(--foreground)] mb-1">$VIBE Wallet</h2>
         <p className="text-xs mb-4" style={{ color: "var(--text-muted)" }}>
           Link a Solana wallet to earn extra free streak freezes for holding $VIBE.

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -102,6 +102,16 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         lastModified: new Date(user.created_at),
       }));
 
+    // Supabase returns data: null on a query error, so an unlogged failure here
+    // would look identical to "nobody has launched" and quietly drop every
+    // /bags URL from the sitemap.
+    if (bagsLaunchesResult.error) {
+      console.error(
+        "[sitemap] bags_launches query failed:",
+        bagsLaunchesResult.error,
+      );
+    }
+
     // Newest verification per builder, so <lastmod> moves when the daily sync
     // reconfirms a launch rather than sitting at whenever the profile was made.
     const lastVerifiedByUser = new Map<string, string>();

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -21,6 +21,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${siteUrl}/about`, lastModified: new Date("2026-04-06") },
     { url: `${siteUrl}/roadmap`, lastModified: new Date("2026-04-23") },
     { url: `${siteUrl}/token`, lastModified: new Date("2026-08-11") },
+    { url: `${siteUrl}/bags`, lastModified: new Date("2026-08-22") },
     { url: `${siteUrl}/privacy`, lastModified: new Date("2026-04-06") },
     { url: `${siteUrl}/terms`, lastModified: new Date("2026-04-06") },
     { url: `${siteUrl}/glossary`, lastModified: new Date("2026-05-22") },
@@ -51,13 +52,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     // site-wide quality signals and gives Google ~empty pages to crawl.
     // Streak-or-project (not just GitHub linked) catches builders who
     // imported projects manually or whose GitHub connect didn't land.
-    const [usersResult, projectUserIdsResult] = await Promise.all([
-      supabase
-        .from("users")
-        .select("id, username, created_at, longest_streak")
-        .not("username", "is", null),
-      supabase.from("projects").select("user_id"),
-    ]);
+    const [usersResult, projectUserIdsResult, bagsLaunchesResult] =
+      await Promise.all([
+        supabase
+          .from("users")
+          .select("id, username, created_at, longest_streak")
+          .not("username", "is", null),
+        supabase.from("projects").select("user_id"),
+        // Builders with a verified Bags launch each get a /bags page. Their
+        // errors are not fatal here: a missing table or a bad minute upstream
+        // should cost those few URLs, not the whole sitemap.
+        supabase.from("bags_launches").select("user_id, last_verified_at"),
+      ]);
 
     if (usersResult.error) {
       console.error("[sitemap] users query failed:", usersResult.error);
@@ -96,7 +102,29 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         lastModified: new Date(user.created_at),
       }));
 
-    return [...staticPages, ...profilePages];
+    // Newest verification per builder, so <lastmod> moves when the daily sync
+    // reconfirms a launch rather than sitting at whenever the profile was made.
+    const lastVerifiedByUser = new Map<string, string>();
+    for (const row of (bagsLaunchesResult.data ?? []) as {
+      user_id: string;
+      last_verified_at: string;
+    }[]) {
+      const seen = lastVerifiedByUser.get(row.user_id);
+      if (!seen || row.last_verified_at > seen) {
+        lastVerifiedByUser.set(row.user_id, row.last_verified_at);
+      }
+    }
+
+    const bagsPages: MetadataRoute.Sitemap = (
+      (usersResult.data ?? []) as SitemapUser[]
+    )
+      .filter((u) => lastVerifiedByUser.has(u.id))
+      .map((user) => ({
+        url: `${siteUrl}/bags/${user.username.trim()}`,
+        lastModified: new Date(lastVerifiedByUser.get(user.id)!),
+      }));
+
+    return [...staticPages, ...profilePages, ...bagsPages];
   } catch (error) {
     // Last-resort fallback. The previous `catch {}` swallowed errors with
     // no signal — a column rename or env-var misconfig delisted every

--- a/src/components/bags/bags-builder-row.tsx
+++ b/src/components/bags/bags-builder-row.tsx
@@ -1,0 +1,141 @@
+import Link from "next/link";
+import Image from "next/image";
+import {
+  ArrowUpRight,
+  GithubLogo,
+  Flame,
+} from "@phosphor-icons/react/dist/ssr";
+
+import { shortMint, type BagsBoardEntry } from "@/lib/bags-board";
+
+/**
+ * One builder on the /bags board, in Bags' visual language: a dark rounded
+ * card, hairline border, lime reserved for the one number that matters.
+ *
+ * Colours come from the .bags-theme scope rather than the site palette, because
+ * this card sits on a canvas that stays dark in both site themes.
+ *
+ * The name opens this builder's launch detail rather than their VibeTalent
+ * profile: someone scanning this board is asking what a person launched, and
+ * the detail page links on to the profile for the rest.
+ *
+ * Deliberately not a single wrapping link: the card carries both that link and
+ * one outbound link per mint, and nesting anchors is invalid markup that screen
+ * readers announce as a single ambiguous target.
+ */
+export function BagsBuilderRow({
+  entry,
+  position,
+}: {
+  entry: BagsBoardEntry;
+  position: number;
+}) {
+  return (
+    <li
+      className="rounded-[20px] p-4 transition-colors hover:bg-[var(--bags-surface-hover)] sm:p-5"
+      style={{
+        backgroundColor: "var(--bags-surface)",
+        border: "1px solid var(--bags-border)",
+      }}
+    >
+      <div className="flex items-center gap-3 sm:gap-4">
+        <span className="w-6 shrink-0 font-mono text-sm font-bold text-[var(--bags-text-faint)]">
+          {String(position).padStart(2, "0")}
+        </span>
+
+        <Link
+          href={`/bags/${entry.username}`}
+          className="shrink-0"
+          tabIndex={-1}
+          aria-hidden="true"
+        >
+          {entry.avatarUrl ? (
+            <Image
+              src={entry.avatarUrl}
+              alt=""
+              width={44}
+              height={44}
+              className="h-11 w-11 rounded-full object-cover"
+              style={{ border: "1px solid var(--bags-border)" }}
+            />
+          ) : (
+            <div
+              className="flex h-11 w-11 items-center justify-center rounded-full text-base font-bold text-[var(--bags-bg)]"
+              style={{ backgroundColor: "var(--bags-green)" }}
+            >
+              {entry.username[0]?.toUpperCase()}
+            </div>
+          )}
+        </Link>
+
+        <div className="min-w-0 flex-1">
+          <Link
+            href={`/bags/${entry.username}`}
+            className="truncate text-[16px] font-bold tracking-[-0.02em] text-[var(--bags-text)] hover:text-[var(--bags-green)]"
+          >
+            @{entry.username}
+          </Link>
+          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[12px] text-[var(--bags-text-muted)]">
+            {entry.githubUsername ? (
+              <span className="inline-flex items-center gap-1">
+                <GithubLogo size={12} weight="fill" />
+                {entry.githubUsername}
+              </span>
+            ) : null}
+            {entry.streak > 0 ? (
+              <span className="inline-flex items-center gap-1">
+                <Flame size={12} weight="fill" />
+                {entry.streak}-day streak
+              </span>
+            ) : null}
+            {/* Below sm the launch column is hidden, so the count lives here instead. */}
+            <span className="sm:hidden">
+              {entry.launchCount}{" "}
+              {entry.launchCount === 1 ? "launch" : "launches"}
+            </span>
+          </div>
+        </div>
+
+        {/* Five columns do not fit a phone; the count moves into the meta line there. */}
+        <div className="hidden shrink-0 text-right sm:block">
+          <div className="font-mono text-xl font-extrabold leading-none text-[var(--bags-text)]">
+            {entry.launchCount}
+          </div>
+          <div className="bags-label mt-1.5 text-[10px] font-semibold text-[var(--bags-text-faint)]">
+            {entry.launchCount === 1 ? "launch" : "launches"}
+          </div>
+        </div>
+
+        <div className="w-[76px] shrink-0 text-right">
+          <div
+            className="font-mono text-xl font-extrabold leading-none"
+            style={{ color: "var(--bags-green)" }}
+          >
+            {entry.vibeScore}
+          </div>
+          <div className="bags-label mt-1.5 text-[10px] font-semibold text-[var(--bags-text-faint)]">
+            vibe score
+          </div>
+        </div>
+      </div>
+
+      <ul className="mt-3 flex flex-wrap gap-2 pl-9 sm:pl-[52px]">
+        {entry.mints.map((mint) => (
+          <li key={mint}>
+            <a
+              href={`https://bags.fm/${mint}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={`View ${shortMint(mint)} on Bags (opens in new tab)`}
+              className="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 font-mono text-[11px] font-bold text-[var(--bags-green)] transition-opacity hover:opacity-75"
+              style={{ backgroundColor: "var(--bags-green-soft)" }}
+            >
+              {shortMint(mint)}
+              <ArrowUpRight size={11} weight="bold" />
+            </a>
+          </li>
+        ))}
+      </ul>
+    </li>
+  );
+}

--- a/src/components/bags/builder-trust-card.tsx
+++ b/src/components/bags/builder-trust-card.tsx
@@ -15,7 +15,13 @@ function monthYear(iso: string): string | null {
   const date = new Date(iso);
   return Number.isNaN(date.getTime())
     ? null
-    : date.toLocaleDateString("en-US", { month: "short", year: "numeric" });
+    : // Fixed to UTC: a timestamp just after midnight on the 1st would
+      // otherwise render as the previous month wherever the server sits.
+      date.toLocaleDateString("en-US", {
+        month: "short",
+        year: "numeric",
+        timeZone: "UTC",
+      });
 }
 
 /**

--- a/src/components/bags/builder-trust-card.tsx
+++ b/src/components/bags/builder-trust-card.tsx
@@ -1,0 +1,105 @@
+import { SealCheck, Warning } from "@phosphor-icons/react/dist/ssr";
+
+import type { BuilderTrust } from "@/lib/builder-trust";
+
+export type BuilderTrustCardProps = {
+  trust: BuilderTrust;
+  verifiedProjects: number;
+  lifetimeContributions: number;
+  longestStreak: number;
+  memberSince: string;
+};
+
+/** "Mar 2026" — a join date needs no more precision than the month. */
+function monthYear(iso: string): string | null {
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime())
+    ? null
+    : date.toLocaleDateString("en-US", { month: "short", year: "numeric" });
+}
+
+/**
+ * How much this builder's record is worth, in terms a visitor from Bags can
+ * read without knowing what a vibe score is.
+ *
+ * Always shows the receipts under the headline. The rank is a summary of those
+ * facts, and a summary nobody can check is just an assertion.
+ */
+export function BuilderTrustCard({
+  trust,
+  verifiedProjects,
+  lifetimeContributions,
+  longestStreak,
+  memberSince,
+}: BuilderTrustCardProps) {
+  const since = monthYear(memberSince);
+
+  const receipts = [
+    verifiedProjects > 0
+      ? `${verifiedProjects} verified ${verifiedProjects === 1 ? "project" : "projects"}`
+      : null,
+    lifetimeContributions > 0
+      ? `${lifetimeContributions.toLocaleString("en-US")} commits`
+      : null,
+    longestStreak > 0 ? `${longestStreak}-day best streak` : null,
+    since ? `building since ${since}` : null,
+  ].filter((r): r is string => r !== null);
+
+  return (
+    <section
+      className="mt-6 rounded-[20px] p-5"
+      style={{
+        backgroundColor: "var(--bags-surface)",
+        border: `1px solid ${trust.sufficient ? "var(--bags-border)" : "rgba(255, 200, 0, 0.28)"}`,
+      }}
+      aria-labelledby="trust-heading"
+    >
+      <div className="flex items-start gap-3">
+        {trust.sufficient ? (
+          <SealCheck
+            weight="fill"
+            size={20}
+            className="mt-0.5 shrink-0"
+            style={{ color: "var(--bags-green)" }}
+          />
+        ) : (
+          <Warning
+            weight="fill"
+            size={20}
+            className="mt-0.5 shrink-0"
+            style={{ color: "#ffc800" }}
+          />
+        )}
+
+        <div className="min-w-0">
+          <h2
+            id="trust-heading"
+            className="text-[15px] font-bold tracking-[-0.02em] text-[var(--bags-text)]"
+          >
+            {trust.label}
+          </h2>
+
+          {trust.caveat ? (
+            <p className="mt-1.5 max-w-xl text-[13px] leading-relaxed text-[var(--bags-text-muted)]">
+              {trust.caveat}
+            </p>
+          ) : null}
+
+          {receipts.length > 0 ? (
+            <p className="mt-1.5 text-[13px] leading-relaxed text-[var(--bags-text-muted)]">
+              {receipts.join(" · ")}
+            </p>
+          ) : null}
+
+          {/* The distinction the rest of this page depends on. A builder's
+              record says nothing about how a coin is structured, and a reader
+              who conflates the two is the one this page would have failed. */}
+          <p className="mt-3 text-[11px] leading-relaxed text-[var(--bags-text-faint)]">
+            Measures the builder, not the coin. Token risk is never folded into
+            this.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/bags/token-card.tsx
+++ b/src/components/bags/token-card.tsx
@@ -139,7 +139,8 @@ export function TokenCard({
         />
         <Stat
           label="fee share"
-          value={royaltyBps ? `${royaltyBps / 100}%` : "—"}
+          // 0 bps is a real answer ("this creator takes no fee"), not a missing one.
+          value={royaltyBps != null ? `${royaltyBps / 100}%` : "—"}
         />
       </dl>
 

--- a/src/components/bags/token-card.tsx
+++ b/src/components/bags/token-card.tsx
@@ -1,0 +1,206 @@
+import Image from "next/image";
+import { ArrowUpRight } from "@phosphor-icons/react/dist/ssr";
+
+import { shortMint } from "@/lib/bags-board";
+import { buildSparkline } from "@/lib/sparkline";
+import { formatTokenPrice, formatTokenCount } from "@/lib/token-stats";
+import type { TokenMarket } from "@/lib/token-market";
+
+const CHART_WIDTH = 132;
+const CHART_HEIGHT = 40;
+
+export type TokenCardProps = {
+  mint: string;
+  /** Creator's fee share on this launch, in basis points, as Bags reports it. */
+  royaltyBps: number | null;
+  /** Null when GeckoTerminal has not indexed the token — normal before it trades. */
+  market: TokenMarket | null;
+  /** Daily closes, oldest first. Fewer than two points means no chart. */
+  closes: number[];
+};
+
+/** Compact dollars: $2808.27 -> "$2.81K". */
+function compactUsd(value: number): string {
+  return `$${formatTokenCount(value)}`;
+}
+
+/** One launched coin: what it is, what it is worth, and where it is heading. */
+export function TokenCard({
+  mint,
+  royaltyBps,
+  market,
+  closes,
+}: TokenCardProps) {
+  const spark = buildSparkline(closes, CHART_WIDTH, CHART_HEIGHT);
+  const first = closes[0];
+  const last = closes[closes.length - 1];
+  const changePct =
+    first !== undefined &&
+    last !== undefined &&
+    first !== 0 &&
+    closes.length > 1
+      ? ((last - first) / first) * 100
+      : null;
+  // A falling chart drawn in the "everything is fine" colour is a lie.
+  const trendColor =
+    changePct !== null && changePct < 0 ? "#ff4d4d" : "var(--bags-green)";
+
+  return (
+    <li
+      className="rounded-[20px] p-5"
+      style={{
+        backgroundColor: "var(--bags-surface)",
+        border: "1px solid var(--bags-border)",
+      }}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-3">
+          {market?.imageUrl ? (
+            <Image
+              src={market.imageUrl}
+              alt=""
+              width={44}
+              height={44}
+              className="h-11 w-11 shrink-0 rounded-full object-cover"
+              style={{ border: "1px solid var(--bags-border)" }}
+            />
+          ) : (
+            <div
+              className="h-11 w-11 shrink-0 rounded-full"
+              style={{ backgroundColor: "var(--bags-green-soft)" }}
+            />
+          )}
+          <div className="min-w-0">
+            <div className="truncate text-[16px] font-bold tracking-[-0.02em] text-[var(--bags-text)]">
+              {market?.name ?? "Unindexed launch"}
+            </div>
+            <div className="mt-0.5 truncate font-mono text-[11px] text-[var(--bags-text-muted)]">
+              {market?.symbol ? `$${market.symbol}` : null}
+              {/* An already-shortened mint that then truncates reads as broken,
+                  and phones have no room for both. The mint is one tap away on
+                  the Bags link below. */}
+              <span className="hidden sm:inline">
+                {market?.symbol ? " · " : ""}
+                {shortMint(mint)}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {spark ? (
+          <div className="shrink-0 text-right">
+            <svg
+              width={CHART_WIDTH}
+              height={CHART_HEIGHT}
+              viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+              role="img"
+              aria-label={`Price over the last ${closes.length} days`}
+              className="block"
+            >
+              <path d={spark.area} fill={trendColor} opacity={0.12} />
+              <polyline
+                points={spark.line}
+                fill="none"
+                stroke={trendColor}
+                strokeWidth={1.5}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+            {changePct !== null ? (
+              <div
+                className="mt-1 font-mono text-[11px] font-bold"
+                style={{ color: trendColor }}
+              >
+                {changePct >= 0 ? "+" : ""}
+                {changePct.toFixed(1)}%
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+
+      <dl className="mt-5 grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <Stat
+          label="price"
+          value={
+            market?.priceUsd != null ? formatTokenPrice(market.priceUsd) : "—"
+          }
+        />
+        <Stat
+          label="fdv"
+          value={market?.fdvUsd != null ? compactUsd(market.fdvUsd) : "—"}
+        />
+        <Stat
+          label="24h vol"
+          value={
+            market?.volume24hUsd != null ? compactUsd(market.volume24hUsd) : "—"
+          }
+        />
+        <Stat
+          label="fee share"
+          value={royaltyBps ? `${royaltyBps / 100}%` : "—"}
+        />
+      </dl>
+
+      <div className="mt-5 flex flex-wrap items-center justify-between gap-3">
+        {market && !market.graduated && market.graduationPct !== null ? (
+          <div className="min-w-[180px] flex-1">
+            <div
+              className="h-1.5 w-full overflow-hidden rounded-full"
+              style={{ backgroundColor: "var(--bags-green-soft)" }}
+            >
+              <div
+                className="h-full rounded-full"
+                style={{
+                  width: `${Math.min(Math.max(market.graduationPct, 0), 100)}%`,
+                  backgroundColor: "var(--bags-green)",
+                }}
+              />
+            </div>
+            <p className="mt-2 text-[11px] text-[var(--bags-text-faint)]">
+              {market.graduationPct.toFixed(1)}% of the way to graduating the
+              bonding curve
+            </p>
+          </div>
+        ) : market?.graduated ? (
+          <p className="text-[11px] text-[var(--bags-text-faint)]">
+            Graduated off the bonding curve
+          </p>
+        ) : (
+          <p className="text-[11px] text-[var(--bags-text-faint)]">
+            No market data yet — this launch has not traded.
+          </p>
+        )}
+
+        <a
+          href={`https://bags.fm/${mint}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={`View ${market?.name ?? shortMint(mint)} on Bags (opens in new tab)`}
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-full px-3.5 py-1.5 text-[11px] font-bold transition-opacity hover:opacity-75"
+          style={{
+            backgroundColor: "var(--bags-green-soft)",
+            color: "var(--bags-green)",
+          }}
+        >
+          view on bags
+          <ArrowUpRight size={11} weight="bold" />
+        </a>
+      </div>
+    </li>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="bags-label text-[10px] font-semibold text-[var(--bags-text-faint)]">
+        {label}
+      </dt>
+      <dd className="mt-1 font-mono text-[15px] font-bold text-[var(--bags-text)]">
+        {value}
+      </dd>
+    </div>
+  );
+}

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -32,6 +32,7 @@ export function Footer() {
               <Link href="/dashboard" className="text-sm font-semibold hover:text-[var(--accent)] transition-colors" style={{ color: "var(--text-muted)" }}>Dashboard</Link>
               <Link href="/roadmap" className="text-sm font-semibold hover:text-[var(--accent)] transition-colors" style={{ color: "var(--text-muted)" }}>Roadmap</Link>
               <Link href="/token" className="text-sm font-semibold hover:text-[var(--accent)] transition-colors" style={{ color: "var(--text-muted)" }}>$VIBE Token</Link>
+              <Link href="/bags" className="text-sm font-semibold hover:text-[var(--accent)] transition-colors" style={{ color: "var(--text-muted)" }}>Bags Builders</Link>
               <a href="https://vibe-talent.gitbook.io/untitled" target="_blank" rel="noopener noreferrer" aria-label="Docs (opens in new tab)" className="text-sm font-semibold hover:text-[var(--accent)] transition-colors" style={{ color: "var(--text-muted)" }}>Docs</a>
             </div>
           </div>

--- a/src/lib/__tests__/bags-board.test.ts
+++ b/src/lib/__tests__/bags-board.test.ts
@@ -7,19 +7,25 @@ import {
   type BagsLaunchRow,
 } from "@/lib/bags-board";
 
-function builder(over: Partial<BagsBuilderRow> & { id: string }): BagsBuilderRow {
+function builder(
+  over: Partial<BagsBuilderRow> & { id: string },
+): BagsBuilderRow {
   return {
     username: `u-${over.id}`,
     display_name: null,
     avatar_url: null,
-    github_username: null,
+    // Present by default: the board only carries GitHub-verified builders, so
+    // an unset handle is the exception a test opts into, not the baseline.
+    github_username: `gh-${over.id}`,
     vibe_score: 0,
     streak: 0,
     ...over,
   };
 }
 
-function launch(over: Partial<BagsLaunchRow> & { token_mint: string; user_id: string }): BagsLaunchRow {
+function launch(
+  over: Partial<BagsLaunchRow> & { token_mint: string; user_id: string },
+): BagsLaunchRow {
   return {
     royalty_bps: 0,
     first_seen_at: "2026-08-20T00:00:00Z",
@@ -79,6 +85,26 @@ describe("buildBagsBoard", () => {
     expect(board.map((e) => e.username)).toEqual(["bbb", "aaa", "ccc"]);
   });
 
+  it("drops a builder with no GitHub handle", () => {
+    // The board states in as many words that every builder on it is
+    // GitHub-verified, and linking a wallet does not require GitHub. A row
+    // without a handle would sit under that sentence and make it false.
+    const board = buildBagsBoard(
+      [
+        launch({ token_mint: "unverified", user_id: "no-gh" }),
+        launch({ token_mint: "blank-gh", user_id: "blank" }),
+        launch({ token_mint: "good", user_id: "ok" }),
+      ],
+      [
+        builder({ id: "no-gh", username: "nogh", github_username: null }),
+        builder({ id: "blank", username: "blank", github_username: "   " }),
+        builder({ id: "ok", username: "ok" }),
+      ],
+    );
+
+    expect(board.map((e) => e.username)).toEqual(["ok"]);
+  });
+
   it("drops launches whose builder is missing or has no username", () => {
     const board = buildBagsBoard(
       [
@@ -86,7 +112,10 @@ describe("buildBagsBoard", () => {
         launch({ token_mint: "nameless", user_id: "no-name" }),
         launch({ token_mint: "good", user_id: "ok" }),
       ],
-      [builder({ id: "no-name", username: null }), builder({ id: "ok", username: "ok" })],
+      [
+        builder({ id: "no-name", username: null }),
+        builder({ id: "ok", username: "ok" }),
+      ],
     );
 
     expect(board.map((e) => e.username)).toEqual(["ok"]);
@@ -95,9 +124,21 @@ describe("buildBagsBoard", () => {
   it("orders a builder's mints newest first and reports their earliest launch", () => {
     const board = buildBagsBoard(
       [
-        launch({ token_mint: "older", user_id: "1", first_seen_at: "2026-01-02T00:00:00Z" }),
-        launch({ token_mint: "newest", user_id: "1", first_seen_at: "2026-08-20T00:00:00Z" }),
-        launch({ token_mint: "middle", user_id: "1", first_seen_at: "2026-05-05T00:00:00Z" }),
+        launch({
+          token_mint: "older",
+          user_id: "1",
+          first_seen_at: "2026-01-02T00:00:00Z",
+        }),
+        launch({
+          token_mint: "newest",
+          user_id: "1",
+          first_seen_at: "2026-08-20T00:00:00Z",
+        }),
+        launch({
+          token_mint: "middle",
+          user_id: "1",
+          first_seen_at: "2026-05-05T00:00:00Z",
+        }),
       ],
       [builder({ id: "1" })],
     );
@@ -122,7 +163,9 @@ describe("buildBagsBoard", () => {
 
 describe("shortMint", () => {
   it("keeps both recognisable ends of a mint", () => {
-    expect(shortMint("FfDYT3WqimMw7itMxw4kYJ26GPG78RfpZmepQCFpBAGS")).toBe("FfDYT3…BAGS");
+    expect(shortMint("FfDYT3WqimMw7itMxw4kYJ26GPG78RfpZmepQCFpBAGS")).toBe(
+      "FfDYT3…BAGS",
+    );
   });
 
   it("leaves an already-short value alone", () => {

--- a/src/lib/__tests__/bags-board.test.ts
+++ b/src/lib/__tests__/bags-board.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  buildBagsBoard,
+  shortMint,
+  type BagsBuilderRow,
+  type BagsLaunchRow,
+} from "@/lib/bags-board";
+
+function builder(over: Partial<BagsBuilderRow> & { id: string }): BagsBuilderRow {
+  return {
+    username: `u-${over.id}`,
+    display_name: null,
+    avatar_url: null,
+    github_username: null,
+    vibe_score: 0,
+    streak: 0,
+    ...over,
+  };
+}
+
+function launch(over: Partial<BagsLaunchRow> & { token_mint: string; user_id: string }): BagsLaunchRow {
+  return {
+    royalty_bps: 0,
+    first_seen_at: "2026-08-20T00:00:00Z",
+    ...over,
+  };
+}
+
+describe("buildBagsBoard", () => {
+  it("groups launches under their builder and counts them", () => {
+    const board = buildBagsBoard(
+      [
+        launch({ token_mint: "mintA", user_id: "1" }),
+        launch({ token_mint: "mintB", user_id: "1" }),
+        launch({ token_mint: "mintC", user_id: "2" }),
+      ],
+      [builder({ id: "1" }), builder({ id: "2" })],
+    );
+
+    expect(board).toHaveLength(2);
+    expect(board.find((e) => e.username === "u-1")?.launchCount).toBe(2);
+    expect(board.find((e) => e.username === "u-2")?.launchCount).toBe(1);
+  });
+
+  it("ranks by vibe score, not by launch count", () => {
+    // The builder with more launches must not outrank the one who ships more:
+    // minting is cheap, and rewarding it is the failure mode of this board.
+    const board = buildBagsBoard(
+      [
+        launch({ token_mint: "mintA", user_id: "prolific" }),
+        launch({ token_mint: "mintB", user_id: "prolific" }),
+        launch({ token_mint: "mintC", user_id: "builder" }),
+      ],
+      [
+        builder({ id: "prolific", username: "prolific", vibe_score: 10 }),
+        builder({ id: "builder", username: "builder", vibe_score: 900 }),
+      ],
+    );
+
+    expect(board.map((e) => e.username)).toEqual(["builder", "prolific"]);
+  });
+
+  it("breaks a vibe-score tie on launch count, then on username", () => {
+    const board = buildBagsBoard(
+      [
+        launch({ token_mint: "m1", user_id: "a" }),
+        launch({ token_mint: "m2", user_id: "b" }),
+        launch({ token_mint: "m3", user_id: "b" }),
+        launch({ token_mint: "m4", user_id: "c" }),
+      ],
+      [
+        builder({ id: "a", username: "aaa", vibe_score: 100 }),
+        builder({ id: "b", username: "bbb", vibe_score: 100 }),
+        builder({ id: "c", username: "ccc", vibe_score: 100 }),
+      ],
+    );
+
+    expect(board.map((e) => e.username)).toEqual(["bbb", "aaa", "ccc"]);
+  });
+
+  it("drops launches whose builder is missing or has no username", () => {
+    const board = buildBagsBoard(
+      [
+        launch({ token_mint: "orphan", user_id: "gone" }),
+        launch({ token_mint: "nameless", user_id: "no-name" }),
+        launch({ token_mint: "good", user_id: "ok" }),
+      ],
+      [builder({ id: "no-name", username: null }), builder({ id: "ok", username: "ok" })],
+    );
+
+    expect(board.map((e) => e.username)).toEqual(["ok"]);
+  });
+
+  it("orders a builder's mints newest first and reports their earliest launch", () => {
+    const board = buildBagsBoard(
+      [
+        launch({ token_mint: "older", user_id: "1", first_seen_at: "2026-01-02T00:00:00Z" }),
+        launch({ token_mint: "newest", user_id: "1", first_seen_at: "2026-08-20T00:00:00Z" }),
+        launch({ token_mint: "middle", user_id: "1", first_seen_at: "2026-05-05T00:00:00Z" }),
+      ],
+      [builder({ id: "1" })],
+    );
+
+    expect(board[0]!.mints).toEqual(["newest", "middle", "older"]);
+    expect(board[0]!.firstLaunchAt).toBe("2026-01-02T00:00:00Z");
+  });
+
+  it("treats a null vibe score or streak as zero rather than dropping the row", () => {
+    const board = buildBagsBoard(
+      [launch({ token_mint: "m", user_id: "1" })],
+      [builder({ id: "1", vibe_score: null, streak: null })],
+    );
+
+    expect(board[0]).toMatchObject({ vibeScore: 0, streak: 0 });
+  });
+
+  it("returns an empty board when nobody has launched", () => {
+    expect(buildBagsBoard([], [builder({ id: "1" })])).toEqual([]);
+  });
+});
+
+describe("shortMint", () => {
+  it("keeps both recognisable ends of a mint", () => {
+    expect(shortMint("FfDYT3WqimMw7itMxw4kYJ26GPG78RfpZmepQCFpBAGS")).toBe("FfDYT3…BAGS");
+  });
+
+  it("leaves an already-short value alone", () => {
+    expect(shortMint("SHORT")).toBe("SHORT");
+  });
+});

--- a/src/lib/__tests__/bags.test.ts
+++ b/src/lib/__tests__/bags.test.ts
@@ -4,12 +4,16 @@ import {
   bagsConfigured,
   fetchLaunchesForWallet,
   fetchCreatedLaunches,
+  fetchCreatorProfile,
 } from "@/lib/bags";
 
 const WALLET = "DYp2cUmgoBEYPxN9xPwiqKZoi5WR4SRAWJnLD1d5QAdT";
 const MINT = "FfDYT3WqimMw7itMxw4kYJ26GPG78RfpZmepQCFpBAGS";
 
-function mockFetch(body: unknown, init: { ok?: boolean; status?: number } = {}) {
+function mockFetch(
+  body: unknown,
+  init: { ok?: boolean; status?: number } = {},
+) {
   const fn = vi.fn().mockResolvedValue({
     ok: init.ok ?? true,
     status: init.status ?? 200,
@@ -118,7 +122,10 @@ describe("fetchLaunchesForWallet", () => {
 
   it("drops entries that are not plausible mints", async () => {
     vi.stubEnv("BAGS_API_KEY", "k");
-    mockFetch({ success: true, response: { tokenMints: [MINT, "", null, 42, "short"] } });
+    mockFetch({
+      success: true,
+      response: { tokenMints: [MINT, "", null, 42, "short"] },
+    });
     expect(await fetchLaunchesForWallet(WALLET)).toEqual([MINT]);
   });
 
@@ -154,15 +161,20 @@ describe("fetchCreatedLaunches", () => {
   });
 
   /** Route each URL to a canned payload so one test can span both endpoints. */
-  function routeFetch(routes: { admin: unknown; creators: Record<string, unknown> }) {
+  function routeFetch(routes: {
+    admin: unknown;
+    creators: Record<string, unknown>;
+  }) {
     const fn = vi.fn().mockImplementation((input: URL | string) => {
       const url = String(input);
       const body = url.includes("/fee-share/admin/list")
         ? routes.admin
-        : routes.creators[new URL(url).searchParams.get("tokenMint") ?? ""] ?? {
+        : (routes.creators[
+            new URL(url).searchParams.get("tokenMint") ?? ""
+          ] ?? {
             success: true,
             response: [],
-          };
+          });
       return Promise.resolve({ ok: true, status: 200, json: async () => body });
     });
     vi.stubGlobal("fetch", fn);
@@ -172,13 +184,21 @@ describe("fetchCreatedLaunches", () => {
   it("keeps only mints where this wallet is a confirmed creator", async () => {
     vi.stubEnv("BAGS_API_KEY", "k");
     routeFetch({
-      admin: { success: true, response: { tokenMints: [MINT_EMPTY, MINT_REAL] } },
+      admin: {
+        success: true,
+        response: { tokenMints: [MINT_EMPTY, MINT_REAL] },
+      },
       creators: {
         [MINT_EMPTY]: { success: true, response: [] },
         [MINT_REAL]: {
           success: true,
           response: [
-            { wallet: WALLET_A, isCreator: true, twitterUsername: "abhiontwt", royaltyBps: 8000 },
+            {
+              wallet: WALLET_A,
+              isCreator: true,
+              twitterUsername: "abhiontwt",
+              royaltyBps: 8000,
+            },
           ],
         },
       },
@@ -212,7 +232,11 @@ describe("fetchCreatedLaunches", () => {
       creators: {
         [MINT_REAL]: {
           success: true,
-          response: [{ wallet: "SomeOtherWalletEntirely1111111111111111111", isCreator: true },
+          response: [
+            {
+              wallet: "SomeOtherWalletEntirely1111111111111111111",
+              isCreator: true,
+            },
           ],
         },
       },
@@ -226,8 +250,12 @@ describe("fetchCreatedLaunches", () => {
       const url = String(input);
       if (url.includes("/fee-share/admin/list")) {
         return Promise.resolve({
-          ok: true, status: 200,
-          json: async () => ({ success: true, response: { tokenMints: [MINT_REAL] } }),
+          ok: true,
+          status: 200,
+          json: async () => ({
+            success: true,
+            response: { tokenMints: [MINT_REAL] },
+          }),
         });
       }
       return Promise.reject(new Error("network"));
@@ -244,7 +272,10 @@ describe("fetchCreatedLaunches", () => {
 
   it("returns [] without a second call when the wallet has no candidates", async () => {
     vi.stubEnv("BAGS_API_KEY", "k");
-    const fn = routeFetch({ admin: { success: true, response: { tokenMints: [] } }, creators: {} });
+    const fn = routeFetch({
+      admin: { success: true, response: { tokenMints: [] } },
+      creators: {},
+    });
     expect(await fetchCreatedLaunches(WALLET_A)).toEqual([]);
     expect(fn).toHaveBeenCalledTimes(1);
   });
@@ -254,11 +285,93 @@ describe("fetchCreatedLaunches", () => {
     routeFetch({
       admin: { success: true, response: { tokenMints: [MINT_REAL] } },
       creators: {
-        [MINT_REAL]: { success: true, response: [{ wallet: WALLET_A, isCreator: true }] },
+        [MINT_REAL]: {
+          success: true,
+          response: [{ wallet: WALLET_A, isCreator: true }],
+        },
       },
     });
     expect(await fetchCreatedLaunches(WALLET_A)).toEqual([
       { tokenMint: MINT_REAL, twitterUsername: null, royaltyBps: 0 },
     ]);
+  });
+});
+
+describe("fetchCreatorProfile", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("returns the Bags-side identity for the creating wallet", async () => {
+    vi.stubEnv("BAGS_API_KEY", "test-key");
+    mockFetch({
+      success: true,
+      response: [
+        {
+          wallet: WALLET,
+          isCreator: true,
+          bagsUsername: "defiunknownking",
+          twitterUsername: "abhiontwt",
+          pfp: "https://pbs.twimg.com/profile_images/abc.jpg",
+          royaltyBps: 8000,
+        },
+      ],
+    });
+
+    expect(await fetchCreatorProfile(MINT, WALLET)).toEqual({
+      bagsUsername: "defiunknownking",
+      twitterUsername: "abhiontwt",
+      pfpUrl: "https://pbs.twimg.com/profile_images/abc.jpg",
+      royaltyBps: 8000,
+    });
+  });
+
+  it("ignores fee-share recipients who did not create the token", async () => {
+    // Bags lists every fee recipient on a launch. Reading identity off the wrong
+    // one would print a stranger's handle under a builder's launch.
+    vi.stubEnv("BAGS_API_KEY", "test-key");
+    mockFetch({
+      success: true,
+      response: [
+        {
+          wallet: "OtherWallet1111111111111111111111111111111",
+          isCreator: true,
+          bagsUsername: "someoneelse",
+        },
+        { wallet: WALLET, isCreator: false, bagsUsername: "notthecreator" },
+      ],
+    });
+
+    expect(await fetchCreatorProfile(MINT, WALLET)).toBeNull();
+  });
+
+  it("blanks out empty strings rather than rendering them", async () => {
+    vi.stubEnv("BAGS_API_KEY", "test-key");
+    mockFetch({
+      success: true,
+      response: [
+        {
+          wallet: WALLET,
+          isCreator: true,
+          bagsUsername: "   ",
+          twitterUsername: "",
+        },
+      ],
+    });
+
+    expect(await fetchCreatorProfile(MINT, WALLET)).toEqual({
+      bagsUsername: null,
+      twitterUsername: null,
+      pfpUrl: null,
+      royaltyBps: 0,
+    });
+  });
+
+  it("returns null when Bags cannot answer", async () => {
+    vi.stubEnv("BAGS_API_KEY", "test-key");
+    mockFetch({ success: false }, { ok: false, status: 500 });
+    expect(await fetchCreatorProfile(MINT, WALLET)).toBeNull();
   });
 });

--- a/src/lib/__tests__/builder-trust.test.ts
+++ b/src/lib/__tests__/builder-trust.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  assessBuilderTrust,
+  hasVerifiableRecord,
+  percentileOf,
+  rankedCohort,
+  type BuilderTrustInput,
+} from "@/lib/builder-trust";
+
+function builder(over: Partial<BuilderTrustInput> = {}): BuilderTrustInput {
+  return {
+    vibeScore: 100,
+    verifiedProjects: 1,
+    lifetimeContributions: 200,
+    longestStreak: 10,
+    ...over,
+  };
+}
+
+describe("rankedCohort", () => {
+  it("drops accounts sitting on the untouched baseline", () => {
+    // Signed-up-and-left rows would otherwise push every active builder into
+    // the top decile.
+    expect(rankedCohort([10, 10, 47, 265, 5])).toEqual([47, 265]);
+  });
+});
+
+describe("percentileOf", () => {
+  it("measures the share of the cohort scoring strictly below", () => {
+    expect(percentileOf(50, [10, 20, 30, 40])).toBe(100);
+    expect(percentileOf(25, [10, 20, 30, 40])).toBe(50);
+    expect(percentileOf(5, [10, 20, 30, 40])).toBe(0);
+  });
+
+  it("does not credit a builder for the peers they merely tied", () => {
+    expect(percentileOf(20, [20, 20, 20, 20])).toBe(0);
+  });
+
+  it("has nothing to measure against an empty cohort", () => {
+    expect(percentileOf(100, [])).toBeNull();
+  });
+});
+
+describe("hasVerifiableRecord", () => {
+  it("accepts a verified project", () => {
+    expect(
+      hasVerifiableRecord(
+        builder({ verifiedProjects: 1, lifetimeContributions: 0 }),
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts attributed commits", () => {
+    expect(
+      hasVerifiableRecord(
+        builder({ verifiedProjects: 0, lifetimeContributions: 5 }),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a record that is only a streak", () => {
+    // Production case: a 115-day streak with no verified project and no
+    // attributed commits. Ranking that in the top decile next to a token
+    // launch would vouch for something nobody outside our database can check.
+    expect(
+      hasVerifiableRecord(
+        builder({
+          verifiedProjects: 0,
+          lifetimeContributions: 0,
+          longestStreak: 115,
+        }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("assessBuilderTrust", () => {
+  const cohort = [20, 40, 60, 80, 100, 200, 265, 280, 630];
+
+  it("ranks a builder with a verifiable record", () => {
+    const trust = assessBuilderTrust(builder({ vibeScore: 265 }), cohort);
+    expect(trust.sufficient).toBe(true);
+    expect(trust.percentile).toBe(67);
+    expect(trust.label).toBe("Top 33% of builders");
+    expect(trust.caveat).toBeNull();
+  });
+
+  it("withholds the rank when the record is only a streak, and says why", () => {
+    const trust = assessBuilderTrust(
+      builder({
+        vibeScore: 280,
+        verifiedProjects: 0,
+        lifetimeContributions: 0,
+        longestStreak: 115,
+      }),
+      cohort,
+    );
+
+    // The highest score in this set, and still unranked: score alone is not
+    // evidence when none of it came from outside the platform.
+    expect(trust.percentile).toBeNull();
+    expect(trust.sufficient).toBe(false);
+    expect(trust.label).toBe("Limited public record");
+    expect(trust.caveat).toContain("no GitHub-verified project");
+  });
+
+  it("does not claim a top percentage for a below-median builder", () => {
+    const trust = assessBuilderTrust(builder({ vibeScore: 30 }), cohort);
+    expect(trust.sufficient).toBe(true);
+    expect(trust.label).toBe("Ranked builder");
+  });
+
+  it("never advertises 'top 0%'", () => {
+    const trust = assessBuilderTrust(builder({ vibeScore: 10_000 }), cohort);
+    expect(trust.percentile).toBe(100);
+    expect(trust.label).toBe("Top 1% of builders");
+  });
+
+  it("reports honestly when there is no cohort to compare against", () => {
+    const trust = assessBuilderTrust(builder(), []);
+    expect(trust.percentile).toBeNull();
+    expect(trust.label).toBe("Unranked");
+  });
+});

--- a/src/lib/__tests__/sparkline.test.ts
+++ b/src/lib/__tests__/sparkline.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+
+import { buildSparkline } from "@/lib/sparkline";
+
+describe("buildSparkline", () => {
+  it("returns null below two points", () => {
+    expect(buildSparkline([], 100, 40)).toBeNull();
+    expect(buildSparkline([1], 100, 40)).toBeNull();
+  });
+
+  it("spreads points evenly across the width", () => {
+    const shape = buildSparkline([1, 2, 3], 100, 40)!;
+    const xs = shape.line.split(" ").map((p) => Number(p.split(",")[0]));
+    expect(xs).toEqual([0, 50, 100]);
+  });
+
+  it("puts the highest value at the top and the lowest at the bottom", () => {
+    const shape = buildSparkline([1, 5], 100, 40, 2)!;
+    const ys = shape.line.split(" ").map((p) => Number(p.split(",")[1]));
+    // First point is the low, so it sits lower down the SVG than the high.
+    expect(ys[0]).toBeGreaterThan(ys[1]!);
+    expect(ys[1]).toBeCloseTo(2, 5); // top, inset by the padding
+    expect(ys[0]).toBeCloseTo(38, 5); // bottom, inset by the padding
+  });
+
+  it("draws a flat series down the middle, not along the floor", () => {
+    const shape = buildSparkline([7, 7, 7], 100, 40)!;
+    const ys = shape.line.split(" ").map((p) => Number(p.split(",")[1]));
+    for (const y of ys) expect(y).toBeCloseTo(20, 5);
+  });
+
+  it("closes the area path along the bottom edge", () => {
+    const shape = buildSparkline([1, 2], 100, 40)!;
+    expect(shape.area.startsWith("M0,40 L")).toBe(true);
+    expect(shape.area.endsWith("L100,40 Z")).toBe(true);
+  });
+
+  it("survives a series with an extreme outlier", () => {
+    const shape = buildSparkline([0.000001, 0.4, 0.000002], 120, 40)!;
+    const ys = shape.line.split(" ").map((p) => Number(p.split(",")[1]));
+    expect(ys.every((y) => y >= 0 && y <= 40)).toBe(true);
+  });
+});

--- a/src/lib/__tests__/token-market.test.ts
+++ b/src/lib/__tests__/token-market.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+import {
+  fetchTokenMarket,
+  fetchDailyCloses,
+  changePct,
+} from "@/lib/token-market";
+
+const MINT = "FfDYT3WqimMw7itMxw4kYJ26GPG78RfpZmepQCFpBAGS";
+const POOL = "2tFgxKjVjppSLp2bQR9YJpLZW5zc5qaFdsEtzwcyjuF2";
+
+function mockFetch(
+  body: unknown,
+  init: { ok?: boolean; status?: number } = {},
+) {
+  const fn = vi.fn().mockResolvedValue({
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    json: async () => body,
+  });
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+const TOKEN_BODY = {
+  data: {
+    attributes: {
+      name: "VIBE TALENT",
+      symbol: "VIBE",
+      image_url: "https://assets.geckoterminal.com/abc",
+      price_usd: "0.000002808278971",
+      fdv_usd: "2808.2789708513",
+      volume_usd: { h24: "12.5" },
+      launchpad_details: { graduation_percentage: 2.04, completed: false },
+    },
+    relationships: {
+      top_pools: { data: [{ id: `solana_${POOL}`, type: "pool" }] },
+    },
+  },
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("fetchTokenMarket", () => {
+  it("maps GeckoTerminal's string numerics onto real numbers", async () => {
+    mockFetch(TOKEN_BODY);
+    const market = await fetchTokenMarket(MINT);
+
+    expect(market).toMatchObject({
+      mint: MINT,
+      name: "VIBE TALENT",
+      symbol: "VIBE",
+      priceUsd: 0.000002808278971,
+      fdvUsd: 2808.2789708513,
+      volume24hUsd: 12.5,
+      graduationPct: 2.04,
+      graduated: false,
+    });
+  });
+
+  it("strips the network prefix off the pool id", async () => {
+    mockFetch(TOKEN_BODY);
+    const market = await fetchTokenMarket(MINT);
+    expect(market?.poolAddress).toBe(POOL);
+  });
+
+  it("returns null when the token is not indexed", async () => {
+    mockFetch({ errors: [{ status: "404" }] }, { ok: false, status: 404 });
+    expect(await fetchTokenMarket(MINT)).toBeNull();
+  });
+
+  it("returns null rather than throwing when the request fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("network down")),
+    );
+    expect(await fetchTokenMarket(MINT)).toBeNull();
+  });
+
+  it("survives a payload with no launchpad or pool data", async () => {
+    mockFetch({ data: { attributes: { name: "Bare", symbol: "BARE" } } });
+    const market = await fetchTokenMarket(MINT);
+    expect(market).toMatchObject({
+      name: "Bare",
+      priceUsd: null,
+      graduationPct: null,
+      graduated: false,
+      poolAddress: null,
+    });
+  });
+});
+
+describe("fetchDailyCloses", () => {
+  it("returns closes oldest first", async () => {
+    // GeckoTerminal sends newest first.
+    mockFetch({
+      data: {
+        attributes: {
+          ohlcv_list: [
+            [1787270400, 2, 3, 1, 3, 9],
+            [1787184000, 1, 2, 1, 2, 4],
+            [1787097600, 1, 1, 1, 1, 1],
+          ],
+        },
+      },
+    });
+
+    expect(await fetchDailyCloses(POOL)).toEqual([1, 2, 3]);
+  });
+
+  it("skips malformed candles instead of dropping the series", async () => {
+    mockFetch({
+      data: {
+        attributes: {
+          ohlcv_list: [[1, 1, 1, 1, 5, 1], "junk", [2, 1, 1, 1, null, 1]],
+        },
+      },
+    });
+    expect(await fetchDailyCloses(POOL)).toEqual([5]);
+  });
+
+  it("returns an empty series when the pool has no candles", async () => {
+    mockFetch({ data: { attributes: {} } });
+    expect(await fetchDailyCloses(POOL)).toEqual([]);
+  });
+});
+
+describe("changePct", () => {
+  it("measures first close against last", () => {
+    expect(changePct([2, 4])).toBe(100);
+    expect(changePct([4, 2])).toBe(-50);
+  });
+
+  it("has nothing to report on a single point", () => {
+    expect(changePct([1])).toBeNull();
+  });
+
+  it("refuses to divide by a zero open", () => {
+    expect(changePct([0, 5])).toBeNull();
+  });
+});

--- a/src/lib/bags-board.ts
+++ b/src/lib/bags-board.ts
@@ -1,0 +1,104 @@
+// Aggregation for the /bags board: verified Bags launches, grouped per builder.
+//
+// Split out from the page so the ranking rule is unit-testable without a
+// database. The rule is the opinionated part of this feature: the board exists
+// to answer "which of these token launchers actually builds", so it ranks on
+// vibe score — VibeTalent's side of the join — and shows launch count as
+// supporting evidence rather than as the ranking itself. Ranking by launch
+// count would reward minting, which is the one behaviour this page must not
+// flatter.
+
+/** A cached row from public.bags_launches. */
+export type BagsLaunchRow = {
+  token_mint: string;
+  user_id: string;
+  royalty_bps: number | null;
+  first_seen_at: string;
+};
+
+/** The builder fields the board needs, as stored on public.users. */
+export type BagsBuilderRow = {
+  id: string;
+  username: string | null;
+  display_name: string | null;
+  avatar_url: string | null;
+  github_username: string | null;
+  vibe_score: number | null;
+  streak: number | null;
+};
+
+/** One builder's launches, ready to render. */
+export type BagsBoardEntry = {
+  /** Username is non-null here: an entry that cannot link to a profile is dropped. */
+  username: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  githubUsername: string | null;
+  vibeScore: number;
+  streak: number;
+  /** Mints this builder created, newest first. */
+  mints: string[];
+  launchCount: number;
+  /** When their earliest known launch first appeared in the cache. */
+  firstLaunchAt: string;
+};
+
+/**
+ * Group launches under their builder and rank them.
+ *
+ * Launches whose builder is missing or has no username are dropped rather than
+ * rendered anonymously: every row on this board is a claim that a named,
+ * GitHub-verified person is behind a token, and a row that cannot link to a
+ * profile makes that claim without backing it.
+ */
+export function buildBagsBoard(
+  launches: BagsLaunchRow[],
+  builders: BagsBuilderRow[],
+): BagsBoardEntry[] {
+  const byId = new Map<string, BagsBuilderRow>();
+  for (const builder of builders) {
+    if (builder.username) byId.set(builder.id, builder);
+  }
+
+  const grouped = new Map<string, BagsLaunchRow[]>();
+  for (const launch of launches) {
+    if (!byId.has(launch.user_id)) continue;
+    const existing = grouped.get(launch.user_id);
+    if (existing) existing.push(launch);
+    else grouped.set(launch.user_id, [launch]);
+  }
+
+  const entries: BagsBoardEntry[] = [];
+  for (const [userId, rows] of grouped) {
+    const builder = byId.get(userId)!;
+    const newestFirst = [...rows].sort(
+      (a, b) => Date.parse(b.first_seen_at) - Date.parse(a.first_seen_at),
+    );
+
+    entries.push({
+      username: builder.username!,
+      displayName: builder.display_name,
+      avatarUrl: builder.avatar_url,
+      githubUsername: builder.github_username,
+      vibeScore: builder.vibe_score ?? 0,
+      streak: builder.streak ?? 0,
+      mints: newestFirst.map((r) => r.token_mint),
+      launchCount: rows.length,
+      firstLaunchAt: newestFirst[newestFirst.length - 1]!.first_seen_at,
+    });
+  }
+
+  // Vibe score first, launches as the tie-break, then username so the order is
+  // stable across renders instead of drifting with whatever the DB returned.
+  return entries.sort(
+    (a, b) =>
+      b.vibeScore - a.vibeScore ||
+      b.launchCount - a.launchCount ||
+      a.username.localeCompare(b.username),
+  );
+}
+
+/** Shorten a mint for display: the ends are what people actually recognise. */
+export function shortMint(mint: string): string {
+  return mint.length <= 12 ? mint : `${mint.slice(0, 6)}…${mint.slice(-4)}`;
+}

--- a/src/lib/bags-board.ts
+++ b/src/lib/bags-board.ts
@@ -57,7 +57,13 @@ export function buildBagsBoard(
 ): BagsBoardEntry[] {
   const byId = new Map<string, BagsBuilderRow>();
   for (const builder of builders) {
-    if (builder.username) byId.set(builder.id, builder);
+    // Two hard requirements, both load-bearing for what the page claims.
+    // A username, or the row cannot link to the profile that backs it. And a
+    // GitHub handle, because the board states in as many words that every
+    // builder on it is GitHub-verified: linking a wallet does not require
+    // GitHub, so without this an unverified account could sit under that
+    // sentence and make it false.
+    if (builder.username && builder.github_username?.trim()) byId.set(builder.id, builder);
   }
 
   const grouped = new Map<string, BagsLaunchRow[]>();

--- a/src/lib/bags.ts
+++ b/src/lib/bags.ts
@@ -45,7 +45,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  * for application-level failures alongside a 200, so the flag is checked
  * explicitly rather than trusting the status code.
  */
-async function bagsGet(path: string, params: Record<string, string>): Promise<unknown | null> {
+async function bagsGet(
+  path: string,
+  params: Record<string, string>,
+): Promise<unknown | null> {
   const apiKey = process.env.BAGS_API_KEY?.trim();
   if (!apiKey) return null;
 
@@ -68,7 +71,9 @@ async function bagsGet(path: string, params: Record<string, string>): Promise<un
     // symptom otherwise is "no builder ever has launches", which reads as
     // nobody using Bags rather than as a broken credential.
     if (res.status === 401 || res.status === 403) {
-      console.error(`Bags API rejected the key (HTTP ${res.status}) on ${path}`);
+      console.error(
+        `Bags API rejected the key (HTTP ${res.status}) on ${path}`,
+      );
     }
     return null;
   }
@@ -92,7 +97,9 @@ async function bagsGet(path: string, params: Record<string, string>): Promise<un
  * when the wallet simply has no launches. Callers must distinguish the two:
  * null means "unknown, try later", [] means "asked, genuinely none".
  */
-export async function fetchLaunchesForWallet(wallet: string): Promise<string[] | null> {
+export async function fetchLaunchesForWallet(
+  wallet: string,
+): Promise<string[] | null> {
   if (!SOLANA_ADDRESS_RE.test(wallet)) return null;
 
   const response = await bagsGet("/fee-share/admin/list", { wallet });
@@ -102,7 +109,9 @@ export async function fetchLaunchesForWallet(wallet: string): Promise<string[] |
   if (!Array.isArray(mints)) return null;
 
   // Drop anything that isn't a plausible mint rather than trusting the payload.
-  return mints.filter((m): m is string => typeof m === "string" && SOLANA_ADDRESS_RE.test(m));
+  return mints.filter(
+    (m): m is string => typeof m === "string" && SOLANA_ADDRESS_RE.test(m),
+  );
 }
 
 /** A launch this wallet genuinely created, as confirmed by the creator record. */
@@ -119,6 +128,10 @@ type CreatorEntry = {
   isCreator?: unknown;
   twitterUsername?: unknown;
   royaltyBps?: unknown;
+  /** The creator's handle on Bags itself, distinct from their X handle. */
+  bagsUsername?: unknown;
+  /** Avatar Bags holds for the creator, sourced from their linked social. */
+  pfp?: unknown;
 };
 
 /**
@@ -127,7 +140,9 @@ type CreatorEntry = {
  * An empty array is a real answer: Bags knows the mint but holds no creator
  * record for it.
  */
-export async function fetchTokenCreators(tokenMint: string): Promise<CreatorEntry[] | null> {
+export async function fetchTokenCreators(
+  tokenMint: string,
+): Promise<CreatorEntry[] | null> {
   if (!SOLANA_ADDRESS_RE.test(tokenMint)) return null;
   const response = await bagsGet("/token-launch/creator/v3", { tokenMint });
   return Array.isArray(response) ? (response as CreatorEntry[]) : null;
@@ -148,7 +163,9 @@ export async function fetchTokenCreators(tokenMint: string): Promise<CreatorEntr
  * Verified against production data: wallet 4Evn…WwX9 has three fee-share mints
  * and exactly one real launch ($VIBE); the other two return no creators.
  */
-export async function fetchCreatedLaunches(wallet: string): Promise<BagsLaunch[] | null> {
+export async function fetchCreatedLaunches(
+  wallet: string,
+): Promise<BagsLaunch[] | null> {
   const candidates = await fetchLaunchesForWallet(wallet);
   if (candidates === null) return null;
   if (candidates.length === 0) return [];
@@ -159,7 +176,10 @@ export async function fetchCreatedLaunches(wallet: string): Promise<BagsLaunch[]
     if (!creators) continue; // couldn't confirm — omit rather than guess
 
     const mine = creators.find(
-      (c) => typeof c.wallet === "string" && c.wallet === wallet && c.isCreator === true,
+      (c) =>
+        typeof c.wallet === "string" &&
+        c.wallet === wallet &&
+        c.isCreator === true,
     );
     if (!mine) continue;
 
@@ -173,4 +193,55 @@ export async function fetchCreatedLaunches(wallet: string): Promise<BagsLaunch[]
     });
   }
   return launches;
+}
+
+/** Who Bags says a wallet is, for one launch it created. */
+export type BagsCreatorProfile = {
+  /** Handle on Bags itself. Null when the creator never claimed one. */
+  bagsUsername: string | null;
+  /** X handle Bags holds for them, verified on their side. */
+  twitterUsername: string | null;
+  pfpUrl: string | null;
+  royaltyBps: number;
+};
+
+/** Trim a string field off an untrusted payload, treating blank as absent. */
+function str(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+/**
+ * The Bags-side identity behind a launch: their Bags handle, X handle and
+ * avatar.
+ *
+ * This is the answer to "can we link a Bags account": we never have to ask the
+ * builder to connect one. Because the wallet was already bound to their profile
+ * by signature, whatever Bags reports for that wallet's creator record is
+ * transitively theirs — a stronger link than an OAuth connect, which would only
+ * prove they can log into an account.
+ *
+ * Null when Bags cannot confirm this wallet as the creator of this mint, which
+ * is also the guard against showing one person's identity on another's launch.
+ */
+export async function fetchCreatorProfile(
+  tokenMint: string,
+  wallet: string,
+): Promise<BagsCreatorProfile | null> {
+  const creators = await fetchTokenCreators(tokenMint);
+  if (!creators) return null;
+
+  const mine = creators.find(
+    (c) =>
+      typeof c.wallet === "string" &&
+      c.wallet === wallet &&
+      c.isCreator === true,
+  );
+  if (!mine) return null;
+
+  return {
+    bagsUsername: str(mine.bagsUsername),
+    twitterUsername: str(mine.twitterUsername),
+    pfpUrl: str(mine.pfp),
+    royaltyBps: typeof mine.royaltyBps === "number" ? mine.royaltyBps : 0,
+  };
 }

--- a/src/lib/builder-trust.ts
+++ b/src/lib/builder-trust.ts
@@ -1,0 +1,115 @@
+// Builder trust for the /bags pages.
+//
+// WHY THIS IS A TRANSLATION, NOT A NEW SCORE: vibe_score already measures
+// building — streaks, verified projects, quality, endorsements, contribution
+// volume. Deriving a second number from the same inputs would add no
+// information and would eventually disagree with the leaderboard, which is the
+// opposite of trust. What a visitor arriving from Bags actually lacks is a
+// frame of reference: "265" means nothing to them, "top 6% of builders" does.
+// So this ranks the existing score and shows the receipts behind it.
+//
+// WHY IT NEVER TOUCHES TOKEN RISK: mint authority, dev holdings and holder
+// concentration belong to the coin, not the person. Averaging them into a
+// builder number would let a long streak make a rug-shaped launch look safe,
+// which is the one failure this page cannot afford. Those stay a separate,
+// unblendable checklist.
+
+import { VIBE_SCORE } from "@/lib/scoring-config";
+
+/** Everything the assessment reads about one builder. */
+export type BuilderTrustInput = {
+  vibeScore: number;
+  /** GitHub-verified projects. The strongest single piece of evidence. */
+  verifiedProjects: number;
+  /** Commits attributed by the GitHub sync, lifetime. */
+  lifetimeContributions: number;
+  longestStreak: number;
+};
+
+export type BuilderTrust = {
+  /**
+   * Share of ranked builders this one is ahead of, 0-100. Null whenever the
+   * record is too thin to place them, which is a deliberate refusal rather
+   * than a zero.
+   */
+  percentile: number | null;
+  /** Human-readable headline. Always safe to render. */
+  label: string;
+  /** False when the evidence does not support ranking them at all. */
+  sufficient: boolean;
+  /** Why a rank was withheld, shown to the reader instead of hidden. */
+  caveat: string | null;
+};
+
+/**
+ * The cohort a percentile is measured against: everyone who has done anything
+ * at all. Ranking against all rows — including accounts that signed up and
+ * left — would flatter every active builder into the top decile.
+ */
+export function rankedCohort(allScores: number[]): number[] {
+  return allScores.filter((s) => s > VIBE_SCORE.baseline);
+}
+
+/**
+ * Percentage of the cohort scoring strictly below `score`, rounded.
+ *
+ * Strictly-below (rather than at-or-below) means a builder is never told they
+ * beat someone they merely tied.
+ */
+export function percentileOf(score: number, cohort: number[]): number | null {
+  if (cohort.length === 0) return null;
+  const below = cohort.filter((s) => s < score).length;
+  return Math.round((below / cohort.length) * 100);
+}
+
+/**
+ * Does this record support a public ranking?
+ *
+ * Requires evidence that leaves VibeTalent: a GitHub-verified project or
+ * attributed commits. A streak on its own does not qualify — it accrues from
+ * activity on this platform, and production has builders carrying 100+ day
+ * streaks with zero verified projects and zero contributions. Ranking those in
+ * the top decile beside a token launch would vouch for something nobody
+ * outside this database can check.
+ */
+export function hasVerifiableRecord(input: BuilderTrustInput): boolean {
+  return input.verifiedProjects > 0 || input.lifetimeContributions > 0;
+}
+
+/** Rank a builder against their peers, or explain why they cannot be ranked. */
+export function assessBuilderTrust(
+  input: BuilderTrustInput,
+  allScores: number[],
+): BuilderTrust {
+  if (!hasVerifiableRecord(input)) {
+    return {
+      percentile: null,
+      label: "Limited public record",
+      sufficient: false,
+      caveat:
+        input.longestStreak > 0
+          ? "This builder has a streak on VibeTalent but no GitHub-verified project or attributed commits yet, so there is nothing external to rank."
+          : "Not enough verified building activity to rank this builder yet.",
+    };
+  }
+
+  const percentile = percentileOf(input.vibeScore, rankedCohort(allScores));
+  if (percentile === null) {
+    return {
+      percentile: null,
+      label: "Unranked",
+      sufficient: false,
+      caveat: "No comparable builders to rank against.",
+    };
+  }
+
+  return {
+    percentile,
+    label:
+      percentile >= 50
+        ? `Top ${Math.max(100 - percentile, 1)}% of builders`
+        : "Ranked builder",
+    sufficient: true,
+    caveat: null,
+  };
+}

--- a/src/lib/sparkline.ts
+++ b/src/lib/sparkline.ts
@@ -1,0 +1,55 @@
+// Geometry for the inline price sparklines on /bags.
+//
+// Kept as pure maths so the awkward cases — a single trade, a flat series, a
+// series that spikes 400x — are unit-testable, and so the charts stay plain
+// server-rendered SVG instead of pulling a charting library into the bundle.
+
+export type SparklineShape = {
+  /** Polyline points for the price line. */
+  line: string;
+  /** Closed path for the tint under the line. */
+  area: string;
+};
+
+/**
+ * Map a price series onto an SVG viewbox.
+ *
+ * Returns null below two points: one trade is not a trend, and drawing a dot
+ * as though it were would overstate what the data says.
+ *
+ * A flat series is drawn down the middle rather than at the bottom, so a token
+ * whose price never moved does not read as one that collapsed.
+ */
+export function buildSparkline(
+  values: number[],
+  width: number,
+  height: number,
+  padding = 2,
+): SparklineShape | null {
+  if (values.length < 2 || width <= 0 || height <= 0) return null;
+
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const span = max - min;
+
+  const usableHeight = Math.max(height - padding * 2, 0);
+  const stepX = width / (values.length - 1);
+
+  const points = values.map((value, i) => {
+    const x = i * stepX;
+    const ratio = span === 0 ? 0.5 : (value - min) / span;
+    // SVG y grows downward, so the highest price sits at the smallest y.
+    const y = padding + (1 - ratio) * usableHeight;
+    return `${round(x)},${round(y)}`;
+  });
+
+  const line = points.join(" ");
+  const area = `M0,${round(height)} L${points.join(" L")} L${round(width)},${round(height)} Z`;
+
+  return { line, area };
+}
+
+/** Two decimals is beyond sub-pixel; more just bloats the markup. */
+function round(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/src/lib/token-market.ts
+++ b/src/lib/token-market.ts
@@ -1,0 +1,153 @@
+// Market data for a Solana token, from GeckoTerminal's free public API.
+//
+// WHY GECKOTERMINAL: Bags tokens trade on a Bags bonding curve and are not
+// routable on Jupiter, so the usual Solana price sources return nothing for
+// them. GeckoTerminal indexes the curve pools directly, needs no key, and is
+// already the price source this codebase uses for $VIBE.
+//
+// This is enrichment, never a source of truth. The verification claim on a
+// /bags page comes from the database; price, chart and artwork come from here
+// and every call fails soft, so an outage costs a card its numbers rather than
+// taking the page down.
+
+const GECKO_API_BASE = "https://api.geckoterminal.com/api/v2";
+const NETWORK = "solana";
+
+/** GeckoTerminal is not on our critical path; give up quickly. */
+const REQUEST_TIMEOUT_MS = 8_000;
+
+/**
+ * Cache window for market data, in seconds. Matches the /bags ISR window: there
+ * is no point holding a fresher price than the page that renders it.
+ */
+const MARKET_REVALIDATE_S = 300;
+
+export type TokenMarket = {
+  mint: string;
+  name: string | null;
+  symbol: string | null;
+  imageUrl: string | null;
+  priceUsd: number | null;
+  fdvUsd: number | null;
+  volume24hUsd: number | null;
+  /** Bonding-curve progress, 0-100, for tokens that have not graduated. */
+  graduationPct: number | null;
+  graduated: boolean;
+  /** Pool used for the chart; null when the token has no indexed pool. */
+  poolAddress: string | null;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Parse the numeric strings GeckoTerminal returns, rejecting junk and NaN. */
+function toNumber(value: unknown): number | null {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value !== "string" || !value.trim()) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+async function geckoGet(path: string): Promise<unknown | null> {
+  try {
+    const res = await fetch(`${GECKO_API_BASE}${path}`, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      next: { revalidate: MARKET_REVALIDATE_S },
+    });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    // Timeout, network failure, or malformed JSON. All mean the same thing here.
+    return null;
+  }
+}
+
+/**
+ * Name, artwork, price and pool for one mint.
+ *
+ * Returns null when GeckoTerminal has never indexed the token, which is normal
+ * for a launch that has not traded yet.
+ */
+export async function fetchTokenMarket(
+  mint: string,
+): Promise<TokenMarket | null> {
+  const body = await geckoGet(
+    `/networks/${NETWORK}/tokens/${encodeURIComponent(mint)}`,
+  );
+  if (!isRecord(body) || !isRecord(body.data)) return null;
+
+  const attrs = body.data.attributes;
+  if (!isRecord(attrs)) return null;
+
+  const launchpad = isRecord(attrs.launchpad_details)
+    ? attrs.launchpad_details
+    : null;
+
+  // The first related pool is the deepest one, which is the pool worth charting.
+  let poolAddress: string | null = null;
+  const relationships = body.data.relationships;
+  if (isRecord(relationships) && isRecord(relationships.top_pools)) {
+    const pools = relationships.top_pools.data;
+    if (
+      Array.isArray(pools) &&
+      isRecord(pools[0]) &&
+      typeof pools[0].id === "string"
+    ) {
+      // Ids arrive network-prefixed ("solana_<address>").
+      poolAddress = pools[0].id.replace(`${NETWORK}_`, "");
+    }
+  }
+
+  return {
+    mint,
+    name: typeof attrs.name === "string" ? attrs.name : null,
+    symbol: typeof attrs.symbol === "string" ? attrs.symbol : null,
+    imageUrl: typeof attrs.image_url === "string" ? attrs.image_url : null,
+    priceUsd: toNumber(attrs.price_usd),
+    fdvUsd: toNumber(attrs.fdv_usd),
+    volume24hUsd: isRecord(attrs.volume_usd)
+      ? toNumber(attrs.volume_usd.h24)
+      : null,
+    graduationPct: launchpad ? toNumber(launchpad.graduation_percentage) : null,
+    graduated: launchpad?.completed === true,
+    poolAddress,
+  };
+}
+
+/**
+ * Daily closing prices for a pool, oldest first.
+ *
+ * GeckoTerminal returns candles newest-first as [timestamp, o, h, l, c, volume];
+ * a chart reads left to right, so they are reversed here rather than in the view.
+ */
+export async function fetchDailyCloses(
+  pool: string,
+  days = 30,
+): Promise<number[]> {
+  const body = await geckoGet(
+    `/networks/${NETWORK}/pools/${encodeURIComponent(pool)}/ohlcv/day?aggregate=1&limit=${days}`,
+  );
+  if (!isRecord(body) || !isRecord(body.data)) return [];
+
+  const attrs = body.data.attributes;
+  if (!isRecord(attrs) || !Array.isArray(attrs.ohlcv_list)) return [];
+
+  const closes: number[] = [];
+  for (const candle of attrs.ohlcv_list) {
+    if (!Array.isArray(candle)) continue;
+    const close = toNumber(candle[4]);
+    if (close !== null) closes.push(close);
+  }
+  return closes.reverse();
+}
+
+/** Percentage change across a series, or null when there is nothing to compare. */
+export function changePct(closes: number[]): number | null {
+  if (closes.length < 2) return null;
+  const first = closes[0]!;
+  const last = closes[closes.length - 1]!;
+  if (first === 0) return null;
+  return ((last - first) / first) * 100;
+}


### PR DESCRIPTION
## What

Two new pages that make the Bags data we already cache legible to people arriving from Bags.

**`/bags`** — builders with a launch Bags confirms they created, ranked by **vibe score, not launch count**. Ranking on launches would reward minting, which is the one behaviour this board must not flatter. Below the board sits the claim CTA, so the page still does work at low coverage instead of just looking empty.

**`/bags/<username>`** — what they launched: artwork, price, FDV, 24h volume, bonding-curve progress and a 30-day chart per coin, plus their Bags handle and X handle.

## On "can we connect a Bags account"

No connect flow is needed or offered. The creator record already returns the Bags-side identity for a wallet:

```
bagsUsername: "defiunknownking"   twitterUsername: "abhiontwt"   isCreator: true
```

Because the wallet was bound by signature, whatever Bags reports for it is transitively the builder's. An OAuth connect would only prove someone can log into an account, which is weaker.

Deliberately **not** linking to `bags.fm/@handle`: that URL is a referral/invite landing page, not a public profile, so the handle renders as text and coins link to `bags.fm/<mint>`.

## Builder trust is a translation, not a new score

`vibe_score` already measures building. A second number off the same inputs adds no information and eventually disagrees with the leaderboard. What a visitor from Bags lacks is a frame of reference — "265" means nothing to them. So the page ranks the existing score into a percentile and prints the receipts.

Two refusals are deliberate:

- **A rank needs evidence that leaves VibeTalent** — a GitHub-verified project or attributed commits. A streak alone does not qualify. Production has a builder on a 115-day streak with **zero verified projects and zero commits**, whose 280 vibe score outranks every other verified-wallet holder. Ranking that in the top decile beside a token launch would vouch for something nobody outside our database can check, so it renders "Limited public record" with the reason shown.
- **Token risk is never folded in.** Mint authority, dev holdings and holder concentration belong to the coin. Averaging them into a builder number is how a long streak makes a rug-shaped launch look safe.

## Data sources

GeckoTerminal for market data — already this codebase's price source, because Bags curve tokens are not routable on Jupiter. DexScreener returns **zero pairs** for them. Every upstream call fails soft: an outage costs a card its numbers, not the page. Charts are server-rendered SVG, so no charting library enters the bundle. Live lookups are capped at 12 coins per render and cached 5 minutes.

## Design

The Bags palette (`#0C1014` canvas, `#00FF00` accent, 16-20px radii, sentence-case headings) is sampled from the live app and pinned in a `.bags-theme` scope that **holds in both site themes**. Half-adopting either palette reads as a bug; a fixed dark canvas reads as the branded surface it is.

## Also

- `/bags` and each builder page in the sitemap, `lastmod` from the last verification
- A Bags section in `llms.txt` stating coverage is opt-in and a lower bound, never a complete list
- `#wallet` anchor on the settings card the claim CTA points at
- Token artwork proxied through `/_next/image`, so the strict `img-src` CSP is untouched
- Fixed a light-mode contrast bug found on the way: the mint chips used `--bg-pill`, which is permanently dark in **both** themes. `src/components/profile/backed-by.tsx:157` has the same latent bug, left untouched here

## Verification

- 557 tests, 43 files (33 new: ranking rules, sparkline geometry including flat series and outliers, market-client parsing and failure paths, the trust gate, and a test that `fetchCreatorProfile` ignores fee-share recipients who are not the creator so a bot in the fee split cannot print its handle under someone's launch)
- `eslint src` clean, `npx tsc --noEmit` clean
- Rendered against production data in dark, light and at 390px

**Not visually confirmed:** the "Limited public record" state is unit-tested but no builder currently trips it *and* has a launch. **No migration** — nothing to apply before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Bags Builders board with ranked builders, launch counts, vibe scores, streaks, and mint links.
  * Added builder detail pages with profiles, trust indicators, verified launches, token market data, charts, and graduation progress.
  * Added creator verification, market-data enrichment, and graceful handling for missing or unavailable data.
  * Added Bags navigation, wallet-claim guidance, SEO metadata, structured data, and sitemap coverage.
  * Added a dedicated dark Bags visual theme and responsive token and builder cards.

* **Documentation**
  * Added Bags Builders details to the site’s machine-readable documentation.

* **Bug Fixes**
  * Added secure remote image support and preserved the existing security-header behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->