### PR TITLE
feat(bags): price launches from the Actions runner, not the Worker

### DIFF
--- a/.github/workflows/bags-market.yml
+++ b/.github/workflows/bags-market.yml
@@ -1,0 +1,37 @@
+name: Bags market refresh
+
+# Prices the launches in bags_launches from the runner's own IP.
+#
+# The lookups cannot run on the Worker: GeckoTerminal rate-limits by IP and
+# Cloudflare's egress pool is shared, so the pass that used to live inside
+# /api/cron/bags-discover managed one chunk on its best run and zero on the two
+# after, while the identical call from a laptop returned 200. The runner has an
+# IP of its own, so it does the asking and posts the answers to
+# /api/cron/bags-market, which is where the writing (and its invariants) stays.
+on:
+  schedule:
+    # Every 6h, offset from bags-discover at :00 so a run prices what that pass
+    # has just discovered rather than racing it.
+    - cron: "20 8/6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: bags-market
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Refresh market data
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+          SITE_URL: https://www.vibetalent.work
+        run: node scripts/bags-market-refresh.mjs

--- a/.github/workflows/bags-market.yml
+++ b/.github/workflows/bags-market.yml
@@ -10,10 +10,17 @@ name: Bags market refresh
 # /api/cron/bags-market, which is where the writing (and its invariants) stays.
 on:
   schedule:
-    # Every 6h, offset from bags-discover at :00 so a run prices what that pass
-    # has just discovered rather than racing it.
-    - cron: "20 8/6 * * *"
+    # Every 6h, offset twenty minutes after bags-discover so a run prices what
+    # that pass has just discovered rather than racing it. Written out rather
+    # than as "20 2/6": a step expands only to the end of the field, so 8/6
+    # would give 08/14/20 and then nothing until the next morning.
+    - cron: "20 2,8,14,20 * * *"
   workflow_dispatch:
+
+# Only ever reads the repo to get the script; the work is done over HTTPS
+# against our own API with CRON_SECRET.
+permissions:
+  contents: read
 
 concurrency:
   group: bags-market
@@ -25,6 +32,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Nothing here uses git after checkout, so the token has no reason to
+          # stay in the local git config.
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -16,9 +16,12 @@ on:
     - cron: "30 5 * * *" # verify-backfill
     - cron: "0 15 * * 1,2" # weekly-digest (Mon + Tue)
     - cron: "30 7 * * *" # bags-sync — after the 06:00 daily fan-out has settled
-    - cron: "0 8/6 * * *" # bags-discover — every 6h: the feed holds only the 100
-      # most recent launches and does not paginate, so a daily run would miss
-      # everything beyond the last 100 whenever Bags is busy.
+    - cron: "0 2,8,14,20 * * *" # bags-discover — every 6h: the feed holds only
+      # the 100 most recent launches and does not paginate, so a daily run would
+      # miss everything beyond the last 100 whenever Bags is busy. Hours are
+      # written out because a step expands only to the end of the field: the
+      # "0 8/6 * * *" this replaces meant 08/14/20 and then a twelve-hour gap
+      # overnight, so it had been running three times a day, not four.
   workflow_dispatch:
     inputs:
       route:
@@ -45,7 +48,7 @@ jobs:
             "30 5 * * *")   ROUTE=verify-backfill ;;
             "0 15 * * 1,2") ROUTE=weekly-digest ;;
             "30 7 * * *")   ROUTE=bags-sync ;;
-            "0 8/6 * * *")  ROUTE=bags-discover ;;
+            "0 2,8,14,20 * * *") ROUTE=bags-discover ;;
             *)              ROUTE="${{ github.event.inputs.route }}" ;;
           esac
           echo "route=$ROUTE" >> "$GITHUB_OUTPUT"

