### PR TITLE
fix(bags): price the table, not the feed, so launches stop blanking each other

### DIFF
--- a/src/app/api/cron/bags-discover/route.ts
+++ b/src/app/api/cron/bags-discover/route.ts
@@ -5,7 +5,7 @@ import {
   fetchTokenCreators,
   fetchLaunchFeed,
 } from "@/lib/bags";
-import { fetchTokenMarket } from "@/lib/token-market";
+import { fetchTokenMarkets } from "@/lib/token-market";
 
 /**
  * Cron job: discover Bags launches we have no wallet for.
@@ -23,14 +23,102 @@ import { fetchTokenMarket } from "@/lib/token-market";
  */
 
 /**
- * How many confirmed launches get live market data in one run.
+ * How many stored launches get their market data refreshed in one run.
  *
- * GeckoTerminal's free tier rate-limits well below one call per launch, and
- * price is enrichment: a row without it still names a real launch and its
- * confirmed creator. Confirmation runs first, so this budget is only ever
- * spent on launches that survived it.
+ * This used to be a per-run budget of twenty, spent in feed order, and it was
+ * the reason the board rendered blank: the feed leads with the newest launches,
+ * which are exactly the ones with no pool to price yet, and every launch past
+ * the twentieth was written with null market columns that overwrote whatever an
+ * earlier run had found. Thirty mints per multi lookup makes a full refresh
+ * cost tens of requests rather than hundreds, so the budget is gone and the cap
+ * is only a guard rail. Rows are taken stalest-first, so a table that ever
+ * outgrows the cap still cycles instead of starving its tail.
  */
-const MARKET_ENRICH_LIMIT = 20;
+const MARKET_REFRESH_LIMIT = 1500;
+
+type MarketRefresh = {
+  /** Rows selected for refresh. */
+  considered: number;
+  /** Rows GeckoTerminal answered for, priced or not. */
+  refreshed: number;
+  /** Of those, how many it actually indexes. */
+  priced: number;
+};
+
+/**
+ * Re-price every stored launch, including the ones this run did not discover.
+ *
+ * Discovery only ever sees the current Bags feed, so a launch that scrolls off
+ * it would keep whatever price it had on the day it appeared. Pricing the table
+ * rather than the feed is what lets a row that missed out — or that had its
+ * columns blanked by the old budget — recover on the next run without a
+ * one-off backfill.
+ */
+async function refreshMarketData(
+  sb: ReturnType<typeof createAdminClient>,
+): Promise<MarketRefresh> {
+  const empty: MarketRefresh = { considered: 0, refreshed: 0, priced: 0 };
+
+  const { data, error } = await sb
+    .from("bags_launches")
+    .select("token_mint, creator_wallet")
+    // Never-priced rows first, then the stalest. At the current table size
+    // every row makes the cut on every run.
+    .order("market_synced_at", { ascending: true, nullsFirst: true })
+    .limit(MARKET_REFRESH_LIMIT);
+
+  if (error) {
+    console.error("bags-discover: market refresh select failed:", error.message);
+    return empty;
+  }
+
+  const rows = (data ?? []) as { token_mint: string; creator_wallet: string }[];
+  if (rows.length === 0) return empty;
+
+  const { markets, answered } = await fetchTokenMarkets(
+    rows.map((r) => r.token_mint),
+  );
+
+  const now = new Date().toISOString();
+  // Only rows GeckoTerminal answered for. A chunk that failed leaves its mints
+  // untouched, so an outage costs a refresh rather than wiping real prices.
+  const updates = rows
+    .filter((r) => answered.has(r.token_mint))
+    .map((r) => {
+      const market = markets.get(r.token_mint) ?? null;
+      return {
+        token_mint: r.token_mint,
+        // Carried so the upsert has every NOT NULL column it would need if a
+        // row vanished between the select and the write. Same value either way.
+        creator_wallet: r.creator_wallet,
+        // Null here is a finding, not a gap: GeckoTerminal was asked and does
+        // not index this mint, which is normal before a launch trades.
+        token_image_url: market?.imageUrl ?? null,
+        fdv_usd: market?.fdvUsd ?? null,
+        volume_24h_usd: market?.volume24hUsd ?? null,
+        market_synced_at: now,
+      };
+    });
+
+  if (updates.length === 0) return { ...empty, considered: rows.length };
+
+  // Columns absent from the payload are left alone by the conflict update, so
+  // this cannot disturb user_id, the Bags identity fields or last_verified_at.
+  const { error: writeError } = await sb
+    .from("bags_launches")
+    .upsert(updates, { onConflict: "token_mint" });
+
+  if (writeError) {
+    console.error("bags-discover: market refresh write failed:", writeError.message);
+    return { ...empty, considered: rows.length };
+  }
+
+  return {
+    considered: rows.length,
+    refreshed: updates.length,
+    priced: updates.filter((u) => u.fdv_usd !== null).length,
+  };
+}
 
 export async function GET(req: NextRequest) {
   const cronSecret = process.env.CRON_SECRET;
@@ -102,8 +190,6 @@ export async function GET(req: NextRequest) {
     );
   }
 
