### PR TITLE
feat(bags): page and search every tracked launch, not just the busiest 25

### DIFF
--- a/src/app/bags/page.tsx
+++ b/src/app/bags/page.tsx
@@ -10,7 +10,7 @@ import {
   type BagsLaunchRow,
 } from "@/lib/bags-board";
 import { BagsBuilderRow as BoardRow } from "@/components/bags/bags-builder-row";
-import { UnverifiedLaunchRow } from "@/components/bags/unverified-launch-row";
+import { UnverifiedLaunchBoard } from "@/components/bags/unverified-launch-board";
 import { BagsAttribution } from "@/components/bags/bags-attribution";
 import { BagsMark } from "@/components/bags/bags-mark";
 import { BoardViewToggle } from "@/components/bags/board-view-toggle";
@@ -58,9 +58,6 @@ const LAUNCH_PAGE_SIZE = 1000;
  * builders and understates the launch counts of the ones that survive.
  */
 const MAX_LAUNCHES = 20_000;
-
-/** How many unverified launches the board renders. The rest are counted, not listed. */
-const MAX_UNVERIFIED_SHOWN = 25;
 
 const BUILDER_FIELDS =
   "id, username, display_name, avatar_url, github_username, vibe_score, streak";
@@ -240,9 +237,6 @@ export default async function BagsPage() {
     loadHackathonRoster(),
   ]);
   const matchedHackathon = roster.filter((r) => r.builder).length;
-  // Bounded render: the discovery cron adds rows every day, and an unbounded
-  // list would grow the page without limit. The full count is still stated.
-  const shownUnverified = unverified.slice(0, MAX_UNVERIFIED_SHOWN);
   const launchCount = board.reduce((sum, entry) => sum + entry.launchCount, 0);
 
   const jsonLd = {
@@ -377,17 +371,7 @@ export default async function BagsPage() {
                     being made about the person. If one of them is yours, link
                     the wallet and it moves up.
                   </p>
-                  <ul className="flex flex-col gap-2">
-                    {shownUnverified.map((launch) => (
-                      <UnverifiedLaunchRow key={launch.mint} launch={launch} />
-                    ))}
-                  </ul>
-                  {unverified.length > shownUnverified.length ? (
-                    <p className="mt-3 text-[12px] text-[var(--bags-text-faint)]">
-                      Showing the {shownUnverified.length} busiest of{" "}
-                      {unverified.length} tracked launches.
-                    </p>
-                  ) : null}
+                  <UnverifiedLaunchBoard launches={unverified} />
                 </section>
               ) : null}
             </>

