### PR TITLE
fix(bags): size the market refresh to the rate limit, not to the table

### DIFF
--- a/src/app/api/cron/bags-discover/route.ts
+++ b/src/app/api/cron/bags-discover/route.ts
@@ -25,16 +25,21 @@ import { fetchTokenMarkets } from "@/lib/token-market";
 /**
  * How many stored launches get their market data refreshed in one run.
  *
- * This used to be a per-run budget of twenty, spent in feed order, and it was
- * the reason the board rendered blank: the feed leads with the newest launches,
- * which are exactly the ones with no pool to price yet, and every launch past
- * the twentieth was written with null market columns that overwrote whatever an
- * earlier run had found. Thirty mints per multi lookup makes a full refresh
- * cost tens of requests rather than hundreds, so the budget is gone and the cap
- * is only a guard rail. Rows are taken stalest-first, so a table that ever
- * outgrows the cap still cycles instead of starving its tail.
+ * This used to be a budget of twenty spent in feed order, and it was the reason
+ * the board rendered blank: the feed leads with the newest launches, which are
+ * exactly the ones with no pool to price yet, and every launch past the
+ * twentieth was written with null market columns that overwrote whatever an
+ * earlier run had found.
+ *
+ * Sized to the free tier rather than to the table. Measured, GeckoTerminal
+ * accepts about five multi lookups before it starts refusing, and once refused
+ * it keeps refusing however slowly you ask — so a run that reaches for all 400
+ * rows gets one chunk's worth and thirteen rejections, which is what the first
+ * deploy did. Five chunks is what actually lands. Rows are taken stalest-first
+ * and the cron runs every six hours, so the table still cycles in well under a
+ * day, and the /bags pages spend from the same limit.
  */
