### PR TITLE
feat(homepage): live builder count, rolling to each new figure

### DIFF
--- a/src/app/api/hero-stats/route.ts
+++ b/src/app/api/hero-stats/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { statsLimiter, checkRateLimit, getIP } from "@/lib/rate-limit";
+import { fetchHeroStatsCached } from "@/lib/supabase/server-queries";
+
+/**
+ * Live figures for the homepage stat strip (`ProofWallStats`).
+ *
+ * The strip is server-rendered from the same numbers on first paint and then
+ * polls this every 60s, so a new signup lands on the page without a refresh.
+ * Anonymous and aggregate-only — nothing here identifies a builder — so it
+ * stays publicly cacheable.
+ */
+export async function GET(request: NextRequest) {
+  const { success } = await checkRateLimit(statsLimiter, getIP(request));
+  if (!success) {
+    return NextResponse.json({ error: "Rate limited" }, { status: 429 });
+  }
+
+  try {
+    const stats = await fetchHeroStatsCached();
+    return NextResponse.json(stats, {
+      headers: { "Cache-Control": "public, s-maxage=30, stale-while-revalidate=120" },
+    });
+  } catch (err) {
+    console.error("[hero-stats] fetch failed:", err);
+    return NextResponse.json({ error: "Failed to fetch stats" }, { status: 500 });
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -780,3 +780,62 @@ body:has(.chat-page-wrapper) main {
   text-transform: uppercase;
   letter-spacing: 0.1em;
 }
+
+/* Rolling stat numbers (homepage proof-wall strip, `RollingNumber`).
+   The ghost is a transparent, in-flow copy of the number: it owns the width
+   and the baseline so the absolutely-positioned digit columns can be masked
+   without shifting the layout or the suffix next to them. line-height:1 makes
+   the container exactly 1em tall, which is both the mask height and the cell
+   height — that identity is what keeps a rolled digit landing pixel-exactly
+   where the ghost's digit sits. */
+.stat-roll {
+  position: relative;
+  display: inline-block;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+.stat-roll-ghost {
+  color: transparent;
+}
+.stat-roll-track {
+  position: absolute;
+  inset: 0;
+  display: flex;
+}
+.stat-roll-col,
+.stat-roll-sep {
+  /* Never shrink: the track is width-constrained by the ghost, and a shrunk
+     column would slide the digits out of register with it. */
+  flex: 0 0 auto;
+}
+.stat-roll-col {
+  height: 1em;
+  overflow: hidden;
+}
+.stat-roll-strip {
+  display: block;
+  /* The per-column delay that staggers the cascade is set inline, from the
+     column's distance to the right edge. */
+  transition: transform 0.6s var(--ease-out);
+}
+.stat-roll-cell {
+  display: block;
+  height: 1em;
+}
+/* The one-shot lift that fires alongside the roll lives in RollingNumber as a
+   Web Animation, not here — see the comment there. Colour stays untouched
+   either way: the hero is single-colour above the fold. */
+@media (prefers-reduced-motion: reduce) {
+  .stat-roll-strip {
+    transition: none;
+  }
+}
+/* Forced colours (Windows high contrast) override the ghost's `transparent`
+   with a system colour, which would show it through the digits stacked on top
+   of it. Dropping the track there leaves the plain number, which is the one
+   thing that has to survive. */
+@media (forced-colors: active) {
+  .stat-roll-track {
+    display: none;
+  }
+}

--- a/src/components/homepage/proof-wall-hero.tsx
+++ b/src/components/homepage/proof-wall-hero.tsx
@@ -1,14 +1,16 @@
 import Link from "next/link";
 import type { ProofWallData } from "@/lib/supabase/server-queries";
+import { ProofWallStats } from "@/components/homepage/proof-wall-stats";
 
 /**
  * The homepage hero, from the owner's design: a wall of real builder-days.
  *
  * Every square is one (builder, day) pair read from streak_logs — the last 70
  * days for the 8 most-active builders, shaded by commit count on the same
- * `--hm-*` scale as the profile heatmaps. Nothing here animates and nothing is
- * mocked; hovering a square names the builder, the day, and the commits
- * (native title tooltip, no JS).
+ * `--hm-*` scale as the profile heatmaps. Nothing here is mocked; hovering a
+ * square names the builder, the day, and the commits (native title tooltip,
+ * no JS). The wall itself is static — the only motion is the stat strip
+ * below it rolling to a new figure when one lands (`ProofWallStats`).
  *
  * The headline is deliberately sentence case (`normal-case` beats the global
  * uppercase heading rule): it's a sentence being said, not a page title.
@@ -41,29 +43,6 @@ export function ProofWallHero({
   avgStreak: number;
 }) {
   const { days, rows, totalBuilderDays, longestStreak, buildersTracked } = data;
-
-  // Every figure here is a live count. Deliberately absent: the old
-  // "Top Vibers" tile, which rendered topVibecoders.length against an array
-  // hardcoded to .slice(0, 3) — it read "3" no matter what the data did.
-  //
-  // Also deliberate: no stat is accent-coloured. The hero is single-colour
-  // text by design, so the only accent above the fold is the primary button.
-  // "Builders tracked" used to carry an `accent: true` flag; don't put it back
-  // without changing that rule too.
-  const stats = [
-    {
-      label: "GitHub-verified days",
-      value: totalBuilderDays.toLocaleString("en-US"),
-    },
-    { label: "Longest streak", value: longestStreak, suffix: "days" },
-    { label: "Builders tracked", value: buildersTracked },
-    { label: "Projects shipped", value: totalProjects },
-    {
-      label: "Avg. streak",
-      value: avgStreak,
-      suffix: avgStreak === 1 ? "day" : "days",
-    },
-  ];
 
   return (
     <section className="mx-auto max-w-7xl px-4 sm:px-6 pt-12 sm:pt-16 pb-14">
@@ -122,29 +101,19 @@ export function ProofWallHero({
 
       {/* Real totals + the builder/hirer CTAs */}
       <div className="mt-8 flex flex-wrap items-end justify-between gap-x-10 gap-y-8">
-        {/* Wording matters on the first tile. Roughly half of streak_logs
-            predates the platform (the github-sync backfill reads a year of
-            contribution history), so "days verified" implied activity ON
-            VibeTalent that those rows cannot support. "GitHub-verified days"
-            is what the number actually is: commit days read from GitHub
-            rather than self-reported. */}
-        <div className="flex flex-wrap gap-x-10 gap-y-6">
-          {stats.map((s) => (
-            <div key={s.label}>
-              <div className="text-[11px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
-                {s.label}
-              </div>
-              <div className="mt-1 text-3xl sm:text-4xl font-extrabold tracking-tight text-[var(--foreground)]">
-                {s.value}
-                {s.suffix && (
-                  <span className="ml-1.5 text-base font-bold text-[var(--text-muted)]">
-                    {s.suffix}
-                  </span>
-                )}
-              </div>
-            </div>
-          ))}
-        </div>
+        {/* Live from here down: the strip polls /api/hero-stats and rolls to
+            the new figure, so a signup shows up without a reload. These
+            props are the same counts the endpoint returns, so first paint
+            already carries the real numbers (crawlers included). */}
+        <ProofWallStats
+          initial={{
+            totalBuilderDays,
+            longestStreak,
+            buildersTracked,
+            totalProjects,
+            avgStreak,
+          }}
+        />
         {/* Two doors, and hiring is the primary one. VibeTalent is sold as a
             hiring platform: demand is the scarce side, builder supply is not,
             so the accent goes to /explore and builder signup takes the quieter

--- a/src/components/homepage/proof-wall-stats.tsx
+++ b/src/components/homepage/proof-wall-stats.tsx
@@ -35,15 +35,20 @@ export function ProofWallStats({ initial }: { initial: HeroStats }) {
   useEffect(() => {
     let cancelled = false;
     let interval: ReturnType<typeof setInterval> | null = null;
+    // A focus refresh can overlap an interval tick still in flight. Without a
+    // sequence number the slower of the two wins whenever it lands last, and
+    // the strip drops back to the older count until the next poll.
+    let latest = 0;
 
     const fetchStats = async () => {
+      const id = ++latest;
       try {
         const res = await fetch("/api/hero-stats");
         // Non-2xx bodies are the rate-limit / failure shapes, not stats.
         // Keeping the last good numbers beats blanking the strip mid-poll.
         if (!res.ok) return;
         const data = await res.json();
-        if (!cancelled && isHeroStats(data)) setStats(data);
+        if (!cancelled && id === latest && isHeroStats(data)) setStats(data);
       } catch {
         // Network errors are swallowed; the rendered numbers stay put.
       }
@@ -68,9 +73,13 @@ export function ProofWallStats({ initial }: { initial: HeroStats }) {
     };
 
     // One fetch on mount: the page itself is ISR-cached for minutes, so this
-    // is what pulls a stale strip up to date on arrival.
-    fetchStats();
-    startPolling();
+    // is what pulls a stale strip up to date on arrival. Skipped when the tab
+    // opens in the background (a middle-click into a new tab) — the visibility
+    // handler covers the moment it's actually looked at.
+    if (!document.hidden) {
+      fetchStats();
+      startPolling();
+    }
     document.addEventListener("visibilitychange", onVisibilityChange);
 
     return () => {

--- a/src/components/homepage/proof-wall-stats.tsx
+++ b/src/components/homepage/proof-wall-stats.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { HeroStats } from "@/lib/supabase/server-queries";
+
+/**
+ * The stat strip under the proof wall.
+ *
+ * Server-rendered from the same counts on first paint (so the numbers are in
+ * the HTML for crawlers and there's no empty flash), then polled so a signup
+ * or a shipped project shows up without the visitor reloading the page. The
+ * poll pauses while the tab is hidden and re-syncs on focus — same contract as
+ * the network feed, for the same reason: background tabs shouldn't burn
+ * Supabase egress on numbers nobody is looking at.
+ */
+
+const POLL_INTERVAL = 60_000;
+
+/** Guards the response before it replaces good numbers with `undefined`. */
+function isHeroStats(value: unknown): value is HeroStats {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.totalBuilderDays === "number" &&
+    typeof v.longestStreak === "number" &&
+    typeof v.buildersTracked === "number" &&
+    typeof v.totalProjects === "number" &&
+    typeof v.avgStreak === "number"
+  );
+}
+
+export function ProofWallStats({ initial }: { initial: HeroStats }) {
+  const [stats, setStats] = useState<HeroStats>(initial);
+
+  useEffect(() => {
+    let cancelled = false;
+    let interval: ReturnType<typeof setInterval> | null = null;
+
+    const fetchStats = async () => {
+      try {
+        const res = await fetch("/api/hero-stats");
+        // Non-2xx bodies are the rate-limit / failure shapes, not stats.
+        // Keeping the last good numbers beats blanking the strip mid-poll.
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!cancelled && isHeroStats(data)) setStats(data);
+      } catch {
+        // Network errors are swallowed; the rendered numbers stay put.
+      }
+    };
+
+    const startPolling = () => {
+      if (interval !== null) return;
+      interval = setInterval(fetchStats, POLL_INTERVAL);
+    };
+    const stopPolling = () => {
+      if (interval === null) return;
+      clearInterval(interval);
+      interval = null;
+    };
+    const onVisibilityChange = () => {
+      if (document.hidden) {
+        stopPolling();
+      } else {
+        fetchStats();
+        startPolling();
+      }
+    };
+
+    // One fetch on mount: the page itself is ISR-cached for minutes, so this
+    // is what pulls a stale strip up to date on arrival.
+    fetchStats();
+    startPolling();
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      stopPolling();
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, []);
+
+  // Every figure here is a live count. Deliberately absent: the old
+  // "Top Vibers" tile, which rendered topVibecoders.length against an array
+  // hardcoded to .slice(0, 3) — it read "3" no matter what the data did.
+  //
+  // Also deliberate: no stat is accent-coloured, not even on a tick. The hero
+  // is single-colour text by design, so the only accent above the fold is the
+  // primary button. "Builders tracked" used to carry an `accent: true` flag;
+  // don't put it back without changing that rule too — which is why the update
+  // animation is motion (roll + lift) rather than colour.
+  const items = [
+    // Wording matters on the first tile. Roughly half of streak_logs predates
+    // the platform (the github-sync backfill reads a year of contribution
+    // history), so "days verified" implied activity ON VibeTalent that those
+    // rows cannot support. "GitHub-verified days" is what the number actually
+    // is: commit days read from GitHub rather than self-reported.
+    { label: "GitHub-verified days", value: stats.totalBuilderDays },
+    { label: "Longest streak", value: stats.longestStreak, suffix: "days" },
+    { label: "Builders tracked", value: stats.buildersTracked },
+    { label: "Projects shipped", value: stats.totalProjects },
+    {
+      label: "Avg. streak",
+      value: stats.avgStreak,
+      suffix: stats.avgStreak === 1 ? "day" : "days",
+    },
+  ];
+
+  return (
+    <div className="flex flex-wrap gap-x-10 gap-y-6">
+      {items.map((s) => (
+        <Stat key={s.label} label={s.label} value={s.value} suffix={s.suffix} />
+      ))}
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  suffix,
+}: {
+  label: string;
+  value: number;
+  suffix?: string;
+}) {
+  return (
+    <div>
+      <div className="text-[11px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+        {label}
+      </div>
+      <div className="mt-1 text-3xl sm:text-4xl font-extrabold tracking-tight text-[var(--foreground)]">
+        <RollingNumber value={value} />
+        {suffix && (
+          <span className="ml-1.5 text-base font-bold text-[var(--text-muted)]">
+            {suffix}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const DIGITS = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
+
+/**
+ * A number whose digits roll to their new value.
+ *
+ * Each digit is a masked column holding 0-9, so a change is one transform per
+ * changed digit — 205 -> 206 rolls only the ones column, and nothing else on
+ * the strip moves. Layout and baseline come from a real, in-flow copy of the
+ * text (transparent, still readable by screen readers and still selectable);
+ * the columns are absolutely positioned over it, which is what keeps the
+ * masked boxes from dragging the baseline off the "days" suffix beside them.
+ *
+ * Columns are keyed from the right so the ones column keeps its identity when
+ * the number gains a digit (99 -> 100) and rolls instead of being remounted —
+ * which also gives each column its place in the cascade: the ones column moves
+ * first and each column left of it follows a beat later, the way a counter
+ * carries. Capped at four beats so a long number doesn't drag.
+ *
+ * A change also fires a one-shot lift on the whole figure, so an update that
+ * only moves the last digit (205 -> 206) still reads as an event.
+ */
+function RollingNumber({ value }: { value: number }) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const prev = useRef(value);
+
+  // The lift runs straight on the DOM node rather than through state: it's a
+  // one-shot flourish, so re-rendering the strip for it (twice — on and off)
+  // would be pure waste. Skipped on mount, since `prev` starts at `value`.
+  //
+  // Web Animations rather than a CSS class because the class has to be taken
+  // off again, and every signal for "it's over" is unreliable in a tab that
+  // isn't being painted: `animationend` never arrives there, and the class
+  // sticks. An Animation object owns its own lifetime and the cleanup cancels
+  // it, so a second update restarts the lift instead of stacking on it.
+  useEffect(() => {
+    if (prev.current === value) return;
+    prev.current = value;
+    const el = ref.current;
+    if (!el) return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+    const lift = el.animate(
+      [
+        { transform: "none" },
+        { transform: "translateY(-2px) scale(1.045)", offset: 0.35 },
+        { transform: "none" },
+      ],
+      // Duration and curve match the digit roll below (--ease-out), so the
+      // lift and the roll land together.
+      { duration: 600, easing: "cubic-bezier(0.23, 1, 0.32, 1)" }
+    );
+    return () => lift.cancel();
+  }, [value]);
+
+  const text = value.toLocaleString("en-US");
+  const chars = text.split("");
+
+  return (
+    <span className="stat-roll" ref={ref}>
+      <span className="stat-roll-ghost">{text}</span>
+      <span className="stat-roll-track" aria-hidden="true">
+        {chars.map((ch, i) => {
+          const fromRight = chars.length - 1 - i;
+          const digit = DIGITS.indexOf(ch);
+          if (digit === -1) {
+            return (
+              <span key={fromRight} className="stat-roll-sep">
+                {ch}
+              </span>
+            );
+          }
+          return (
+            <span key={fromRight} className="stat-roll-col">
+              <span
+                className="stat-roll-strip"
+                style={{
+                  transform: `translateY(-${digit * 10}%)`,
+                  transitionDelay: `${Math.min(fromRight, 3) * 45}ms`,
+                }}
+              >
+                {DIGITS.map((d) => (
+                  <span key={d} className="stat-roll-cell">
+                    {d}
+                  </span>
+                ))}
+              </span>
+            </span>
+          );
+        })}
+      </span>
+    </span>
+  );
+}

--- a/src/lib/supabase/server-queries.ts
+++ b/src/lib/supabase/server-queries.ts
@@ -419,11 +419,14 @@ async function _fetchHeroStats(): Promise<HeroStats> {
 
   // Throw rather than return zeros: unstable_cache would hold a strip reading
   // "0 builders tracked" for the full TTL, and the client keeps its last good
-  // numbers when the poll fails, which is the better failure.
-  if (buildersRes.error || projectsRes.error) {
-    throw new Error(
-      `Hero stats query failed: ${buildersRes.error?.message || ""} ${projectsRes.error?.message || ""}`.trim()
-    );
+  // numbers when the poll fails, which is the better failure. Every query
+  // counts here — each one is a figure on the strip, so a transient failure in
+  // any of them would otherwise be served as a confident zero.
+  const failed = [daysRes, longestRes, buildersRes, projectsRes, streakRes]
+    .map((res) => res.error?.message)
+    .filter(Boolean);
+  if (failed.length) {
+    throw new Error(`Hero stats query failed: ${failed.join("; ")}`);
   }
 
   const streaks = (streakRes.data ?? []) as { streak: number }[];

--- a/src/lib/supabase/server-queries.ts
+++ b/src/lib/supabase/server-queries.ts
@@ -379,3 +379,69 @@ async function _fetchProofWall(): Promise<ProofWallData> {
 export const fetchProofWallCached = unstable_cache(_fetchProofWall, ["proof-wall-v3"], {
   revalidate: 300,
 });
+
+// ---------------------------------------------------------------------------
+// Hero stats (the polled stat strip under the proof wall)
+// ---------------------------------------------------------------------------
+
+/**
+ * The five figures the homepage stat strip renders. They already exist on the
+ * SSR path, spread across `_fetchProofWall` (days / longest streak / builders)
+ * and `_fetchHomepageData` (projects / avg streak). This gathers exactly the
+ * same counts, with exactly the same filters, into one payload the client
+ * poller can refresh from — if the filters here drift from the ones above, the
+ * number a visitor lands on and the number they hold on would disagree.
+ */
+export interface HeroStats {
+  totalBuilderDays: number;
+  longestStreak: number;
+  buildersTracked: number;
+  totalProjects: number;
+  avgStreak: number;
+}
+
+async function _fetchHeroStats(): Promise<HeroStats> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const sb = getPublicClient() as any;
+
+  const [daysRes, longestRes, buildersRes, projectsRes, streakRes] = await Promise.all([
+    sb.from("streak_logs").select("*", { count: "exact", head: true }),
+    sb
+      .from("users")
+      .select("longest_streak")
+      .not("username", "is", null)
+      .order("longest_streak", { ascending: false })
+      .limit(1),
+    sb.from("users").select("id", { count: "exact", head: true }).not("username", "is", null),
+    sb.from("projects").select("id", { count: "exact", head: true }).eq("is_private", false),
+    sb.from("users").select("streak").not("username", "is", null),
+  ]);
+
+  // Throw rather than return zeros: unstable_cache would hold a strip reading
+  // "0 builders tracked" for the full TTL, and the client keeps its last good
+  // numbers when the poll fails, which is the better failure.
+  if (buildersRes.error || projectsRes.error) {
+    throw new Error(
+      `Hero stats query failed: ${buildersRes.error?.message || ""} ${projectsRes.error?.message || ""}`.trim()
+    );
+  }
+
+  const streaks = (streakRes.data ?? []) as { streak: number }[];
+  const avgStreak = streaks.length
+    ? Math.round(streaks.reduce((acc, u) => acc + (u.streak || 0), 0) / streaks.length)
+    : 0;
+
+  return {
+    totalBuilderDays: daysRes.count ?? 0,
+    longestStreak: longestRes.data?.[0]?.longest_streak ?? 0,
+    buildersTracked: buildersRes.count ?? 0,
+    totalProjects: projectsRes.count ?? 0,
+    avgStreak,
+  };
+}
+
+// 30s. This backs a 60s client poll on the busiest page on the site, so the TTL
+// is what keeps N concurrent visitors from becoming N x 5 Supabase queries.
+export const fetchHeroStatsCached = unstable_cache(_fetchHeroStats, ["hero-stats-v1"], {
+  revalidate: 30,
+});


### PR DESCRIPTION
The "Builders tracked" figure only moved when the visitor reloaded — the homepage is ISR-cached for 180s and the proof wall behind it for 300s, so a new signup sat invisible until something forced a fresh render.

## What changed

**It updates itself.** The stat strip is now a client component: server-rendered from the same counts on first paint (numbers stay in the HTML for crawlers, no empty flash), then it polls `/api/hero-stats` every 60s. The poll pauses while the tab is hidden and re-syncs on focus — the same contract the network feed uses, for the same reason: background tabs shouldn't burn Supabase egress on numbers nobody is looking at. A 30s cache on the query keeps N concurrent visitors from becoming N × 5 Supabase queries.

The endpoint gathers the five figures with exactly the filters the SSR path already uses (users with a username, non-private projects, all `streak_logs` rows), so the number a visitor lands on and the number they hold on can't disagree.

**A change rolls rather than swaps.** Each digit is a masked column holding 0–9, so `205 → 206` rolls only the ones column, and `199 → 200` cascades right to left at 45ms per column, the way a counter carries. The whole figure also lifts once (600ms, `--ease-out`) so a +1 reads as an event — deliberately motion and not colour, since the hero is single-colour above the fold and the only accent there is the primary button.

Layout and baseline come from a transparent, in-flow copy of the number, with the masked columns absolutely positioned over it — that's what keeps the masked boxes from dragging the baseline off the "days" suffix beside them.

`prefers-reduced-motion` drops the roll and the lift. `forced-colors` drops the animated track and leaves the plain number, since the forced palette would otherwise show the ghost through the digits.

## Verified

Drove a simulated update through the real poll path in the browser: values update, columns roll, and the rendered digits match the underlying value for all five stats afterwards. Geometry measured rather than eyeballed — the ghost's text box and the rolled digit's text box land on the same pixel, track width equals ghost width, and digits clear the mask by ~3.7px top / ~4px bottom at both breakpoints, so nothing shifted versus the current design. Checked dark and light, desktop and mobile.

`npm run test` → 667 passed · eslint on `src/` clean · `next build` clean.

## Note

For signed-in visitors the poll goes through `updateSession` in middleware like every other API route here, so those responses aren't edge-cacheable. Not new — the feed poller has the same shape at twice the rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live homepage hero statistics for builder days, longest streak, builders tracked, projects shipped, and average streak.
  * Statistics refresh automatically while the page is active and resync when returning to the tab.
  * Added animated number transitions with support for reduced-motion and high-contrast accessibility settings.
  * Added a public endpoint for retrieving aggregate hero statistics.

* **Bug Fixes**
  * Preserves the last known statistics when a refresh fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->