--- a/scripts/admin/debug-set-prices.ts
+++ b/scripts/admin/debug-set-prices.ts
@@ -1,0 +1,158 @@
+/**
+ * Debug why setPrices() is reverting. Probes the contract via eth_call
+ * (no gas spent, no tx) with a variety of inputs to narrow down what
+ * validation is failing.
+ */
+import { createPublicClient, http, encodeFunctionData, parseAbi, decodeErrorResult, formatUnits } from "viem";
+import { base } from "viem/chains";
+
+const CONTRACT = "0x2cDB438f418f5cb53e8Ea87cFD981397FDe3d0da" as const;
+const OWNER = "0xc2599F1009669f4cdA7Ac2493De06D450Fc79EF9" as const;
+const RPC = "https://mainnet.base.org";
+
+const ABI = parseAbi([
+  "function setPrices(uint256, uint256, uint256, uint256, uint256)",
+  "function setPrices(uint256[5])",
+  "function setPrices(uint256[])",
+  "function getPrices() view returns (uint256, uint256, uint256, uint256, uint256)",
+  "function owner() view returns (address)",
+  "function paused() view returns (bool)",
+  "function PAUSED() view returns (bool)",
+]);
+
+const pub = createPublicClient({ chain: base, transport: http(RPC) });
+
+async function tryRead(name: "owner" | "paused" | "PAUSED" | "getPrices") {
+  try {
+    const r = await pub.readContract({ address: CONTRACT, abi: ABI, functionName: name });
+    return r;
+  } catch (e) {
+    return `(no ${name}: ${(e as Error).message.split("\n")[0]})`;
+  }
+}
+
+async function simulateSetPrices(label: string, args: bigint[] | [bigint[]] | [readonly [bigint, bigint, bigint, bigint, bigint]]) {
+  // Use a generic encoder fallback so we can test multiple ABI shapes.
+  let calldata: `0x${string}`;
+  try {
+    if (Array.isArray(args[0])) {
+      // setPrices(uint256[5]) or setPrices(uint256[])
+      calldata = encodeFunctionData({
+        abi: ABI,
+        functionName: "setPrices",
+        args: args as [readonly [bigint, bigint, bigint, bigint, bigint]],
+      });
+    } else {
+      calldata = encodeFunctionData({
+        abi: ABI,
+        functionName: "setPrices",
+        args: args as [bigint, bigint, bigint, bigint, bigint],
+      });
+    }
+  } catch (e) {
+    console.log(`  ${label.padEnd(40)} ENCODE-FAIL: ${(e as Error).message.split("\n")[0]}`);
+    return;
+  }
+  try {
+    await pub.call({ account: OWNER, to: CONTRACT, data: calldata });
+    console.log(`  ${label.padEnd(40)} ✅ would succeed (selector ${calldata.slice(0, 10)})`);
+  } catch (e) {
+    const err = e as { cause?: { data?: string }; shortMessage?: string; message?: string };
+    const data = err.cause?.data;
+    let reason = err.shortMessage || err.message?.split("\n")[0] || "unknown";
+    // Try to decode standard Error(string) revert
+    if (data && data.length > 10) {
+      try {
+        const decoded = decodeErrorResult({
+          abi: parseAbi(["error Error(string)"]),
+          data: data as `0x${string}`,
+        });
+        reason = `Error: ${decoded.args[0]}`;
+      } catch {
+        // Not a standard string revert — keep raw data
+        reason = `revert data: ${data.slice(0, 66)}`;
+      }
+    }
+    console.log(`  ${label.padEnd(40)} ❌ ${reason}`);
+  }
+}
+
+async function main() {
+  const owner = await tryRead("owner");
+  const paused = await tryRead("paused");
+  const paused2 = await tryRead("PAUSED");
+  const cur = await tryRead("getPrices");
+
+  console.log("\n── Contract state ──");
+  console.log(`  owner():     ${owner}`);
+  console.log(`  paused():    ${paused}`);
+  console.log(`  PAUSED():    ${paused2}`);
+  if (Array.isArray(cur)) {
+    console.log(`  getPrices(): [${cur.map((p) => "$" + formatUnits(p as bigint, 6)).join(", ")}]`);
+  } else {
+    console.log(`  getPrices(): ${cur}`);
+  }
+
+  console.log("\n── Probing setPrices(uint256,uint256,uint256,uint256,uint256) signatures ──");
+
+  const cur5 = Array.isArray(cur) ? (cur as bigint[]) : null;
+
+  // 1. Re-set the CURRENT prices (no-op) — should succeed if not paused / no other gating
+  if (cur5) {
+    await simulateSetPrices("set CURRENT prices (no-op)", cur5);
+  }
+
+  // 2. Slight bumps (small absolute increase)
+  if (cur5) {
+    const tinyBump = cur5.map((p) => p + BigInt(1)) as bigint[];
+    await simulateSetPrices("CURRENT + 1 microUSDC each", tinyBump);
+  }
+
+  // 3. 2x current
+  if (cur5) {
+    const doubled = cur5.map((p) => p * BigInt(2)) as bigint[];
+    await simulateSetPrices("CURRENT × 2", doubled);
+  }
+
+  // 4. Our target with monotonic gap (the prices we want)
+  await simulateSetPrices("TARGET 2/5/10/29/199 USDC", [
+    BigInt(2_000_000),
+    BigInt(5_000_000),
+    BigInt(10_000_000),
+    BigInt(29_000_000),
+    BigInt(199_000_000),
+  ]);
+
+  // 5. Same target but smaller jump (closer to current)
+  await simulateSetPrices("TARGET ×3 of current", [
+    BigInt(1_500_000), // $1.50
+    BigInt(3_000_000), // $3
+    BigInt(6_000_000), // $6
+    BigInt(15_000_000), // $15
+    BigInt(45_000_000), // $45
+  ]);
+
+  // 6. Even smaller bump
+  await simulateSetPrices("TARGET +50% each", [
+    BigInt(750_000),    // $0.75
+    BigInt(1_500_000),  // $1.50
+    BigInt(3_000_000),  // $3
+    BigInt(7_500_000),  // $7.50
+    BigInt(22_500_000), // $22.50
+  ]);
+
+  // 7. All zeros (often special-cased)
+  await simulateSetPrices("all zeros", Array(5).fill(BigInt(0)));
+
+  // 8. Try the array-shape ABI in case the contract expects a single array arg
+  console.log("\n── Probing setPrices(uint256[5]) signature ──");
+  await simulateSetPrices("array-arg target", [[
+    BigInt(2_000_000),
+    BigInt(5_000_000),
+    BigInt(10_000_000),
+    BigInt(29_000_000),
+    BigInt(199_000_000),
+  ]] as [readonly [bigint, bigint, bigint, bigint, bigint]]);
+}
+
+main().catch(console.error);