-  let enriched = 0;
-
   for (const launch of feed) {
     if (processed.has(launch.tokenMint)) continue;
     processed.add(launch.tokenMint);
@@ -131,14 +217,6 @@ export async function GET(req: NextRequest) {
     const wallet = creator.wallet as string;
     const userId = walletToUser.get(wallet);
 
-    // Only for launches that already passed confirmation, and only up to the
-    // budget. A brand new PRE_GRAD token usually has no pool to price anyway.
-    const withinBudget = enriched < MARKET_ENRICH_LIMIT;
-    const market = withinBudget
-      ? await fetchTokenMarket(launch.tokenMint)
-      : null;
-    if (withinBudget) enriched += 1;
-
     // Names and tickers are whatever the launcher minted. Stored raw and
     // sanitised where they are rendered, so the record stays faithful and a
     // change to the sanitiser needs no re-sync.
@@ -155,13 +233,12 @@ export async function GET(req: NextRequest) {
         typeof creator.royaltyBps === "number" ? creator.royaltyBps : 0,
       token_name: launch.name,
       token_symbol: launch.symbol,
-      // Artwork from GeckoTerminal, never from the feed: see fetchLaunchFeed.
-      token_image_url: market?.imageUrl ?? null,
-      fdv_usd: market?.fdvUsd ?? null,
-      volume_24h_usd: market?.volume24hUsd ?? null,
-      market_synced_at: new Date().toISOString(),
       last_verified_at: new Date().toISOString(),
     };
+
+    // No market columns here, deliberately. Discovery answers "who launched
+    // this"; pricing is a separate pass over the whole table. Writing both from
+    // one loop is what let an unpriced launch blank a priced one.
 
     // user_id is written ONLY when a proved wallet matches. Omitting the key
     // leaves an existing claim untouched, so a discovery pass can never unclaim
@@ -184,11 +261,14 @@ export async function GET(req: NextRequest) {
     if (userId) claimed += 1;
   }
 
+  const market = await refreshMarketData(sb);
+
   return NextResponse.json({
     seen,
     written,
     claimed,
     unattributable,
     lookupFailed,
+    market,
   });
 }

--- a/src/lib/__tests__/token-market.test.ts
+++ b/src/lib/__tests__/token-market.test.ts
@@ -6,6 +6,7 @@ import {
   fetchDailyCloses,
   changePct,
   fetchBagsDexPools,
+  fetchTokenMarkets,
 } from "@/lib/token-market";
 
 const MINT = "FfDYT3WqimMw7itMxw4kYJ26GPG78RfpZmepQCFpBAGS";
@@ -92,6 +93,59 @@ describe("fetchTokenMarket", () => {
       graduated: false,
       poolAddress: null,
     });
+  });
+});
+
+describe("fetchTokenMarkets", () => {
+  function multiEntry(address: string, fdv: string) {
+    return {
+      attributes: {
+        address,
+        name: address,
+        symbol: address.slice(0, 4),
+        fdv_usd: fdv,
+        volume_usd: { h24: "1.5" },
+      },
+    };
+  }
+
+  it("keys results by the mint on the payload, not request order", async () => {
+    mockFetch({ data: [multiEntry("BBB", "20"), multiEntry("AAA", "10")] });
+
+    const { markets } = await fetchTokenMarkets(["AAA", "BBB"]);
+
+    expect(markets.get("AAA")?.fdvUsd).toBe(10);
+    expect(markets.get("BBB")?.fdvUsd).toBe(20);
+  });
+
+  it("splits requests into chunks of thirty", async () => {
+    const mints = Array.from({ length: 61 }, (_, i) => `M${i}`);
+    const fetchMock = mockFetch({ data: [] });
+
+    const { answered } = await fetchTokenMarkets(mints);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(answered.size).toBe(61);
+  });
+
+  it("answers for a mint it does not index, so the caller may store the null", async () => {
+    mockFetch({ data: [multiEntry("AAA", "10")] });
+
+    const { markets, answered } = await fetchTokenMarkets(["AAA", "BBB"]);
+
+    expect(markets.has("BBB")).toBe(false);
+    expect(answered.has("BBB")).toBe(true);
+  });
+
+  it("leaves a failed chunk unanswered rather than reporting it as empty", async () => {
+    mockFetch({}, { ok: false, status: 429 });
+
+    const { markets, answered } = await fetchTokenMarkets(["AAA", "BBB"]);
+
+    expect(markets.size).toBe(0);
+    // The distinction the refresh pass depends on: nothing was learned here, so
+    // these mints must keep whatever prices they already had.
+    expect(answered.size).toBe(0);
   });
 });
 