--- a/src/components/bags/__tests__/unverified-launch-board.test.tsx
+++ b/src/components/bags/__tests__/unverified-launch-board.test.tsx
@@ -1,0 +1,123 @@
+// The board is the only way to reach a tracked launch that is not among the
+// busiest few, so these cover the two things that can strand one: a page that
+// never advances, and controls that are not rendered at all.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+import { UnverifiedLaunchBoard } from "@/components/bags/unverified-launch-board";
+import type { UnverifiedLaunch } from "@/lib/bags-board";
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+/** Mints end in the Bags vanity suffix, as every real one does. */
+function makeLaunches(count: number): UnverifiedLaunch[] {
+  return Array.from({ length: count }, (_, i) => ({
+    mint: `Mint${String(i).padStart(3, "0")}xxxxxxxxxxxxxxxxxxxxxxxxxBAGS`,
+    name: `Launch ${i}`,
+    symbol: `SYM${i}`,
+    imageUrl: null,
+    fdvUsd: null,
+    volume24hUsd: null,
+    bagsUsername: `creator${i}`,
+    twitterUsername: null,
+    profileUsername: null,
+  }));
+}
+
+function render(launches: UnverifiedLaunch[]) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root!.render(<UnverifiedLaunchBoard launches={launches} />));
+  return container;
+}
+
+const rowCount = (el: HTMLElement) => el.querySelectorAll("ul > li").length;
+const status = (el: HTMLElement) =>
+  el.querySelector("[aria-live]")?.textContent?.replace(/\s+/g, " ").trim();
+const search = (el: HTMLElement) =>
+  el.querySelector<HTMLInputElement>('input[type="search"]');
+const nextButton = (el: HTMLElement) =>
+  el.querySelector<HTMLButtonElement>('button[aria-label="Next page"]');
+
+function type(el: HTMLElement, value: string) {
+  const input = search(el)!;
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    "value",
+  )!.set!;
+  act(() => {
+    setter.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+describe("UnverifiedLaunchBoard", () => {
+  it("shows one page of rows and reports the full count", () => {
+    const el = render(makeLaunches(60));
+    expect(rowCount(el)).toBe(25);
+    expect(status(el)).toBe("1–25 of 60 launches");
+  });
+
+  it("pages forward through the rest", () => {
+    const el = render(makeLaunches(60));
+    act(() => nextButton(el)!.click());
+    expect(status(el)).toBe("26–50 of 60 launches");
+    act(() => nextButton(el)!.click());
+    expect(status(el)).toBe("51–60 of 60 launches");
+    expect(rowCount(el)).toBe(10);
+    expect(nextButton(el)!.disabled).toBe(true);
+  });
+
+  // Regression: search used to be withheld below 26 launches, which left a
+  // short-but-not-tiny board with no way to find anything in it.
+  it("offers search at the single-page boundary and below", () => {
+    for (const count of [1, 24, 25]) {
+      const el = render(makeLaunches(count));
+      expect(search(el), `${count} launches`).not.toBeNull();
+      expect(nextButton(el), `${count} launches`).toBeNull();
+      expect(status(el)).toBe(
+        `1–${count} of ${count} ${count === 1 ? "launch" : "launches"}`,
+      );
+      act(() => root!.unmount());
+      container!.remove();
+    }
+  });
+
+  it("filters on a query and resets to the first page", () => {
+    const el = render(makeLaunches(60));
+    act(() => nextButton(el)!.click());
+    expect(status(el)).toBe("26–50 of 60 launches");
+
+    type(el, "Launch 7");
+    // "Launch 7" also prefixes nothing else; 7 alone would match 7, 17, 27…
+    expect(status(el)).toBe("1–1 of 1 launch matching “Launch 7”");
+    expect(rowCount(el)).toBe(1);
+  });
+
+  it("explains an empty result rather than rendering a blank list", () => {
+    const el = render(makeLaunches(60));
+    type(el, "nothing-matches-this");
+    expect(rowCount(el)).toBe(0);
+    expect(el.textContent).toContain("No tracked launch matches");
+    expect(status(el)).toBe("0 launches matching “nothing-matches-this”");
+  });
+
+  it("does not match every launch on the shared BAGS mint suffix", () => {
+    const el = render(makeLaunches(60));
+    type(el, "bags");
+    expect(status(el)).toBe("0 launches matching “bags”");
+  });
+});

--- a/src/components/bags/unverified-launch-board.tsx
+++ b/src/components/bags/unverified-launch-board.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useId, useMemo, useState } from "react";
+import { CaretLeft, CaretRight, MagnifyingGlass } from "@phosphor-icons/react";
+
+import { launchMatchesQuery, type UnverifiedLaunch } from "@/lib/bags-board";
+import { UnverifiedLaunchRow } from "./unverified-launch-row";
+
+/** Rows per page. Matches what the board showed before it could be paged. */
+const PAGE_SIZE = 25;
+
+/**
+ * Below this there is nothing to page through and nothing to find, so the
+ * controls would only be chrome around a list you can already read.
+ */
+const CONTROLS_MIN_ROWS = PAGE_SIZE + 1;
+
+/**
+ * The tracked-but-unverified launches, paged and filterable.
+ *
+ * Client-side on purpose. Every row is already read server-side to build the
+ * verified board above, so paging here costs no extra query — and doing it on
+ * a search param instead would turn /bags dynamic and cost it the hourly ISR
+ * window the sync cadence makes free.
+ *
+ * Searching matters more than paging does: only a few dozen of these launches
+ * report any volume, so the "busiest first" order goes flat almost immediately
+ * and the later pages are unranked. Filtering is the only way to find a
+ * specific coin in the tail.
+ */
+export function UnverifiedLaunchBoard({
+  launches,
+}: {
+  launches: UnverifiedLaunch[];
+}) {
+  const [query, setQuery] = useState("");
+  const [page, setPage] = useState(1);
+  const searchId = useId();
+
+  const showControls = launches.length >= CONTROLS_MIN_ROWS;
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return launches;
+    return launches.filter((launch) => launchMatchesQuery(launch, needle));
+  }, [launches, query]);
+
+  const pageCount = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  // Clamped rather than stored: a filter that shrinks the list can strand the
+  // page number past the end, and correcting that in an effect would render an
+  // empty list first.
+  const currentPage = Math.min(page, pageCount);
+  const start = (currentPage - 1) * PAGE_SIZE;
+  const visible = filtered.slice(start, start + PAGE_SIZE);
+
+  // Stepped from the clamped page, not the stored one, so a move made while the
+  // stored page is stranded past the end lands next to what is on screen.
+  const goTo = (next: number) =>
+    setPage(Math.min(Math.max(next, 1), pageCount));
+
+  return (
+    <>
+      {showControls ? (
+        <div className="relative mb-4">
+          <label className="sr-only" htmlFor={searchId}>
+            Search tracked launches by name, ticker, creator or mint
+          </label>
+          <MagnifyingGlass
+            size={15}
+            weight="bold"
+            aria-hidden="true"
+            className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-[var(--bags-text-faint)]"
+          />
+          <input
+            id={searchId}
+            type="search"
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setPage(1);
+            }}
+            placeholder="Search name, ticker, creator or mint"
+            // The border is a class, not an inline style like the rest of this
+            // page: an inline border outranks the focus variant, which would
+            // leave a keyboard user with no focus indicator at all.
+            className="w-full rounded-2xl border border-[var(--bags-border)] py-3 pl-11 pr-4 text-[13px] text-[var(--bags-text)] outline-none transition-colors placeholder:text-[var(--bags-text-faint)] focus:border-[var(--bags-green)]"
+            style={{ backgroundColor: "var(--bags-surface)" }}
+          />
+        </div>
+      ) : null}
+
+      {visible.length > 0 ? (
+        <ul className="flex flex-col gap-2">
+          {visible.map((launch) => (
+            <UnverifiedLaunchRow key={launch.mint} launch={launch} />
+          ))}
+        </ul>
+      ) : (
+        <p
+          className="rounded-2xl px-5 py-8 text-center text-[13px] text-[var(--bags-text-muted)]"
+          style={{
+            backgroundColor: "var(--bags-surface)",
+            border: "1px solid var(--bags-border)",
+          }}
+        >
+          No tracked launch matches &ldquo;{query.trim()}&rdquo;.
+        </p>
+      )}
+
+      {showControls ? (
+        <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+          {/* Announced so a filter typed into the box reports its own result
+              instead of silently rewriting the list under the cursor. */}
+          <p
+            aria-live="polite"
+            className="text-[12px] text-[var(--bags-text-faint)]"
+          >
+            {filtered.length > 0
+              ? `${start + 1}–${start + visible.length} of ${filtered.length}`
+              : "0"}{" "}
+            {filtered.length === 1 ? "launch" : "launches"}
+            {query.trim() ? ` matching “${query.trim()}”` : ""}
+          </p>
+
+          {pageCount > 1 ? (
+            <div className="flex items-center gap-2">
+              <PagerButton
+                label="Previous page"
+                disabled={currentPage === 1}
+                onClick={() => goTo(currentPage - 1)}
+              >
+                <CaretLeft size={13} weight="bold" aria-hidden="true" />
+              </PagerButton>
+              <span className="font-mono text-[12px] text-[var(--bags-text-muted)]">
+                {currentPage} / {pageCount}
+              </span>
+              <PagerButton
+                label="Next page"
+                disabled={currentPage === pageCount}
+                onClick={() => goTo(currentPage + 1)}
+              >
+                <CaretRight size={13} weight="bold" aria-hidden="true" />
+              </PagerButton>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function PagerButton({
+  label,
+  disabled,
+  onClick,
+  children,
+}: {
+  label: string;
+  disabled: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      disabled={disabled}
+      onClick={onClick}
+      className="inline-flex h-8 w-8 items-center justify-center rounded-full text-[var(--bags-text-muted)] transition-colors enabled:hover:text-[var(--bags-text)] disabled:opacity-30"
+      style={{
+        backgroundColor: "var(--bags-surface)",
+        border: "1px solid var(--bags-border)",
+      }}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/bags/unverified-launch-board.tsx
+++ b/src/components/bags/unverified-launch-board.tsx
@@ -10,12 +10,6 @@ import { UnverifiedLaunchRow } from "./unverified-launch-row";
 const PAGE_SIZE = 25;
 
 /**
- * Below this there is nothing to page through and nothing to find, so the
- * controls would only be chrome around a list you can already read.
- */
-const CONTROLS_MIN_ROWS = PAGE_SIZE + 1;
-
-/**
  * The tracked-but-unverified launches, paged and filterable.
  *
  * Client-side on purpose. Every row is already read server-side to build the
@@ -36,8 +30,6 @@ export function UnverifiedLaunchBoard({
   const [query, setQuery] = useState("");
   const [page, setPage] = useState(1);
   const searchId = useId();
-
-  const showControls = launches.length >= CONTROLS_MIN_ROWS;
 
   const filtered = useMemo(() => {
     const needle = query.trim().toLowerCase();
@@ -60,34 +52,32 @@ export function UnverifiedLaunchBoard({
 
   return (
     <>
-      {showControls ? (
-        <div className="relative mb-4">
-          <label className="sr-only" htmlFor={searchId}>
-            Search tracked launches by name, ticker, creator or mint
-          </label>
-          <MagnifyingGlass
-            size={15}
-            weight="bold"
-            aria-hidden="true"
-            className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-[var(--bags-text-faint)]"
-          />
-          <input
-            id={searchId}
-            type="search"
-            value={query}
-            onChange={(e) => {
-              setQuery(e.target.value);
-              setPage(1);
-            }}
-            placeholder="Search name, ticker, creator or mint"
-            // The border is a class, not an inline style like the rest of this
-            // page: an inline border outranks the focus variant, which would
-            // leave a keyboard user with no focus indicator at all.
-            className="w-full rounded-2xl border border-[var(--bags-border)] py-3 pl-11 pr-4 text-[13px] text-[var(--bags-text)] outline-none transition-colors placeholder:text-[var(--bags-text-faint)] focus:border-[var(--bags-green)]"
-            style={{ backgroundColor: "var(--bags-surface)" }}
-          />
-        </div>
-      ) : null}
+      <div className="relative mb-4">
+        <label className="sr-only" htmlFor={searchId}>
+          Search tracked launches by name, ticker, creator or mint
+        </label>
+        <MagnifyingGlass
+          size={15}
+          weight="bold"
+          aria-hidden="true"
+          className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-[var(--bags-text-faint)]"
+        />
+        <input
+          id={searchId}
+          type="search"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setPage(1);
+          }}
+          placeholder="Search name, ticker, creator or mint"
+          // The border is a class, not an inline style like the rest of this
+          // page: an inline border outranks the focus variant, which would
+          // leave a keyboard user with no focus indicator at all.
+          className="w-full rounded-2xl border border-[var(--bags-border)] py-3 pl-11 pr-4 text-[13px] text-[var(--bags-text)] outline-none transition-colors placeholder:text-[var(--bags-text-faint)] focus:border-[var(--bags-green)]"
+          style={{ backgroundColor: "var(--bags-surface)" }}
+        />
+      </div>
 
       {visible.length > 0 ? (
         <ul className="flex flex-col gap-2">
@@ -107,44 +97,42 @@ export function UnverifiedLaunchBoard({
         </p>
       )}
 
-      {showControls ? (
-        <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
-          {/* Announced so a filter typed into the box reports its own result
-              instead of silently rewriting the list under the cursor. */}
-          <p
-            aria-live="polite"
-            className="text-[12px] text-[var(--bags-text-faint)]"
-          >
-            {filtered.length > 0
-              ? `${start + 1}–${start + visible.length} of ${filtered.length}`
-              : "0"}{" "}
-            {filtered.length === 1 ? "launch" : "launches"}
-            {query.trim() ? ` matching “${query.trim()}”` : ""}
-          </p>
+      <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+        {/* Announced so a filter typed into the box reports its own result
+            instead of silently rewriting the list under the cursor. */}
+        <p
+          aria-live="polite"
+          className="text-[12px] text-[var(--bags-text-faint)]"
+        >
+          {filtered.length > 0
+            ? `${start + 1}–${start + visible.length} of ${filtered.length}`
+            : "0"}{" "}
+          {filtered.length === 1 ? "launch" : "launches"}
+          {query.trim() ? ` matching “${query.trim()}”` : ""}
+        </p>
 
-          {pageCount > 1 ? (
-            <div className="flex items-center gap-2">
-              <PagerButton
-                label="Previous page"
-                disabled={currentPage === 1}
-                onClick={() => goTo(currentPage - 1)}
-              >
-                <CaretLeft size={13} weight="bold" aria-hidden="true" />
-              </PagerButton>
-              <span className="font-mono text-[12px] text-[var(--bags-text-muted)]">
-                {currentPage} / {pageCount}
-              </span>
-              <PagerButton
-                label="Next page"
-                disabled={currentPage === pageCount}
-                onClick={() => goTo(currentPage + 1)}
-              >
-                <CaretRight size={13} weight="bold" aria-hidden="true" />
-              </PagerButton>
-            </div>
-          ) : null}
-        </div>
-      ) : null}
+        {pageCount > 1 ? (
+          <div className="flex items-center gap-2">
+            <PagerButton
+              label="Previous page"
+              disabled={currentPage === 1}
+              onClick={() => goTo(currentPage - 1)}
+            >
+              <CaretLeft size={13} weight="bold" aria-hidden="true" />
+            </PagerButton>
+            <span className="font-mono text-[12px] text-[var(--bags-text-muted)]">
+              {currentPage} / {pageCount}
+            </span>
+            <PagerButton
+              label="Next page"
+              disabled={currentPage === pageCount}
+              onClick={() => goTo(currentPage + 1)}
+            >
+              <CaretRight size={13} weight="bold" aria-hidden="true" />
+            </PagerButton>
+          </div>
+        ) : null}
+      </div>
     </>
   );
 }

--- a/src/lib/__tests__/bags-board.test.ts
+++ b/src/lib/__tests__/bags-board.test.ts
@@ -3,9 +3,11 @@ import { describe, it, expect } from "vitest";
 import {
   buildBagsBoard,
   buildUnverifiedLaunches,
+  launchMatchesQuery,
   shortMint,
   type BagsBuilderRow,
   type BagsLaunchRow,
+  type UnverifiedLaunch,
 } from "@/lib/bags-board";
 
 function builder(
@@ -262,5 +264,77 @@ describe("buildUnverifiedLaunches", () => {
       [],
     );
     expect(board[0]!.name).toBe(hostile);
+  });
+});
+
+describe("launchMatchesQuery", () => {
+  function unverified(over: Partial<UnverifiedLaunch> = {}): UnverifiedLaunch {
+    return {
+      mint: "HjMPWnCSCuSVArioHpWGiucxek1KjWK5w7T8XXqBAGS",
+      name: "Oinkington Cashbuck",
+      symbol: "OINK",
+      imageUrl: null,
+      fdvUsd: null,
+      volume24hUsd: null,
+      bagsUsername: "kannamdc",
+      twitterUsername: null,
+      profileUsername: null,
+      ...over,
+    };
+  }
+
+  it("matches on name, ticker and creator handle", () => {
+    expect(launchMatchesQuery(unverified(), "oinking")).toBe(true);
+    expect(launchMatchesQuery(unverified(), "oink")).toBe(true);
+    expect(launchMatchesQuery(unverified(), "kannamdc")).toBe(true);
+    expect(
+      launchMatchesQuery(
+        unverified({ twitterUsername: "shipsdaily" }),
+        "shipsdaily",
+      ),
+    ).toBe(true);
+    expect(
+      launchMatchesQuery(unverified({ profileUsername: "abhinav" }), "abhinav"),
+    ).toBe(true);
+  });
+
+  it("keeps every launch when the query is empty", () => {
+    expect(launchMatchesQuery(unverified({ name: null }), "")).toBe(true);
+  });
+
+  it("matches a mint by prefix so a pasted address finds its launch", () => {
+    expect(launchMatchesQuery(unverified(), "hjmpwncs")).toBe(true);
+    expect(
+      launchMatchesQuery(
+        unverified(),
+        "hjmpwncscusvarioHpWGiucxek1KjWK5w7T8XXqBAGS".toLowerCase(),
+      ),
+    ).toBe(true);
+  });
+
+  // Every Bags mint ends in the vanity suffix, so a substring match here would
+  // make the word "bags" return the entire board.
+  it("does not match a mint on its trailing vanity suffix", () => {
+    expect(launchMatchesQuery(unverified({ name: null, symbol: null, bagsUsername: null }), "bags")).toBe(
+      false,
+    );
+  });
+
+  it("ignores the mint for queries too short to be an address", () => {
+    expect(
+      launchMatchesQuery(
+        unverified({ name: null, symbol: null, bagsUsername: null }),
+        "hjm",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not match a mint from its middle", () => {
+    expect(
+      launchMatchesQuery(
+        unverified({ name: null, symbol: null, bagsUsername: null }),
+        "cusvario",
+      ),
+    ).toBe(false);
   });
 });

--- a/src/lib/bags-board.ts
+++ b/src/lib/bags-board.ts
@@ -159,6 +159,49 @@ export type UnverifiedLaunch = {
 };
 
 /**
+ * Shorter than this, a query is not matched against the mint at all. Base58
+ * addresses contain nearly every letter, so one or two characters match every
+ * launch through the mint alone and the filter looks broken. Anyone actually
+ * looking up an address has more of it than this to paste.
+ */
+const MINT_MATCH_MIN_CHARS = 4;
+
+/**
+ * Does this launch match a board search?
+ *
+ * `query` is expected pre-normalised (trimmed, lower-cased) because the board
+ * filters the whole list on every keystroke and there is no reason to redo that
+ * work per row. An empty query matches everything.
+ *
+ * Matched against the raw fields rather than the sanitised ones the row
+ * renders: sanitising rewrites characters to make a string safe to display,
+ * which would make a launch unfindable by the name its creator gave it.
+ */
+export function launchMatchesQuery(
+  launch: UnverifiedLaunch,
+  query: string,
+): boolean {
+  if (!query) return true;
+
+  const textMatch = [
+    launch.name,
+    launch.symbol,
+    launch.bagsUsername,
+    launch.twitterUsername,
+    launch.profileUsername,
+  ].some((field) => field?.toLowerCase().includes(query));
+  if (textMatch) return true;
+
+  // Prefix, not substring: every Bags mint ends in the vanity suffix "BAGS", so
+  // a substring match means searching the word "bags" on the Bags board returns
+  // every row on it. A pasted address starts at the front.
+  return (
+    query.length >= MINT_MATCH_MIN_CHARS &&
+    launch.mint.toLowerCase().startsWith(query)
+  );
+}
+
+/**
  * Launches the verified board cannot carry, busiest first.
  *
  * Deliberately includes claimed-but-unverified launches. Dropping them would


### PR DESCRIPTION
## Why

`/bags` reads all 486 launches to group the verified ones, then rendered `slice(0, 25)` of the rest and stated the remainder as a bare number — *"Showing the 25 busiest of 485 tracked launches."* Everything past the 25th busiest was unreachable.

## What

A search box, 25 rows per page, and a `‹ 1 / 20 ›` pager with a live `1–25 of 487 launches` counter.

Paged **client-side** rather than on a search param. The rows are already in memory from building the verified board, so paging costs no extra query — and a search param would turn `/bags` dynamic and cost it the hourly ISR window the sync cadence makes free. Build still reports `○ /bags   1m   1y`.

Search matters more than paging does: only ~49 of the launches report any 24h volume, so the "busiest first" order goes flat almost immediately and pages 3–20 are unranked. Filtering is the only way to reach the tail.

## Two non-obvious matching rules

Both surfaced from testing against real data, and both live in `launchMatchesQuery` next to `buildUnverifiedLaunches` rather than inside the component, so they're unit-testable:

- **The mint is matched by prefix, never as a substring.** Every Bags mint ends in the vanity suffix `BAGS` — 488 of 488 rows — so a substring match means searching the word "bags" on the Bags board returns the entire board. A pasted address starts at the front.
- **Queries under 4 characters skip the mint entirely.** Base58 contains nearly every letter, so `a` otherwise matched all 486 through the mint alone and the filter looked broken.

Trade-off: a mid-address fragment won't match. Deliberate, and commented.

## One fix to my own markup

The search input takes its border from a class, unlike the inline styles the rest of this page uses. An inline border outranks the `focus:` variant, which would have left a keyboard user with no focus indicator at all. Verified `rgb(0, 255, 0)` on real focus.

## Verification

- `npx tsc --noEmit` and `eslint src` clean
- 685 tests pass (49 files), including 7 new ones for the matcher
- `npm run build` → `○ /bags` (still prerendered static, not dynamic)
- Driven in a browser against local dev: pager steps 1→2→3→4→5, `bags` → 11 matches (not 488), `dog` → 7, `a` → 352 (not 485), an 8-char mint prefix → 1, a full mint → 1, a mid-mint slice → 0, no-match empty state renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search functionality for unverified launches by name, symbol, usernames, and mint address prefixes.
  * Added pagination for launch results, displaying up to 25 entries per page.
  * Added result counts, empty-state messaging, and accessible search feedback.
  * The Bags page now supports browsing the complete set of tracked unverified launches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->