--- a/scripts/admin/diagnose-identity.mjs
+++ b/scripts/admin/diagnose-identity.mjs
@@ -1,0 +1,152 @@
+// READ-ONLY diagnostic for the username/identity bug.
+//
+// Finds:
+//   [A] Duplicate auth identities — same email → more than one auth.users row.
+//       The person can log in as either; logging in as the one WITHOUT a profile
+//       re-prompts them for a username (and their own name collides → 23505).
+//   [B] Orphaned profiles — public.users.id matches no current auth user, so the
+//       owner can never reach it by their auth.uid().
+//   + tries to match each orphan back to a live auth user by GitHub numeric id
+//     (tells us how many are auto-recoverable).
+//
+// No writes. Prints counts + small samples (usernames are public; emails masked).
+// Run: node scripts/admin/diagnose-identity.mjs
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { createClient } from "@supabase/supabase-js";
+
+function loadEnv(path) {
+  const out = {};
+  for (const line of readFileSync(path, "utf8").split("\n")) {
+    const t = line.trim();
+    if (!t || t.startsWith("#")) continue;
+    const i = t.indexOf("=");
+    if (i === -1) continue;
+    const k = t.slice(0, i).trim();
+    let v = t.slice(i + 1).trim();
+    if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
+      v = v.slice(1, -1);
+    }
+    out[k] = v;
+  }
+  return out;
+}
+
+const env = loadEnv(fileURLToPath(new URL("../../.env.local", import.meta.url)));
+const url = env.NEXT_PUBLIC_SUPABASE_URL;
+const key = env.SUPABASE_SERVICE_ROLE_KEY;
+if (!url || !key) {
+  console.error("Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in .env.local");
+  process.exit(1);
+}
+
+const sb = createClient(url, key, { auth: { persistSession: false } });
+
+const maskEmail = (e) => {
+  if (!e) return "(none)";
+  const [u, d] = e.split("@");
+  return d ? `${u.slice(0, 1)}***@${d}` : "***";
+};
+
+const ghIdOf = (user) => {
+  const gh = (user.identities || []).find((i) => i.provider === "github");
+  const raw = gh?.identity_data?.sub ?? gh?.identity_data?.provider_id ?? null;
+  return raw != null && /^\d+$/.test(String(raw)) ? Number(raw) : null;
+};
+
+const providersOf = (user) => {
+  const fromId = (user.identities || []).map((i) => i.provider);
+  if (fromId.length) return fromId.join("+");
+  const am = user.app_metadata?.providers || (user.app_metadata?.provider ? [user.app_metadata.provider] : []);
+  return am.length ? am.join("+") : "(none)";
+};
+
+// 1) Page through all auth users.
+const authUsers = [];
+for (let page = 1; ; page++) {
+  const { data, error } = await sb.auth.admin.listUsers({ page, perPage: 1000 });
+  if (error) { console.error("listUsers error:", error.message); process.exit(1); }
+  authUsers.push(...data.users);
+  if (data.users.length < 1000) break;
+}
+const authUidSet = new Set(authUsers.map((u) => u.id));
+const ghIdToAuth = new Map();
+for (const u of authUsers) { const g = ghIdOf(u); if (g != null) ghIdToAuth.set(g, u); }
+
+// Duplicate-email groups.
+const emailMap = new Map();
+for (const u of authUsers) {
+  const e = (u.email || "").toLowerCase();
+  if (!e) continue;
+  if (!emailMap.has(e)) emailMap.set(e, []);
+  emailMap.get(e).push(u);
+}
+const dupEmails = [...emailMap.entries()].filter(([, arr]) => arr.length > 1);
+
+// 2) Page through all public.users.
+const profiles = [];
+for (let from = 0; ; from += 1000) {
+  const { data, error } = await sb
+    .from("users")
+    .select("id, username, github_id, created_at")
+    .range(from, from + 999);
+  if (error) { console.error("users select error:", error.message); process.exit(1); }
+  profiles.push(...data);
+  if (data.length < 1000) break;
+}
+const profileIdSet = new Set(profiles.map((p) => p.id));
+const orphans = profiles.filter((p) => !authUidSet.has(p.id));
+
+console.log("\n================ IDENTITY DIAGNOSTIC (read-only) ================");
+console.log(`auth.users total:    ${authUsers.length}`);
+console.log(`public.users total:  ${profiles.length}`);
+
+// Of the duplicate-email groups, which leave the person stuck (some identities
+// have a profile, some don't)?
+const stuckDup = dupEmails.filter(([, arr]) => {
+  const withP = arr.filter((u) => profileIdSet.has(u.id)).length;
+  return withP >= 1 && withP < arr.length;
+});
+
+console.log(`\n[A] Duplicate auth identities (same email, >1 auth user): ${dupEmails.length} group(s)`);
+console.log(`    of which leave the person STUCK (one identity has the profile, another doesn't): ${stuckDup.length}`);
+for (const [email, arr] of dupEmails.slice(0, 20)) {
+  const withProfile = arr.filter((u) => profileIdSet.has(u.id)).length;
+  console.log(`   - ${maskEmail(email)}: ${arr.length} identities, ${withProfile} own a profile | providers: ${arr.map(providersOf).join(", ")}`);
+}
+if (dupEmails.length > 20) console.log(`   ... and ${dupEmails.length - 20} more`);
+
+console.log(`\n[B] Orphaned profiles (users.id matches no auth user): ${orphans.length}`);
+for (const p of orphans.slice(0, 30)) {
+  const match = p.github_id != null ? ghIdToAuth.get(Number(p.github_id)) : null;
+  const recover = match ? `recoverable → auth ${match.id.slice(0, 8)} (${maskEmail(match.email)})` : "no github_id match";
+  console.log(`   - @${p.username} (profile ${p.id.slice(0, 8)}, github_id ${p.github_id ?? "—"}) | ${recover}`);
+}
+if (orphans.length > 30) console.log(`   ... and ${orphans.length - 30} more`);
+
+// [C] Cross-identity by GitHub id: an auth user whose GitHub identity's numeric
+// id matches an existing profile owned by a DIFFERENT auth id. The person has a
+// profile under one identity but logs in under another → PGRST116 + their own
+// username "taken". The email-based [A] check misses this when the two
+// identities carry different emails (e.g. Google email ≠ GitHub email).
+const profileByGhId = new Map();
+for (const p of profiles) { if (p.github_id != null) profileByGhId.set(Number(p.github_id), p); }
+const shadow = [];
+for (const u of authUsers) {
+  const g = ghIdOf(u);
+  if (g == null) continue;
+  const p = profileByGhId.get(g);
+  if (p && p.id !== u.id) {
+    shadow.push({ authId: u.id, email: u.email, username: p.username, profileId: p.id, loginHasProfile: profileIdSet.has(u.id) });
+  }
+}
+console.log(`\n[C] Second identities matched by GitHub id (profile under a different auth id): ${shadow.length}`);
+for (const s of shadow.slice(0, 30)) {
+  console.log(`   - auth ${s.authId.slice(0, 8)} (${maskEmail(s.email)}) ↔ profile @${s.username} (owner ${s.profileId.slice(0, 8)}) | this login already has its own profile: ${s.loginHasProfile}`);
+}
+if (shadow.length > 30) console.log(`   ... and ${shadow.length - 30} more`);
+
+const recoverable = orphans.filter((p) => p.github_id != null && ghIdToAuth.has(Number(p.github_id))).length;
+console.log(`\nSummary: ${dupEmails.length} duplicate-email group(s) (${stuckDup.length} stuck), ${orphans.length} orphaned profile(s) (${recoverable} auto-recoverable via github_id).`);
+console.log("================================================================\n");