--- a/src/lib/__tests__/token-market.test.ts
+++ b/src/lib/__tests__/token-market.test.ts
@@ -137,6 +137,28 @@ describe("fetchTokenMarkets", () => {
     expect(answered.has("BBB")).toBe(true);
   });
 
+  it("stops issuing chunks once the batch deadline passes", async () => {
+    // Every call fails slowly, the way a GeckoTerminal outage does. Without a
+    // deadline the caller would wait out all seven chunks.
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      vi.advanceTimersByTime(30_000);
+      throw new Error("timeout");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.useFakeTimers();
+
+    const mints = Array.from({ length: 200 }, (_, i) => `M${i}`);
+    const { answered } = await fetchTokenMarkets(mints);
+
+    // 60s budget, 30s burned per attempt: it tries, then gives up well short of
+    // the seven chunks 200 mints would otherwise cost.
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(0);
+    expect(fetchMock.mock.calls.length).toBeLessThan(4);
+    expect(answered.size).toBe(0);
+
+    vi.useRealTimers();
+  });
+
   it("leaves a failed chunk unanswered rather than reporting it as empty", async () => {
     mockFetch({}, { ok: false, status: 429 });
 

--- a/src/lib/token-market.ts
+++ b/src/lib/token-market.ts
@@ -52,7 +52,13 @@ function toNumber(value: unknown): number | null {
 async function geckoGet(path: string): Promise<unknown | null> {
   try {
     const res = await fetch(`${GECKO_API_BASE}${path}`, {
-      headers: { Accept: "application/json" },
+      headers: {
+        Accept: "application/json",
+        // GeckoTerminal is a free, keyless API and rejects some default client
+        // agents outright. Identifying the caller is both the fix and the
+        // courtesy owed to an endpoint we are not paying for.
+        "User-Agent": "vibetalent/1.0 (+https://www.vibetalent.work)",
+      },
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       next: { revalidate: MARKET_REVALIDATE_S },
     });
@@ -65,21 +71,26 @@ async function geckoGet(path: string): Promise<unknown | null> {
 }
 
 /**
- * Name, artwork, price and pool for one mint.
+ * Turn one GeckoTerminal token object into a TokenMarket.
  *
- * Returns null when GeckoTerminal has never indexed the token, which is normal
- * for a launch that has not traded yet.
+ * Shared by the single and the multi lookup so both read the same fields the
+ * same way: a shape change upstream breaks one parser instead of two.
  */
-export async function fetchTokenMarket(
-  mint: string,
-): Promise<TokenMarket | null> {
-  const body = await geckoGet(
-    `/networks/${NETWORK}/tokens/${encodeURIComponent(mint)}`,
-  );
-  if (!isRecord(body) || !isRecord(body.data)) return null;
+function parseTokenMarket(
+  entry: unknown,
+  requestedMint: string | null,
+): TokenMarket | null {
+  if (!isRecord(entry)) return null;
 
-  const attrs = body.data.attributes;
+  const attrs = entry.attributes;
   if (!isRecord(attrs)) return null;
+
+  // The multi lookup returns tokens in no guaranteed order and omits any it
+  // does not index, so the mint has to come off the payload rather than off a
+  // caller's position in the request.
+  const address = typeof attrs.address === "string" ? attrs.address : null;
+  const mint = requestedMint ?? address;
+  if (!mint) return null;
 
   const launchpad = isRecord(attrs.launchpad_details)
     ? attrs.launchpad_details
@@ -87,7 +98,7 @@ export async function fetchTokenMarket(
 
   // The first related pool is the deepest one, which is the pool worth charting.
   let poolAddress: string | null = null;
-  const relationships = body.data.relationships;
+  const relationships = entry.relationships;
   if (isRecord(relationships) && isRecord(relationships.top_pools)) {
     const pools = relationships.top_pools.data;
     if (
@@ -114,6 +125,73 @@ export async function fetchTokenMarket(
     graduated: launchpad?.completed === true,
     poolAddress,
   };
+}
+
+/**
+ * Name, artwork, price and pool for one mint.
+ *
+ * Returns null when GeckoTerminal has never indexed the token, which is normal
+ * for a launch that has not traded yet.
+ */
+export async function fetchTokenMarket(
+  mint: string,
+): Promise<TokenMarket | null> {
+  const body = await geckoGet(
+    `/networks/${NETWORK}/tokens/${encodeURIComponent(mint)}`,
+  );
+  if (!isRecord(body)) return null;
+  return parseTokenMarket(body.data, mint);
+}
+
+/** GeckoTerminal accepts at most 30 addresses per multi lookup. */
+const MULTI_LOOKUP_CHUNK = 30;
+
+export type TokenMarketBatch = {
+  /** Market data for every requested mint GeckoTerminal indexes. */
+  markets: Map<string, TokenMarket>;
+  /**
+   * The mints GeckoTerminal actually answered for.
+   *
+   * A mint listed here but absent from `markets` is genuinely unindexed, which
+   * is a fact worth storing. A mint in neither belongs to a chunk whose request
+   * failed, and nothing may be concluded about it — the same "could not ask"
+   * versus "asked, and there is genuinely nothing" split the Bags client keeps.
+   */
+  answered: Set<string>;
+};
+
+/**
+ * Market data for many mints, thirty per request.
+ *
+ * The single lookup costs one request per mint, which is why the discovery cron
+ * could only afford to price a handful of launches per run. This prices a whole
+ * table of them in a couple of dozen requests.
+ */
+export async function fetchTokenMarkets(
+  mints: readonly string[],
+): Promise<TokenMarketBatch> {
+  const markets = new Map<string, TokenMarket>();
+  const answered = new Set<string>();
+
+  for (let i = 0; i < mints.length; i += MULTI_LOOKUP_CHUNK) {
+    const chunk = mints.slice(i, i + MULTI_LOOKUP_CHUNK);
+    const body = await geckoGet(
+      `/networks/${NETWORK}/tokens/multi/${chunk
+        .map(encodeURIComponent)
+        .join(",")}?include=top_pools`,
+    );
+    // A failed chunk leaves its mints out of `answered`, so a caller keeps what
+    // it already had for them instead of blanking the lot on an outage.
+    if (!isRecord(body) || !Array.isArray(body.data)) continue;
+
+    for (const mint of chunk) answered.add(mint);
+    for (const entry of body.data) {
+      const market = parseTokenMarket(entry, null);
+      if (market) markets.set(market.mint, market);
+    }
+  }
+
+  return { markets, answered };
 }
 
 /**

--- a/src/lib/token-market.ts
+++ b/src/lib/token-market.ts
@@ -146,6 +146,17 @@ export async function fetchTokenMarket(
 /** GeckoTerminal accepts at most 30 addresses per multi lookup. */
 const MULTI_LOOKUP_CHUNK = 30;
 
+/**
+ * Wall-clock budget for a whole batch, across every chunk.
+ *
+ * Chunks are sequential and each one can burn REQUEST_TIMEOUT_MS before it
+ * fails, so an outage would otherwise cost the caller eight seconds per chunk
+ * for as many chunks as it asked for — minutes, for a caller refreshing a whole
+ * table. Healthy runs finish far inside this; it only ever bites during an
+ * outage, which is exactly when the caller should stop asking.
+ */
+const BATCH_DEADLINE_MS = 60_000;
+
 export type TokenMarketBatch = {
   /** Market data for every requested mint GeckoTerminal indexes. */
   markets: Map<string, TokenMarket>;
@@ -173,7 +184,15 @@ export async function fetchTokenMarkets(
   const markets = new Map<string, TokenMarket>();
   const answered = new Set<string>();
 
+  const deadline = Date.now() + BATCH_DEADLINE_MS;
+
   for (let i = 0; i < mints.length; i += MULTI_LOOKUP_CHUNK) {
+    // Abandoning the rest costs nothing: their mints stay out of `answered`,
+    // which already means "not asked", so the caller keeps what it had for them
+    // and picks them up next run. Stalest-first ordering means the ones skipped
+    // here are the ones asked about first next time.
+    if (Date.now() > deadline) break;
+
     const chunk = mints.slice(i, i + MULTI_LOOKUP_CHUNK);
     const body = await geckoGet(
       `/networks/${NETWORK}/tokens/multi/${chunk


### PR DESCRIPTION
## The bug

`bags-discover` ran discovery and pricing in one loop. It priced the first 20 feed entries, then wrote `fdv_usd: null, volume_24h_usd: null, token_image_url: null` for **every launch past the twentieth** — and the upsert applied those nulls over rows an earlier run had already priced.

Two runs in, the board was blank: **5 of 351 rows had an FDV, 2 had artwork.**

The budget was also spent in feed order, and the feed leads with the newest launches — exactly the pre-graduation tokens with no pool to price yet. The comment above the call said so; the code did it anyway.

Verified against a live row before the fix: mint `4HEDHDHk…BAGS` (KOBRA) was null in the table while GeckoTerminal returned `fdv_usd = 3063.33` plus artwork and a pool for it.

## The fix

**Discovery writes identity only.** Who launched what, nothing else.

**Pricing is its own pass over the whole table**, stalest-first — so a launch that scrolls off the feed still gets refreshed, and a row that was blanked recovers on the next run with no one-off backfill needed. GeckoTerminal's multi lookup takes 30 mints per request, turning 351 calls into 12 and removing the reason a budget existed at all. `MARKET_REFRESH_LIMIT` is now just a guard rail against future growth.

**`fetchTokenMarkets` returns `answered` alongside `markets`.** A mint that was asked about but is unindexed gets its null stored — that is a finding. A mint whose chunk request *failed* is left alone. Without that split, one outage would wipe every price on the table. Same "could not ask" vs "asked, genuinely nothing" discipline `lib/bags.ts` already keeps.

It earned its keep immediately: the first backfill attempt hit 403s and wrote **nothing**, rather than blanking 351 rows.

**`geckoGet` now sends a `User-Agent`.** GeckoTerminal rejects some default client agents outright; it is a free keyless API and we owe it identification either way.

## Production backfill (already applied)

| | before | after |
|---|---|---|
| rows with FDV | 5 | **93** |
| rows with artwork | 2 | **133** |
| trading in 24h | — | **16** |
| summed 24h volume | \$3,555 | **\$11,158** |
| top FDV | — | **\$57,585** |

Unchanged, as intended: `user_id` 1, `bags_username` 170, `token_symbol` 350. The refresh payload carries only the four market columns, so the conflict update cannot reach identity or claims.

Live on prod — rows that were blank now read `\$HORSES by registonk · \$2.34K 24h vol · \$5.16K fdv`.

## Notes

- `bags-sync` was checked for the same bug class. It never writes market columns, so it was unaffected.
- Artwork stays sparse (133/351) — GeckoTerminal genuinely has none for the rest. That needs a UI fallback, not a fix.
- Only 93 of 335 indexed tokens have an FDV; the rest are pre-graduation with no pool. Good argument for putting the on-chain safety checklist at the centre of the creator pages, since `mint_authority` / `freeze_authority` / `developer_holding_percentage` come back even for tokens with no price.

## Testing

671 tests pass (4 new, covering chunking, payload-keyed results, unindexed mints, and the failed-chunk case). `eslint src` clean. `tsc --noEmit` clean apart from two pre-existing `worker.ts` errors on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Market pricing is now refreshed across a broader set of launches, prioritizing entries with the oldest data.
  - Pricing updates use batched market lookups, improving efficiency and supporting more complete refreshes.
  - Market refresh results now report how many entries were reviewed, updated, and successfully priced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->