### PR TITLE
fix: nine review findings outside the Bags work

### DIFF
--- a/src/components/achievements/achievement-celebration.tsx
+++ b/src/components/achievements/achievement-celebration.tsx
@@ -64,7 +64,9 @@ export function AchievementCelebration({
       "#10B981",
       "#0EA5E9",
       "#EC4899",
-      "#FFFFFF",
+      // Warm off-white, not #FFFFFF: pure white is reserved for primary
+      // elements, and confetti is decoration.
+      "#F5F0EC",
     ];
     const cx = W / 2;
     const cy = H * 0.42;

--- a/src/components/dashboard/email-preferences.tsx
+++ b/src/components/dashboard/email-preferences.tsx
@@ -125,6 +125,7 @@ export function EmailPreferences() {
               </div>
             </div>
             <button
+              type="button"
               onClick={() => handleToggle(key)}
               disabled={saving}
               className="w-10 h-6 rounded-full relative cursor-pointer transition-colors shrink-0"

--- a/src/components/explore/explore-content.tsx
+++ b/src/components/explore/explore-content.tsx
@@ -34,6 +34,19 @@ const ACTIVE_PILL_STYLE = {
 const PILL_REMOVE_BTN =
   "inline-flex items-center justify-center rounded-full p-0.5 cursor-pointer text-[var(--text-muted)] transition-colors hover:text-[var(--foreground)]";
 
+/**
+ * Read a streak bound from a number input, falling back to its default.
+ *
+ * Clearing a number input yields "", and Number("") is 0. On the maximum that
+ * silently became "show only builders with a zero streak" — the opposite of
+ * clearing the filter.
+ */
+function streakInput(raw: string, fallback: number): number {
+  if (!raw.trim()) return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
 export function ExploreContent({ users }: { users: UserWithSocials[] }) {
   const [search, _setSearch] = useState("");
   const [sortBy, _setSortBy] = useState<SortOption>("vibe_score");
@@ -372,7 +385,9 @@ export function ExploreContent({ users }: { users: UserWithSocials[] }) {
                     min={0}
                     max={365}
                     value={minStreak}
-                    onChange={(e) => setMinStreak(Number(e.target.value))}
+                    onChange={(e) =>
+                      setMinStreak(streakInput(e.target.value, 0))
+                    }
                     aria-label="Minimum streak days"
                     className="input-brutal w-20 text-center text-sm py-1.5"
                     placeholder="Min"
@@ -385,7 +400,9 @@ export function ExploreContent({ users }: { users: UserWithSocials[] }) {
                     min={0}
                     max={365}
                     value={maxStreak}
-                    onChange={(e) => setMaxStreak(Number(e.target.value))}
+                    onChange={(e) =>
+                      setMaxStreak(streakInput(e.target.value, 365))
+                    }
                     aria-label="Maximum streak days"
                     className="input-brutal w-20 text-center text-sm py-1.5"
                     placeholder="Max"

--- a/src/components/layout/navbar-client.tsx
+++ b/src/components/layout/navbar-client.tsx
@@ -785,6 +785,7 @@ export function NavbarClient({
               {/* Profile Avatar Dropdown */}
               <div className="relative ml-3" ref={dropdownRef}>
                 <button
+                  type="button"
                   ref={avatarTriggerRef}
                   onClick={() => setProfileDropdownOpen(!profileDropdownOpen)}
                   aria-label="Profile menu"
@@ -943,6 +944,7 @@ export function NavbarClient({
                       style={{ borderTop: "1px solid var(--border-hard)" }}
                     />
                     <button
+                      type="button"
                       role="menuitem"
                       onClick={handleLogout}
                       className="flex items-center gap-2 px-4 py-3 text-sm font-semibold transition-colors w-full text-left"

--- a/src/components/projects/github-sparkline.tsx
+++ b/src/components/projects/github-sparkline.tsx
@@ -1,9 +1,14 @@
 export function GithubSparkline({ values }: { values: number[] }) {
-  // Always render 7 bars. Missing days padded with 0.
-  const data =
-    values.length === 7
-      ? values
-      : [...values, ...Array(7 - values.length).fill(0)];
+  // Always render 7 bars: short input is padded with zeros, long input is
+  // truncated. Truncating matters — Array(7 - values.length) throws RangeError
+  // on a negative length, so an oversized payload used to crash the render
+  // rather than draw a slightly wrong chart.
+  // Taken from the front to match the existing padding convention, which
+  // appends zeros for missing entries. No caller feeds this a real array yet
+  // (both pass null), so whoever wires a producer should confirm the window's
+  // direction against the "last 7 days" label before trusting either end.
+  const recent = values.slice(0, 7);
+  const data = [...recent, ...Array(Math.max(0, 7 - recent.length)).fill(0)];
   const max = Math.max(...data, 1);
   const barWidth = 5;
   const gap = 2;

--- a/src/components/projects/projects-content.tsx
+++ b/src/components/projects/projects-content.tsx
@@ -151,6 +151,7 @@ export function ProjectsContent({
             <select
               value={sortBy}
               onChange={(e) => setSortBy(e.target.value as SortOption)}
+              aria-label="Sort projects"
               className="appearance-none pl-4 pr-10 py-2.5 rounded-xl border border-[var(--border-hard)] bg-[var(--bg-surface)] text-[var(--foreground)] font-semibold text-sm cursor-pointer focus:outline-none focus:border-[var(--accent)]"
             >
               <option value="newest">Newest</option>

--- a/src/components/share/share-button.tsx
+++ b/src/components/share/share-button.tsx
@@ -2,6 +2,8 @@
 
 import { useRef, useState } from "react";
 
+import { getSiteUrl } from "@/lib/seo";
+
 interface ShareButtonProps {
   url: string;
   text: string;
@@ -14,14 +16,16 @@ type Status =
 
 export function ShareButton({ url, text, imageUrl }: ShareButtonProps) {
   const [status, setStatus] = useState<Status>("idle");
-  const absUrl =
-    typeof window !== "undefined"
-      ? new URL(url, window.location.origin).toString()
-      : url;
-  const absImageUrl =
-    imageUrl && typeof window !== "undefined"
-      ? new URL(imageUrl, window.location.origin).toString()
-      : imageUrl;
+  // Resolved against the build-inlined site URL rather than window.location,
+  // which is identical on server and client. Branching on `typeof window` gave
+  // the server a relative href and the client an absolute one — a hydration
+  // mismatch, and worse, a share link that was broken for anyone who clicked
+  // before hydration.
+  const origin = getSiteUrl();
+  const absUrl = new URL(url, origin).toString();
+  const absImageUrl = imageUrl
+    ? new URL(imageUrl, origin).toString()
+    : imageUrl;
 
   // Hold the (in-flight) image blob so a hover/focus can start generating it
   // before the click — the copy then resolves an already-warm promise instead

--- a/src/components/ui/featured/feature-your-project-card.tsx
+++ b/src/components/ui/featured/feature-your-project-card.tsx
@@ -674,9 +674,12 @@ const FeatureCardBody = forwardRef<HTMLDivElement, Props>(
             <>
               {/* Idle stage */}
               <div className="flex items-center justify-between mb-2">
-                <label className="text-[10px] font-semibold text-[var(--text-muted)]">
+                <span
+                  id="featured-chain-label"
+                  className="text-[10px] font-semibold text-[var(--text-muted)]"
+                >
                   Pay on
-                </label>
+                </span>
                 <span
                   className="font-mono text-[10px] font-semibold px-2.5 py-0.5 rounded-full"
                   style={{
@@ -688,7 +691,11 @@ const FeatureCardBody = forwardRef<HTMLDivElement, Props>(
                 </span>
               </div>
 
-              <div className="grid grid-cols-2 gap-2 mb-4">
+              <div
+                role="group"
+                aria-labelledby="featured-chain-label"
+                className="grid grid-cols-2 gap-2 mb-4"
+              >
                 {SUPPORTED_CHAINS.map((key) => {
                   const isActive = selectedChain === key;
                   const chainKey = key as ChainKey;
@@ -763,7 +770,10 @@ const FeatureCardBody = forwardRef<HTMLDivElement, Props>(
               </div>
 
               <div className="mb-3">
-                <label className="block text-[10px] font-semibold text-[var(--text-muted)] mb-1">
+                <label
+                  htmlFor="featured-project"
+                  className="block text-[10px] font-semibold text-[var(--text-muted)] mb-1"
+                >
                   Project
                 </label>
                 {loadingProjects ? (
@@ -790,6 +800,7 @@ const FeatureCardBody = forwardRef<HTMLDivElement, Props>(
                   </div>
                 ) : (
                   <select
+                    id="featured-project"
                     value={selectedProject}
                     onChange={(e) => setSelectedProject(e.target.value)}
                     className="w-full px-3 py-2 text-xs font-medium rounded-xl"
@@ -814,10 +825,17 @@ const FeatureCardBody = forwardRef<HTMLDivElement, Props>(
               {solanaTokenToggle}
 
               <div className="mb-3">
-                <label className="block text-[10px] font-semibold text-[var(--text-muted)] mb-1.5">
+                <span
+                  id="featured-package-label"
+                  className="block text-[10px] font-semibold text-[var(--text-muted)] mb-1.5"
+                >
                   Package
-                </label>
-                <div className="flex flex-col gap-1.5">
+                </span>
+                <div
+                  role="group"
+                  aria-labelledby="featured-package-label"
+                  className="flex flex-col gap-1.5"
+                >
                   {PACKAGES.map((pkg) => {
                     const isActive = selectedPkg === pkg.value;
                     return (

--- a/src/components/ui/quality-score-badge.tsx
+++ b/src/components/ui/quality-score-badge.tsx
@@ -93,10 +93,12 @@ export function QualityScoreBadge({
               Quality Score
             </span>
             <button
+              type="button"
               onClick={() => setShowInfo(false)}
+              aria-label="Close quality score details"
               className="text-[var(--text-muted)] hover:text-[var(--foreground)]"
             >
-              <X size={14} />
+              <X size={14} aria-hidden="true" />
             </button>
           </div>
 

--- a/src/lib/__tests__/achievement-founding-member.test.ts
+++ b/src/lib/__tests__/achievement-founding-member.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  ACHIEVEMENTS,
+  type AchievementCounters,
+} from "@/lib/achievements/definitions";
+
+const foundingMember = ACHIEVEMENTS.find((a) => a.id === "founding_member")!;
+
+/**
+ * `joinedAt` reaches this as `users.created_at`, a Postgres TIMESTAMPTZ, which
+ * arrives as a full ISO-8601 string rather than the bare date the cutoff is
+ * written as. The comparison is lexical, so these cases pin the behaviour that
+ * makes that safe — and would catch it breaking if the cutoff ever gained a
+ * time component or the column started arriving in another format.
+ */
+function counters(joinedAt: string | null): AchievementCounters {
+  return {
+    currentStreak: 0,
+    longestStreak: 0,
+    projectCount: 0,
+    verifiedProjectCount: 0,
+    topQualityScore: 0,
+    endorsementsReceived: 0,
+    hireRequestsReceived: 0,
+    completedHires: 0,
+    reviewsGiven: 0,
+    hasGithubLinked: false,
+    referralCount: 0,
+    joinedAt,
+  } as AchievementCounters;
+}
+
+describe("founding_member", () => {
+  it("is earned by someone who joined on launch day", () => {
+    // The real shape: a TIMESTAMPTZ, not a bare date.
+    expect(
+      foundingMember.progress(counters("2026-03-17T13:07:20.455349+00:00")),
+    ).toBe(1);
+  });
+
+  it("is earned right up to the last moment before the cutoff", () => {
+    expect(
+      foundingMember.progress(counters("2026-03-23T23:59:59.999999+00:00")),
+    ).toBe(1);
+  });
+
+  it("is NOT earned on the cutoff day itself", () => {
+    // The cutoff is exclusive: the founding cohort is the first week, and
+    // 2026-03-24 is the day after it ends.
+    expect(
+      foundingMember.progress(counters("2026-03-24T00:00:00.000000+00:00")),
+    ).toBe(0);
+    expect(foundingMember.progress(counters("2026-03-24"))).toBe(0);
+  });
+
+  it("is not earned by anyone who joined later", () => {
+    expect(foundingMember.progress(counters("2026-08-01T09:00:00+00:00"))).toBe(
+      0,
+    );
+  });
+
+  it("is not earned when the join date is missing", () => {
+    // created_at is nullable in the fetch layer, and a null must not read as
+    // "joined before the cutoff".
+    expect(foundingMember.progress(counters(null))).toBe(0);
+  });
+});


### PR DESCRIPTION
Findings CodeRabbit raised on #258 that were in files that PR never touched. Left out there to keep it scoped.

## One is a crash

**`github-sparkline.tsx`** threw `RangeError` during render for any input longer than seven values — `Array(7 - values.length)` rejects a negative length, so it would take `GithubSignal` down rather than draw a slightly wrong chart. Input is clamped before padding.

Worth knowing: both callers currently pass `null`, so there is **no producer** to check the window's direction against. I kept the existing front-of-array convention and said so in a comment, because whoever wires a producer has to confirm which end is recent against the "last 7 days" label.

## Correctness

**Clearing the max streak filter didn't clear it.** `Number("")` is `0`, so an emptied maximum stored `0` and the filter kept only builders with *no* streak — the opposite of removing it. Empty and non-finite input now restores each bound's own default (0 and 365, the codebase's existing "filter off" sentinels). The minimum runs the same path harmlessly, since 0 is already its no-op value.

**`ShareButton` had a hydration mismatch.** It built absolute URLs from `window.location`, so the server rendered a relative href and the client an absolute one. Deferring normalization would have left the server-rendered X intent link *relative* — broken for anyone clicking before hydration. It resolves against `getSiteUrl()` instead, which is build-inlined and identical on both sides, fixing the mismatch and the pre-hydration link together.

## Accessibility

- The projects sort `<select>`, the quality-score close button, and the featured-payment project `<select>` had no accessible names.
- The **Token**, **Pay on** and **Package** button groups used `<label>` elements that referenced no control — which isn't a label at all. They're named groups now (`role="group"` + `aria-labelledby`), and the project picker keeps a real `<label htmlFor>` since it is a genuine control.

## Smaller

- Explicit `type="button"` on the email preference toggle, the avatar trigger and the logout item, so none can submit an ancestor form.
- Confetti uses a warm off-white rather than `#FFFFFF`; pure white is reserved for primary elements.
- `founding_member` had no tests despite comparing a TIMESTAMPTZ lexically against a bare date. Five boundary cases pin it, including the cutoff day itself and a null join date.

## Verification

657 tests across 48 files, `eslint src` and `npx tsc --noEmit` clean, and `/explore` and `/projects` render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)