--- a/scripts/bags-market-refresh.mjs
+++ b/scripts/bags-market-refresh.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * Ask GeckoTerminal about the mints /api/cron/bags-market names, and post the
+ * answers back.
+ *
+ * WHY THIS RUNS ON THE RUNNER AND NOT IN THE ROUTE: GeckoTerminal rate-limits by
+ * IP, and the Worker egresses from Cloudflare's shared pool — the same lookup
+ * that answers 200 here answers 429 there. This script exists only to make the
+ * request from an IP that is ours, so it deliberately does no parsing: it
+ * forwards GeckoTerminal's own token objects and lets the route parse them with
+ * the function the rest of the codebase already uses.
+ *
+ * Env: SITE_URL, CRON_SECRET.
+ */
+
+const SITE = (process.env.SITE_URL || "https://www.vibetalent.work").replace(/\/$/, "");
+const SECRET = process.env.CRON_SECRET;
+const ENDPOINT = `${SITE}/api/cron/bags-market`;
+
+const GECKO = "https://api.geckoterminal.com/api/v2/networks/solana";
+/** GeckoTerminal accepts at most 30 addresses per multi lookup. */
+const CHUNK = 30;
+/** The free tier tolerates a burst and then refuses; this keeps us under it. */
+const PACING_MS = 4000;
+/** A rate limit is not worth retrying into — the window stays shut. */
+const RATE_LIMITED = 429;
+const UA = "vibetalent/1.0 (+https://www.vibetalent.work)";
+
+if (!SECRET) {
+  console.error("CRON_SECRET is not set");
+  process.exit(1);
+}
+
+const auth = { Authorization: `Bearer ${SECRET}` };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const listed = await fetch(ENDPOINT, { headers: auth });
+if (!listed.ok) {
+  console.error(`GET ${ENDPOINT} -> HTTP ${listed.status}`);
+  process.exit(1);
+}
+const { mints } = await listed.json();
+console.log(`mints to refresh: ${mints.length}`);
+
+const answered = [];
+const entries = [];
+
+for (let i = 0; i < mints.length; i += CHUNK) {
+  if (i > 0) await sleep(PACING_MS);
+
+  const chunk = mints.slice(i, i + CHUNK);
+  const url = `${GECKO}/tokens/multi/${chunk.map(encodeURIComponent).join(",")}?include=top_pools`;
+
+  let res;
+  try {
+    res = await fetch(url, {
+      headers: { Accept: "application/json", "User-Agent": UA },
+      signal: AbortSignal.timeout(15000),
+    });
+  } catch (err) {
+    console.log(`  chunk ${i / CHUNK}: request failed (${err.message}) — left untouched`);
+    continue;
+  }
+
+  // Once the window is shut every later call fails too, so stop rather than
+  // spend the rest. Unasked mints keep their prices and sort first next run.
+  if (res.status === RATE_LIMITED) {
+    console.log(`  chunk ${i / CHUNK}: rate limited — stopping here`);
+    break;
+  }
+  if (!res.ok) {
+    console.log(`  chunk ${i / CHUNK}: HTTP ${res.status} — left untouched`);
+    continue;
+  }
+
+  const body = await res.json();
+  const data = Array.isArray(body?.data) ? body.data : [];
+  answered.push(...chunk);
+  entries.push(...data);
+  console.log(`  chunk ${i / CHUNK}: asked ${chunk.length}, indexed ${data.length}`);
+}
+
+console.log(`answered ${answered.length}, entries ${entries.length}`);
+if (answered.length === 0) {
+  console.log("nothing to post");
+  process.exit(0);
+}
+
+const posted = await fetch(ENDPOINT, {
+  method: "POST",
+  headers: { ...auth, "Content-Type": "application/json" },
+  body: JSON.stringify({ answered, entries }),
+});
+const result = await posted.text();
+console.log(`POST -> HTTP ${posted.status} ${result.slice(0, 300)}`);
+if (!posted.ok) process.exit(1);

--- a/scripts/bags-market-refresh.mjs
+++ b/scripts/bags-market-refresh.mjs
@@ -73,7 +73,15 @@ for (let i = 0; i < mints.length; i += CHUNK) {
     continue;
   }
 