-const MARKET_REFRESH_LIMIT = 1500;
+const MARKET_REFRESH_LIMIT = 150;
 
 type MarketRefresh = {
   /** Rows selected for refresh. */

--- a/src/lib/__tests__/token-market.test.ts
+++ b/src/lib/__tests__/token-market.test.ts
@@ -137,26 +137,43 @@ describe("fetchTokenMarkets", () => {
     expect(answered.has("BBB")).toBe(true);
   });
 
+  it("stops at a rate limit instead of grinding through the rest", async () => {
+    // One good chunk, then the window closes. Every later call would fail too,
+    // so the loop must not spend them.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ data: [] }) })
+      .mockResolvedValue({ ok: false, status: 429, json: async () => ({}) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const mints = Array.from({ length: 150 }, (_, i) => `M${i}`);
+    const { answered } = await fetchTokenMarkets(mints);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // Only the chunk that actually answered; the rest keep whatever they had.
+    expect(answered.size).toBe(30);
+  });
+
   it("stops issuing chunks once the batch deadline passes", async () => {
-    // Every call fails slowly, the way a GeckoTerminal outage does. Without a
-    // deadline the caller would wait out all seven chunks.
+    // A slow outage: each attempt burns 90s of wall clock before failing. Real
+    // timers stay in play (the loop paces itself between chunks), so the clock
+    // is driven directly rather than with fake timers.
+    let clock = 1_000_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => clock);
     const fetchMock = vi.fn().mockImplementation(async () => {
-      vi.advanceTimersByTime(30_000);
+      clock += 90_000;
       throw new Error("timeout");
     });
     vi.stubGlobal("fetch", fetchMock);
-    vi.useFakeTimers();
 
     const mints = Array.from({ length: 200 }, (_, i) => `M${i}`);
     const { answered } = await fetchTokenMarkets(mints);
 
-    // 60s budget, 30s burned per attempt: it tries, then gives up well short of
-    // the seven chunks 200 mints would otherwise cost.
-    expect(fetchMock.mock.calls.length).toBeGreaterThan(0);
-    expect(fetchMock.mock.calls.length).toBeLessThan(4);
+    // One attempt blows the 60s budget, so the other six chunks are never sent.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(answered.size).toBe(0);
 
-    vi.useRealTimers();
+    nowSpy.mockRestore();
   });
 
   it("leaves a failed chunk unanswered rather than reporting it as empty", async () => {

--- a/src/lib/token-market.ts
+++ b/src/lib/token-market.ts
@@ -211,13 +211,14 @@ export async function fetchTokenMarkets(
   const deadline = Date.now() + BATCH_DEADLINE_MS;
 
   for (let i = 0; i < mints.length; i += MULTI_LOOKUP_CHUNK) {
-    // Abandoning the rest costs nothing: their mints stay out of `answered`,
-    // which already means "not asked", so the caller keeps what it had for them
-    // and picks them up next run. Stalest-first ordering means the ones skipped
-    // here are the ones asked about first next time.
-    if (Date.now() > deadline) break;
-
     if (i > 0) await new Promise((r) => setTimeout(r, CHUNK_PACING_MS));
+
+    // Checked after the pacing delay, since the wait itself can be what pushes
+    // the run past the deadline. Abandoning the rest costs nothing: their mints
+    // stay out of `answered`, which already means "not asked", so the caller
+    // keeps what it had for them and picks them up next run — stalest-first
+    // ordering asks about the ones skipped here first next time.
+    if (Date.now() > deadline) break;
 
     const chunk = mints.slice(i, i + MULTI_LOOKUP_CHUNK);
     const { body, status } = await geckoGetWithStatus(

--- a/src/lib/token-market.ts
+++ b/src/lib/token-market.ts
@@ -49,7 +49,16 @@ function toNumber(value: unknown): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-async function geckoGet(path: string): Promise<unknown | null> {
+/** HTTP 429. Worth naming: it is the one failure a caller must not retry into. */
+const RATE_LIMITED = 429;
+
+type GeckoResult = { body: unknown | null; status: number | null };
+
+/**
+ * As geckoGet, but reporting the status so a batch caller can tell a rate limit
+ * apart from an ordinary miss. `status: null` means the request never completed.
+ */
+async function geckoGetWithStatus(path: string): Promise<GeckoResult> {
   try {
     const res = await fetch(`${GECKO_API_BASE}${path}`, {
       headers: {
@@ -62,12 +71,16 @@ async function geckoGet(path: string): Promise<unknown | null> {
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       next: { revalidate: MARKET_REVALIDATE_S },
     });
-    if (!res.ok) return null;
-    return await res.json();
+    if (!res.ok) return { body: null, status: res.status };
+    return { body: await res.json(), status: res.status };
   } catch {
     // Timeout, network failure, or malformed JSON. All mean the same thing here.
-    return null;
+    return { body: null, status: null };
   }
+}
+
+async function geckoGet(path: string): Promise<unknown | null> {
+  return (await geckoGetWithStatus(path)).body;
 }
 
 /**
@@ -157,6 +170,17 @@ const MULTI_LOOKUP_CHUNK = 30;
  */
 const BATCH_DEADLINE_MS = 60_000;
 
+/**
+ * Breathing room between chunks.
+ *
+ * Not enough on its own to stay under the free tier's limit — measured, a burst
+ * trips it after about five calls and then keeps refusing regardless of how
+ * slowly you ask. Asking for less is the actual remedy, and the caller's slice
+ * size is where that happens. This only avoids being the rudest possible client
+ * on the way there.
+ */
+const CHUNK_PACING_MS = 1_000;
+
 export type TokenMarketBatch = {
   /** Market data for every requested mint GeckoTerminal indexes. */
   markets: Map<string, TokenMarket>;
@@ -193,12 +217,21 @@ export async function fetchTokenMarkets(
     // here are the ones asked about first next time.
     if (Date.now() > deadline) break;
 
+    if (i > 0) await new Promise((r) => setTimeout(r, CHUNK_PACING_MS));
+
     const chunk = mints.slice(i, i + MULTI_LOOKUP_CHUNK);
-    const body = await geckoGet(
+    const { body, status } = await geckoGetWithStatus(
       `/networks/${NETWORK}/tokens/multi/${chunk
         .map(encodeURIComponent)
         .join(",")}?include=top_pools`,
     );
+
+    // Once the window is exhausted every further call fails too, so grinding
+    // through the rest only burns the deadline for nothing. Stopping here is
+    // free: these mints stay out of `answered`, keep the prices they had, and
+    // sort to the front of the next run under stalest-first ordering.
+    if (status === RATE_LIMITED) break;
+
     // A failed chunk leaves its mints out of `answered`, so a caller keeps what
     // it already had for them instead of blanking the lot on an outage.
     if (!isRecord(body) || !Array.isArray(body.data)) continue;


### PR DESCRIPTION
Follow-up to #262. That PR fixed the wipe, and the instrumentation it added immediately caught the next problem in production.

## What the first deploy reported

```json
{"seen":100,"written":100,"claimed":0,"unattributable":0,"lookupFailed":0,
 "market":{"considered":412,"refreshed":30,"priced":8}}
```

It asked for fourteen chunks and got one. GeckoTerminal's free-tier window closes after roughly five multi lookups, and once closed it keeps refusing however slowly you ask.

Measured directly:

```
back-to-back, 6 calls:  [200, 200, 200, 200, 200, 429]
paced 3s,      6 calls:  [429, 429, 429, 429, 429, 429]
```

Pacing buys nothing once the window is shut. Asking for less is the only remedy.

## Changes

**Stop the batch on 429.** Continuing spends the remaining chunks on calls that cannot succeed and burns the deadline for nothing. Stopping is free: unasked mints stay out of `answered`, keep the prices they have, and sort to the front of the next run under stalest-first ordering. The rate limit becomes a natural stopping condition rather than something to fight.

**`MARKET_REFRESH_LIMIT` 1500 → 150**, sized to what actually lands in one run rather than to the table. The cron runs every six hours, so 412 rows still cycle in well under a day — and `/bags` ISR renders spend from the same budget, so the cron should not try to take all of it.

**One second of pacing between chunks.** It does not avoid the limit; it just avoids being the rudest possible client of a free, keyless API on the way there.

## Testing

673 pass. New test asserts the loop stops at the 429 rather than sending the remaining four chunks. The deadline test was reworked to drive `Date.now` directly — with pacing in the loop, fake timers left the pacing promise unresolved and the test hung.

`eslint src` clean, `tsc --noEmit` clean apart from the two pre-existing `worker.ts` errors on `main`.

## Verification plan

Merge, then trigger `bags-discover` manually and read the `market` block in the run log. Expect `refreshed` at or near 150 instead of 30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Market refreshes now process smaller batches, prioritizing the oldest entries.
  * Token market lookups pause between batches to reduce rate-limit issues.
  * Lookups stop promptly when the market service returns a rate-limit response.
* **Tests**
  * Added coverage for rate-limit handling and refined batch deadline verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->