-  const body = await res.json();
+  // A 2xx carrying malformed JSON is still a failed chunk, not a failed run:
+  // letting it reject here would throw away every chunk already collected.
+  let body;
+  try {
+    body = await res.json();
+  } catch (err) {
+    console.log(`  chunk ${i / CHUNK}: unreadable body (${err.message}) — left untouched`);
+    continue;
+  }
   const data = Array.isArray(body?.data) ? body.data : [];
   answered.push(...chunk);
   entries.push(...data);

--- a/src/app/api/cron/bags-discover/route.ts
+++ b/src/app/api/cron/bags-discover/route.ts
@@ -5,7 +5,6 @@ import {
   fetchTokenCreators,
   fetchLaunchFeed,
 } from "@/lib/bags";
-import { fetchTokenMarkets } from "@/lib/token-market";
 
 /**
  * Cron job: discover Bags launches we have no wallet for.
@@ -23,107 +22,15 @@ import { fetchTokenMarkets } from "@/lib/token-market";
  */
 
 /**
- * How many stored launches get their market data refreshed in one run.
+ * Pricing lives in bags-market, not here.
  *
- * This used to be a budget of twenty spent in feed order, and it was the reason
- * the board rendered blank: the feed leads with the newest launches, which are
- * exactly the ones with no pool to price yet, and every launch past the
- * twentieth was written with null market columns that overwrote whatever an
- * earlier run had found.
- *
- * Sized to the free tier rather than to the table. Measured, GeckoTerminal
- * accepts about five multi lookups before it starts refusing, and once refused
- * it keeps refusing however slowly you ask — so a run that reaches for all 400
- * rows gets one chunk's worth and thirteen rejections, which is what the first
- * deploy did. Five chunks is what actually lands. Rows are taken stalest-first
- * and the cron runs every six hours, so the table still cycles in well under a
- * day, and the /bags pages spend from the same limit.
+ * It used to run in this loop, which is what let an unpriced launch blank a
+ * priced one. Splitting it out fixed that, but the pass still starved: it ran on
+ * the Worker, and GeckoTerminal rate-limits Cloudflare's shared egress, so it
+ * managed one chunk on its best run and none on the two after. It now runs from
+ * the GitHub Actions runner, which has an IP of its own, against
+ * /api/cron/bags-market. This route discovers; that one prices.
  */
-const MARKET_REFRESH_LIMIT = 150;
-
-type MarketRefresh = {
-  /** Rows selected for refresh. */
-  considered: number;
-  /** Rows GeckoTerminal answered for, priced or not. */
-  refreshed: number;
-  /** Of those, how many it actually indexes. */
-  priced: number;
-};
-
-/**
- * Re-price every stored launch, including the ones this run did not discover.
- *
- * Discovery only ever sees the current Bags feed, so a launch that scrolls off
- * it would keep whatever price it had on the day it appeared. Pricing the table
- * rather than the feed is what lets a row that missed out — or that had its
- * columns blanked by the old budget — recover on the next run without a
- * one-off backfill.
- */
-async function refreshMarketData(
-  sb: ReturnType<typeof createAdminClient>,
-): Promise<MarketRefresh> {
-  const empty: MarketRefresh = { considered: 0, refreshed: 0, priced: 0 };
-
-  const { data, error } = await sb
-    .from("bags_launches")
-    .select("token_mint, creator_wallet")
-    // Never-priced rows first, then the stalest. At the current table size
-    // every row makes the cut on every run.
-    .order("market_synced_at", { ascending: true, nullsFirst: true })
-    .limit(MARKET_REFRESH_LIMIT);
-
-  if (error) {
-    console.error("bags-discover: market refresh select failed:", error.message);
-    return empty;
-  }
-
-  const rows = (data ?? []) as { token_mint: string; creator_wallet: string }[];
-  if (rows.length === 0) return empty;
-
-  const { markets, answered } = await fetchTokenMarkets(
-    rows.map((r) => r.token_mint),
-  );
-
-  const now = new Date().toISOString();
-  // Only rows GeckoTerminal answered for. A chunk that failed leaves its mints
-  // untouched, so an outage costs a refresh rather than wiping real prices.
-  const updates = rows
-    .filter((r) => answered.has(r.token_mint))
-    .map((r) => {
-      const market = markets.get(r.token_mint) ?? null;
-      return {
-        token_mint: r.token_mint,
-        // Carried so the upsert has every NOT NULL column it would need if a
-        // row vanished between the select and the write. Same value either way.
-        creator_wallet: r.creator_wallet,
-        // Null here is a finding, not a gap: GeckoTerminal was asked and does
-        // not index this mint, which is normal before a launch trades.
-        token_image_url: market?.imageUrl ?? null,
-        fdv_usd: market?.fdvUsd ?? null,
-        volume_24h_usd: market?.volume24hUsd ?? null,
-        market_synced_at: now,
-      };
-    });
-
-  if (updates.length === 0) return { ...empty, considered: rows.length };
-
-  // Columns absent from the payload are left alone by the conflict update, so
-  // this cannot disturb user_id, the Bags identity fields or last_verified_at.
-  const { error: writeError } = await sb
-    .from("bags_launches")
-    .upsert(updates, { onConflict: "token_mint" });
-
-  if (writeError) {
-    console.error("bags-discover: market refresh write failed:", writeError.message);
-    return { ...empty, considered: rows.length };
-  }
-
-  return {
-    considered: rows.length,
-    refreshed: updates.length,
-    priced: updates.filter((u) => u.fdv_usd !== null).length,
-  };
-}
 
 export async function GET(req: NextRequest) {
   const cronSecret = process.env.CRON_SECRET;
@@ -266,14 +173,11 @@ export async function GET(req: NextRequest) {
     if (userId) claimed += 1;
   }
 
-  const market = await refreshMarketData(sb);
-
   return NextResponse.json({
     seen,
     written,
     claimed,
     unattributable,
     lookupFailed,
-    market,
   });
 }

--- a/src/app/api/cron/bags-market/route.ts
+++ b/src/app/api/cron/bags-market/route.ts
@@ -1,0 +1,168 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { parseTokenMarket, type TokenMarket } from "@/lib/token-market";
+import { buildMarketUpdates, type ExistingLaunch } from "@/lib/bags-market";
+
+/**
+ * Cron job: refresh the market data on stored Bags launches.
+ *
+ * WHY THIS IS TWO HALVES INSTEAD OF ONE ROUTE THAT JUST FETCHES: GeckoTerminal
+ * rate-limits by IP, and this Worker egresses from Cloudflare's shared pool. The
+ * same multi lookup that answers 200 from a laptop answers 429 here, so the
+ * refresh inside bags-discover was starving — one chunk on its best run, zero on
+ * the two after. The lookups therefore happen on the GitHub Actions runner that
+ * already schedules our crons, which has an IP of its own, and this route is the
+ * half that decides what to ask about and writes what comes back.
+ *
+ * GET  hands out the mints most in need of a refresh.
+ * POST takes the answers and stores them.
+ *
+ * Both are protected by CRON_SECRET.
+ */
+
+/**
+ * How many mints one run refreshes.
+ *
+ * Sized to cover the table in a single pass now that the caller is not fighting
+ * a shared rate limit. Still bounded: stalest-first ordering means a table that
+ * outgrows this cycles rather than starving its tail.
+ */
+const REFRESH_SLICE = 500;
+
+/** Guard rail on the POST body, which is parsed before anything is trusted. */
+const MAX_ENTRIES = 1000;
+
+function unauthorized(req: NextRequest): NextResponse | null {
+  const cronSecret = process.env.CRON_SECRET;
+  // Fail closed: this writes the table behind a public credibility claim.
+  if (!cronSecret && process.env.NODE_ENV === "production") {
+    console.error("CRON_SECRET is not configured");
+    return NextResponse.json(
+      { error: "Cron secret not configured" },
+      { status: 500 },
+    );
+  }
+  if (cronSecret && req.headers.get("authorization") !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  return null;
+}
+
+/** The mints worth asking about, never-priced first and then stalest. */
+export async function GET(req: NextRequest) {
+  const denied = unauthorized(req);
+  if (denied) return denied;
+
+  const sb = createAdminClient();
+  const { data, error } = await sb
+    .from("bags_launches")
+    .select("token_mint")
+    .order("market_synced_at", { ascending: true, nullsFirst: true })
+    .limit(REFRESH_SLICE);
+
+  if (error) {
+    console.error("bags-market: select failed:", error.message);
+    return NextResponse.json({ error: "Select failed" }, { status: 500 });
+  }
+
+  const mints = (data ?? []).map((r) => (r as { token_mint: string }).token_mint);
+  return NextResponse.json({ mints, count: mints.length });
+}
+
+/**
+ * Store what the runner got back.
+ *
+ * The body carries GeckoTerminal's own token objects, unmodified, so the parsing
+ * stays here in the function the single lookup already uses rather than being
+ * reimplemented in a shell script. `answered` is the list of mints the runner
+ * actually got a response for: a mint in it but absent from the entries was
+ * asked about and is genuinely unindexed, so its null is stored, while a mint
+ * missing from both was never successfully asked about and is left alone.
+ *
+ * NOTHING in the body may name a row that does not already exist, and nothing in
+ * it may set a column other than the four market ones. Both are enforced by
+ * reading the affected rows back out of our own table first: the identity that
+ * goes into the write is ours, and only the numbers come from the payload.
+ */
+export async function POST(req: NextRequest) {
+  const denied = unauthorized(req);
+  if (denied) return denied;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Malformed body" }, { status: 400 });
+  }
+
+  const payload = body as { answered?: unknown; entries?: unknown };
+  if (!Array.isArray(payload.answered) || !Array.isArray(payload.entries)) {
+    return NextResponse.json(
+      { error: "Expected { answered: string[], entries: object[] }" },
+      { status: 400 },
+    );
+  }
+  if (
+    payload.answered.length > MAX_ENTRIES ||
+    payload.entries.length > MAX_ENTRIES
+  ) {
+    return NextResponse.json({ error: "Body too large" }, { status: 413 });
+  }
+
+  const answered = new Set(
+    payload.answered.filter((m): m is string => typeof m === "string"),
+  );
+  if (answered.size === 0) {
+    return NextResponse.json({ considered: 0, refreshed: 0, priced: 0 });
+  }
+
+  const markets = new Map<string, TokenMarket>();
+  for (const entry of payload.entries) {
+    const market = parseTokenMarket(entry, null);
+    if (market) markets.set(market.mint, market);
+  }
+
+  const sb = createAdminClient();
+
+  // Identity comes from our own table, so a payload can neither invent a launch
+  // nor rewrite whose launch it is. Anything it names that is not already here
+  // is simply not written.
+  const { data: existing, error: readError } = await sb
+    .from("bags_launches")
+    .select("token_mint, creator_wallet")
+    .in("token_mint", [...answered]);
+
+  if (readError) {
+    console.error("bags-market: read-back failed:", readError.message);
+    return NextResponse.json({ error: "Read failed" }, { status: 500 });
+  }
+
+  const rows = (existing ?? []) as ExistingLaunch[];
+  if (rows.length === 0) {
+    return NextResponse.json({ considered: answered.size, refreshed: 0, priced: 0 });
+  }
+
+  const updates = buildMarketUpdates(
+    answered,
+    markets,
+    rows,
+    new Date().toISOString(),
+  );
+
+  // Columns absent from the payload are left alone by the conflict update, so
+  // this cannot disturb user_id, the Bags identity fields or last_verified_at.
+  const { error: writeError } = await sb
+    .from("bags_launches")
+    .upsert(updates, { onConflict: "token_mint" });
+
+  if (writeError) {
+    console.error("bags-market: write failed:", writeError.message);
+    return NextResponse.json({ error: "Write failed" }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    considered: answered.size,
+    refreshed: updates.length,
+    priced: updates.filter((u) => u.fdv_usd !== null).length,
+  });
+}

--- a/src/app/api/cron/bags-market/route.ts
+++ b/src/app/api/cron/bags-market/route.ts
@@ -95,6 +95,12 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Malformed body" }, { status: 400 });
   }
 
+  // `null` parses as valid JSON, so this has to be checked before any property
+  // is read off it.
+  if (typeof body !== "object" || body === null) {
+    return NextResponse.json({ error: "Malformed body" }, { status: 400 });
+  }
+
   const payload = body as { answered?: unknown; entries?: unknown };
   if (!Array.isArray(payload.answered) || !Array.isArray(payload.entries)) {
     return NextResponse.json(

--- a/src/lib/__tests__/bags-market.test.ts
+++ b/src/lib/__tests__/bags-market.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+
+import { buildMarketUpdates, type ExistingLaunch } from "@/lib/bags-market";
+import type { TokenMarket } from "@/lib/token-market";
+
+const NOW = "2026-09-07T12:00:00.000Z";
+
+function market(mint: string, over: Partial<TokenMarket> = {}): TokenMarket {
+  return {
+    mint,
+    name: "Token",
+    symbol: "TKN",
+    imageUrl: "https://assets.geckoterminal.com/img",
+    priceUsd: 0.001,
+    fdvUsd: 1000,
+    volume24hUsd: 25,
+    graduationPct: null,
+    graduated: false,
+    poolAddress: null,
+    ...over,
+  };
+}
+
+const EXISTING: ExistingLaunch[] = [
+  { token_mint: "AAA", creator_wallet: "wallet-a" },
+  { token_mint: "BBB", creator_wallet: "wallet-b" },
+];
+
+describe("buildMarketUpdates", () => {
+  it("writes the market data for a mint that was asked about and indexed", () => {
+    const updates = buildMarketUpdates(
+      new Set(["AAA"]),
+      new Map([["AAA", market("AAA")]]),
+      EXISTING,
+      NOW,
+    );
+
+    expect(updates).toEqual([
+      {
+        token_mint: "AAA",
+        creator_wallet: "wallet-a",
+        token_image_url: "https://assets.geckoterminal.com/img",
+        fdv_usd: 1000,
+        volume_24h_usd: 25,
+        market_synced_at: NOW,
+      },
+    ]);
+  });
+
+  it("stores nulls for a mint that was asked about but is unindexed", () => {
+    const updates = buildMarketUpdates(
+      new Set(["AAA"]),
+      new Map(),
+      EXISTING,
+      NOW,
+    );
+
+    // Asked, and there is genuinely nothing — a finding worth recording.
+    expect(updates).toHaveLength(1);
+    expect(updates[0].fdv_usd).toBeNull();
+    expect(updates[0].token_image_url).toBeNull();
+  });
+
+  it("leaves a mint that was never answered for entirely alone", () => {
+    const updates = buildMarketUpdates(
+      new Set(["AAA"]),
+      new Map([["AAA", market("AAA")]]),
+      EXISTING,
+      NOW,
+    );
+
+    // BBB was not answered for, so it keeps whatever price it already had.
+    expect(updates.map((u) => u.token_mint)).toEqual(["AAA"]);
+  });
+
+  it("cannot invent a launch that is not already in the table", () => {
+    const updates = buildMarketUpdates(
+      new Set(["AAA", "EVIL"]),
+      new Map([
+        ["AAA", market("AAA")],
+        ["EVIL", market("EVIL")],
+      ]),
+      EXISTING,
+      NOW,
+    );
+
+    expect(updates.map((u) => u.token_mint)).toEqual(["AAA"]);
+  });
+
+  it("takes the creator wallet from our table, never from the answer", () => {
+    const impersonating = market("AAA");
+    // Whatever a payload carries, identity is read back out of our own row.
+    const updates = buildMarketUpdates(
+      new Set(["AAA"]),
+      new Map([["AAA", { ...impersonating, mint: "AAA" }]]),
+      [{ token_mint: "AAA", creator_wallet: "wallet-a" }],
+      NOW,
+    );
+
+    expect(updates[0].creator_wallet).toBe("wallet-a");
+  });
+
+  it("writes only the four market columns plus the row's own identity", () => {
+    const updates = buildMarketUpdates(
+      new Set(["AAA"]),
+      new Map([["AAA", market("AAA")]]),
+      EXISTING,
+      NOW,
+    );
+
+    // user_id, bags_username, token_symbol and last_verified_at must never
+    // appear here: the conflict update only touches keys in the payload.
+    expect(Object.keys(updates[0]).sort()).toEqual([
+      "creator_wallet",
+      "fdv_usd",
+      "market_synced_at",
+      "token_image_url",
+      "token_mint",
+      "volume_24h_usd",
+    ]);
+  });
+});

--- a/src/lib/bags-market.ts
+++ b/src/lib/bags-market.ts
@@ -1,0 +1,69 @@
+// Turning a market-refresh answer into rows to write.
+//
+// WHY THIS IS NOT INLINE IN THE ROUTE: the refresh is the one path where data
+// that came from outside decides what lands in bags_launches. The lookups run on
+// the GitHub Actions runner (GeckoTerminal rate-limits Cloudflare's shared
+// egress, so the Worker cannot do them), which means the numbers arrive over
+// HTTP rather than being fetched in-process. What may and may not come from that
+// payload is therefore a rule worth stating in one place and testing, rather
+// than an implicit property of a request handler.
+//
+// The rule: the payload supplies numbers, and nothing else. Every identity in a
+// written row is read back out of our own table first, so a refresh can neither
+// invent a launch nor change whose launch it is.
+
+import type { TokenMarket } from "@/lib/token-market";
+
+/** A row as it exists before the refresh — our identity for it, not theirs. */
+export type ExistingLaunch = {
+  token_mint: string;
+  creator_wallet: string;
+};
+
+/** Exactly the columns a refresh may write. */
+export type MarketUpdate = {
+  token_mint: string;
+  creator_wallet: string;
+  token_image_url: string | null;
+  fdv_usd: number | null;
+  volume_24h_usd: number | null;
+  market_synced_at: string;
+};
+
+/**
+ * The rows to upsert for one refresh.
+ *
+ * `answered` is what the runner actually got a response for. A mint in it but
+ * absent from `markets` was asked about and is genuinely unindexed, so its null
+ * is stored — that is a finding, not a gap. A mint in neither was never
+ * successfully asked about and is left out entirely, so it keeps the price it
+ * had and sorts to the front of the next run.
+ *
+ * A mint that is not already in `existing` produces nothing, whatever the
+ * payload claimed about it.
+ */
+export function buildMarketUpdates(
+  answered: ReadonlySet<string>,
+  markets: ReadonlyMap<string, TokenMarket>,
+  existing: readonly ExistingLaunch[],
+  now: string,
+): MarketUpdate[] {
+  const updates: MarketUpdate[] = [];
+
+  for (const row of existing) {
+    if (!answered.has(row.token_mint)) continue;
+
+    const market = markets.get(row.token_mint) ?? null;
+    updates.push({
+      token_mint: row.token_mint,
+      // From our table, never from the payload.
+      creator_wallet: row.creator_wallet,
+      token_image_url: market?.imageUrl ?? null,
+      fdv_usd: market?.fdvUsd ?? null,
+      volume_24h_usd: market?.volume24hUsd ?? null,
+      market_synced_at: now,
+    });
+  }
+
+  return updates;
+}

--- a/src/lib/token-market.ts
+++ b/src/lib/token-market.ts
@@ -89,7 +89,7 @@ async function geckoGet(path: string): Promise<unknown | null> {
  * Shared by the single and the multi lookup so both read the same fields the
  * same way: a shape change upstream breaks one parser instead of two.
  */
-function parseTokenMarket(
+export function parseTokenMarket(
   entry: unknown,
   requestedMint: string | null,
 ): TokenMarket | null {


### PR DESCRIPTION
Third and final piece of the `/bags` market-data work, after #262 (the wipe) and #263 (the rate limit). This one addresses *why* the refresh still returns zero.

## The problem

GeckoTerminal rate-limits by IP. This Worker egresses from Cloudflare's shared pool, so we compete with everyone else on Cloudflare hitting that API — and `/bags` ISR renders spend from the same budget.

Measured, minutes apart, same `User-Agent`:

| caller | result |
|---|---|
| Worker (`bags-discover`) | `{considered: 412, refreshed: 30}` then `refreshed: 0`, twice |
| laptop | `200, tokens=2` |

Pacing, slicing and stop-on-429 have all now been tried. None of them address a per-IP limit on an IP we don't control.

## The fix

The lookups move to the GitHub Actions runner that already schedules our crons and has an IP of its own. Responsibilities split cleanly:

- **`bags-discover`** goes back to doing one thing — discovery.
- **`/api/cron/bags-market`** owns pricing. `GET` hands out the stalest mints; `POST` takes the answers and writes them.
- **`scripts/bags-market-refresh.mjs`** runs on the runner and is pure transport — it forwards GeckoTerminal's token objects verbatim so `parseTokenMarket` stays the one place that knows their shape, rather than being reimplemented in a script outside the type system.

## The part worth reviewing

The numbers now arrive **over HTTP** instead of being fetched in-process, so what a payload is allowed to decide stops being an implicit property of a handler. `buildMarketUpdates` in `src/lib/bags-market.ts` states it:

- Identity for every written row is read back out of `bags_launches` first. A payload cannot invent a launch, and cannot change whose launch it is.
- Only the four market columns are ever written — `user_id`, `bags_username`, `token_symbol` and `last_verified_at` are untouchable through this path.
- `answered` minus `markets` still means "asked, genuinely unindexed" and stores its null; a mint in neither is left entirely alone and sorts first next run.

Six tests cover it, including the injection and impersonation cases. It lives in `lib` because that is where this codebase tests logic — 40 test files there against 1 under `app/`.

## Testing

679 pass, `eslint src scripts` clean, `tsc --noEmit` clean apart from the two pre-existing `worker.ts` errors on `main`.

## Verification plan

Merge, then run the new **Bags market refresh** workflow manually and read its log. Expect `answered` in the hundreds rather than 30, and `with_fdv` in the table to climb well past the current 41.

Uses the existing `CRON_SECRET` repo secret; no new secrets required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated market data refreshes for Bags launches, running every six hours or on demand.
  * Added validation and secure processing for market data updates, including handling for incomplete or unavailable pricing data.
  * Market data now records refreshed pricing and volume information for eligible launches.

* **Bug Fixes**
  * Improved reliability of market data collection by separating launch discovery from pricing refreshes.
  * Added safeguards to prevent updates for unknown launches and handle rate limits or failed requests safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->