### PR TITLE
fix(onboarding): repair the GitHub mirror for real, and say it is required

### DIFF
--- a/src/app/auth/profile-setup/page.tsx
+++ b/src/app/auth/profile-setup/page.tsx
@@ -149,10 +149,16 @@ export default function ProfileSetupPage() {
         if (typeof userRow.github_id === "number") {
           setVerifiedGithubId(userRow.github_id);
         }
-      } else {
-        // GitHub might be linked in Supabase auth but not yet synced to the
-        // users table (happens when linkIdentity succeeds but the redirect
-        // back to /auth/callback fails). Detect and sync it now.
+      }
+      // Entered whenever a mirror is incomplete, which includes a stored handle
+      // with no stable id — not only a missing handle. GitHub might be linked in
+      // Supabase auth but not yet synced to the users table (linkIdentity
+      // succeeded and the redirect back to /auth/callback did not), and a row
+      // carrying a handle alone sends github-sync down its username path, which
+      // resolves whoever owns that handle now. The live OAuth identity read here
+      // is authoritative in a way that lookup is not. Runs after the branch
+      // above so its state updates win when both have a value.
+      if (!userRow?.github_username || userRow?.github_id == null) {
         const identity = await syncGithubMirrors(supabase, user.id, user, {
           githubUsername: userRow?.github_username,
           githubId: userRow?.github_id,

--- a/src/app/auth/profile-setup/page.tsx
+++ b/src/app/auth/profile-setup/page.tsx
@@ -7,6 +7,7 @@ import { validateDisplayName, containsProfanity } from "@/lib/profanity";
 import { normalizeSocialHandle } from "@/lib/social-handles";
 import { normalizeExternalUrl, normalizeRepoUrl } from "@/lib/url-normalize";
 import { armTourTrigger, TOUR_FLAG_ENABLED } from "@/lib/onboarding";
+import { syncGithubMirrors } from "@/lib/github-identity";
 import {
   saveOnboardingProfile,
   type ProfileWriteClient,
@@ -152,43 +153,16 @@ export default function ProfileSetupPage() {
         // GitHub might be linked in Supabase auth but not yet synced to the
         // users table (happens when linkIdentity succeeds but the redirect
         // back to /auth/callback fails). Detect and sync it now.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const ghIdentity = user.identities?.find((i: any) => i.provider === "github");
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const ghData = (ghIdentity?.identity_data ?? {}) as any;
-        const ghUsername =
-          ghData.user_name ||
-          ghData.preferred_username ||
-          user.user_metadata?.user_name ||
-          user.user_metadata?.preferred_username ||
-          null;
-        // GitHub's stable numeric ID. Lives in identity_data.sub (OIDC-style
-        // subject id). github-sync uses it to distinguish a legitimate
-        // rename from a handle reclaim, so capturing it on every OAuth-
-        // mediated write keeps that guard accurate.
-        const rawGhId = ghData.sub ?? ghData.provider_id ?? null;
-        const ghId =
-          rawGhId != null && /^\d+$/.test(String(rawGhId)) ? Number(rawGhId) : null;
-        if (ghUsername) {
-          resolvedGithub = ghUsername;
-          setVerifiedGithub(ghUsername);
-          setSocials((s) => ({ ...s, github: ghUsername }));
-          if (ghId !== null && Number.isFinite(ghId)) {
-            setVerifiedGithubId(ghId);
-          }
-          // Sync to DB so the rest of the app sees it
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          await (supabase.from("users") as any)
-            .update({
-              github_username: ghUsername,
-              ...(ghId !== null && Number.isFinite(ghId) ? { github_id: ghId } : {}),
-            })
-            .eq("id", user.id);
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          await (supabase.from("social_links") as any).upsert(
-            { user_id: user.id, github: ghUsername },
-            { onConflict: "user_id" }
-          );
+        const identity = await syncGithubMirrors(supabase, user.id, user, {
+          githubUsername: userRow?.github_username,
+          githubId: userRow?.github_id,
+          socialGithub: null,
+        });
+        if (identity) {
+          resolvedGithub = identity.username;
+          setVerifiedGithub(identity.username);
+          setSocials((s) => ({ ...s, github: identity.username }));
+          if (identity.id !== null) setVerifiedGithubId(identity.id);
         }
       }
 

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -138,13 +138,23 @@ export default function SignUpPage() {
           <GithubLogo weight="fill" size={18} />
           Continue with GitHub
         </AuthPrimaryButton>
+        {/* "Recommended" used to sit here, and it was the wrong word: profile
+            setup blocks on a verified GitHub, so anyone who picks Google or
+            email only finds out it is mandatory after they have committed.
+            Fewer than half of them ever came back to connect it. Saying so up
+            front costs a little friction here and saves the drop-off there. */}
         <p className="text-[11px] font-medium text-center text-[var(--text-muted)]">
-          Recommended: auto-verifies your GitHub and syncs your streak
+          Required — your vibe score is built from verified commits. Read-only:
+          we never push code or change your account.
         </p>
         <AuthSecondaryButton onClick={() => setConsentProvider("google")}>
           <GoogleMark />
           Continue with Google
         </AuthSecondaryButton>
+        <p className="text-[11px] font-medium text-center text-[var(--text-muted)]">
+          You will still be asked to connect GitHub before your profile goes
+          live.
+        </p>
       </div>
 
       <div className="my-6">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -236,7 +236,11 @@ export default function DashboardPage() {
       // of sync, repair them in place so the missing-socials redirect below
       // doesn't bounce the user into an unfixable loop. Same lookup pattern
       // as settings/page.tsx and profile-setup/page.tsx.
-      if (!profile.github_username || !socials?.github) {
+      // github_id is part of the gate, not just the handle: a row with a
+      // handle and no stable id sends github-sync down its username path,
+      // which backfills whatever account owns that handle *now*. The live
+      // OAuth identity read here is authoritative in a way that lookup is not.
+      if (!profile.github_username || !socials?.github || profile.github_id == null) {
         const identity = await syncGithubMirrors(sb, authUser.id, authUser, {
           githubUsername: profile.github_username,
           githubId: profile.github_id,

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import dynamic from "next/dynamic";
 import Image from "next/image";
 import Link from "next/link";
+import { syncGithubMirrors } from "@/lib/github-identity";
 import { createClient } from "@/lib/supabase/client";
 import { fetchStreakLogs } from "@/lib/supabase/queries";
 import { siteUrl } from "@/lib/seo";
@@ -43,7 +44,7 @@ import { Camera, ChatCircle, Check, Clock, Code, CurrencyDollar, Envelope, Envel
 // back to a generic checklist without it), and the Badge Holder chip reads
 // has_vibetalent_badge. It's a flat ~13-key object, so the egress is trivial.
 const DASHBOARD_USER_FIELDS =
-  "id, username, display_name, bio, avatar_url, github_username, vibe_score, streak, longest_streak, badge_level, streak_freezes_remaining, streak_freezes_used, referral_count, created_at, streak_before_break, streak_broken_at, solana_wallet";
+  "id, username, display_name, bio, avatar_url, github_username, github_id, vibe_score, streak, longest_streak, badge_level, streak_freezes_remaining, streak_freezes_used, referral_count, created_at, streak_before_break, streak_broken_at, solana_wallet";
 const DASHBOARD_PROJECT_FIELDS =
   "id, user_id, title, description, tech_stack, live_url, github_url, image_url, build_time, tags, verified, quality_score, quality_metrics, endorsement_count, created_at";
 const DASHBOARD_SOCIAL_FIELDS = "id, user_id, twitter, telegram, github, website, farcaster";
@@ -236,27 +237,19 @@ export default function DashboardPage() {
       // doesn't bounce the user into an unfixable loop. Same lookup pattern
       // as settings/page.tsx and profile-setup/page.tsx.
       if (!profile.github_username || !socials?.github) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const ghIdentity = authUser.identities?.find((i: any) => i.provider === "github");
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const ghData = (ghIdentity?.identity_data ?? {}) as any;
-        const ghUsername =
-          ghData.user_name ||
-          ghData.preferred_username ||
-          authUser.user_metadata?.user_name ||
-          authUser.user_metadata?.preferred_username ||
-          null;
-        if (ghUsername) {
-          if (!profile.github_username) {
-            profile.github_username = ghUsername;
-            sb.from("users").update({ github_username: ghUsername }).eq("id", authUser.id);
-          }
+        const identity = await syncGithubMirrors(sb, authUser.id, authUser, {
+          githubUsername: profile.github_username,
+          githubId: profile.github_id,
+          socialGithub: socials?.github,
+        });
+        if (identity) {
+          profile.github_username ||= identity.username;
           if (!socials?.github) {
-            socials = { ...(socials || {}), github: ghUsername, user_id: authUser.id };
-            sb.from("social_links").upsert(
-              { user_id: authUser.id, github: ghUsername },
-              { onConflict: "user_id" }
-            );
+            socials = {
+              ...(socials || {}),
+              github: identity.username,
+              user_id: authUser.id,
+            };
           }
         }
       }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -95,7 +95,10 @@ export default function SettingsPage() {
         // GitHub might be linked in Supabase auth but not yet synced to the
         // users table (happens when linkIdentity succeeds but the redirect
         // back to /auth/callback fails). Detect and sync it now.
-        if (!profile.github_username) {
+        // Also entered when only github_id is missing — see the dashboard
+        // gate: a handle with no stable id leaves github-sync resolving a
+        // mutable username.
+        if (!profile.github_username || profile.github_id == null) {
           const identity = await syncGithubMirrors(sb, authUser.id, authUser, {
             githubUsername: profile.github_username,
             githubId: profile.github_id,

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import Image from "next/image";
 import { useSearchParams } from "next/navigation";
+import { syncGithubMirrors } from "@/lib/github-identity";
 import { createClient } from "@/lib/supabase/client";
 import { validateDisplayName, containsProfanity } from "@/lib/profanity";
 import { siteUrl } from "@/lib/seo";
@@ -95,29 +96,12 @@ export default function SettingsPage() {
         // users table (happens when linkIdentity succeeds but the redirect
         // back to /auth/callback fails). Detect and sync it now.
         if (!profile.github_username) {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const ghIdentity = authUser.identities?.find((i: any) => i.provider === "github");
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const ghData = (ghIdentity?.identity_data ?? {}) as any;
-          // Only derive a handle when a GitHub identity is actually linked.
-          // user_metadata persists after unlinkIdentity, so trusting it
-          // unconditionally would resurrect an unlinked account on the next load.
-          const ghUsername = ghIdentity
-            ? ghData.user_name ||
-              ghData.preferred_username ||
-              authUser.user_metadata?.user_name ||
-              authUser.user_metadata?.preferred_username ||
-              null
-            : null;
-          if (ghUsername) {
-            profile.github_username = ghUsername;
-            // Sync to DB in the background
-            sb.from("users").update({ github_username: ghUsername }).eq("id", authUser.id);
-            sb.from("social_links").upsert(
-              { user_id: authUser.id, github: ghUsername },
-              { onConflict: "user_id" }
-            );
-          }
+          const identity = await syncGithubMirrors(sb, authUser.id, authUser, {
+            githubUsername: profile.github_username,
+            githubId: profile.github_id,
+            socialGithub: socials?.github,
+          });
+          if (identity) profile.github_username = identity.username;
         }
 
         setUser({

--- a/src/lib/__tests__/github-identity.test.ts
+++ b/src/lib/__tests__/github-identity.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import type { User } from "@supabase/supabase-js";
+
+import {
+  readGithubIdentity,
+  syncGithubMirrors,
+  type MirrorClient,
+} from "@/lib/github-identity";
+
+type Call = { table: string; op: "update" | "upsert"; payload: unknown };
+
+/**
+ * Stands in for PostgREST's builder, which is *lazy*: the request is issued
+ * inside `then()`, so a query nobody awaits never leaves the browser. Recording
+ * on `then` rather than on the method call is the whole point — it is what
+ * makes these tests fail if the `await` is ever dropped again.
+ */
+function lazyResult(record: () => void, error: { message: string } | null) {
+  return {
+    then(
+      onFulfilled: (v: { error: typeof error }) => unknown,
+      onRejected?: (e: unknown) => unknown,
+    ) {
+      record();
+      return Promise.resolve({ error }).then(onFulfilled, onRejected);
+    },
+  };
+}
+
+function fakeClient(error: { message: string } | null = null) {
+  const calls: Call[] = [];
+  const client = {
+    from(table: string) {
+      return {
+        update(payload: unknown) {
+          return {
+            eq: () =>
+              lazyResult(
+                () => calls.push({ table, op: "update", payload }),
+                error,
+              ),
+          };
+        },
+        upsert(payload: unknown) {
+          return lazyResult(
+            () => calls.push({ table, op: "upsert", payload }),
+            error,
+          );
+        },
+      };
+    },
+  };
+  return { client: client as unknown as MirrorClient, calls };
+}
+
+/** A UserIdentity with the bookkeeping fields Supabase always sends. */
+function identity(provider: string, data: Record<string, unknown>) {
+  return {
+    id: `${provider}-id`,
+    user_id: "u1",
+    identity_id: `${provider}-identity`,
+    provider,
+    identity_data: data,
+  };
+}
+
+function user(
+  over: { identities?: unknown; user_metadata?: Record<string, unknown> } = {},
+): User {
+  return {
+    id: "u1",
+    identities: [identity("github", { user_name: "octocat", sub: "583231" })],
+    user_metadata: {},
+    ...over,
+  } as unknown as User;
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("readGithubIdentity", () => {
+  it("reads the handle and numeric id from the identity", () => {
+    expect(readGithubIdentity(user())).toEqual({
+      username: "octocat",
+      id: 583231,
+    });
+  });
+
+  // The bug this guards: user_metadata outlives unlinkIdentity, so a builder
+  // who disconnected GitHub had the handle written straight back.
+  it("returns null once the GitHub identity is gone, whatever metadata says", () => {
+    const unlinked = user({
+      identities: [identity("google", {})],
+      user_metadata: { user_name: "octocat", preferred_username: "octocat" },
+    });
+    expect(readGithubIdentity(unlinked)).toBeNull();
+  });
+
+  it("falls back through preferred_username then metadata", () => {
+    const viaPreferred = user({
+      identities: [identity("github", { preferred_username: "hubot" })],
+    });
+    expect(readGithubIdentity(viaPreferred)?.username).toBe("hubot");
+
+    const viaMetadata = user({
+      identities: [identity("github", {})],
+      user_metadata: { user_name: "hubot" },
+    });
+    expect(readGithubIdentity(viaMetadata)?.username).toBe("hubot");
+  });
+
+  it("treats a non-numeric or missing subject id as no id", () => {
+    const noId = user({
+      identities: [identity("github", { user_name: "octocat" })],
+    });
+    expect(readGithubIdentity(noId)).toEqual({ username: "octocat", id: null });
+
+    const badId = user({
+      identities: [
+        identity("github", { user_name: "octocat", sub: "not-a-number" }),
+      ],
+    });
+    expect(readGithubIdentity(badId)?.id).toBeNull();
+  });
+
+  it("ignores a blank handle rather than mirroring an empty string", () => {
+    const blank = user({
+      identities: [identity("github", { user_name: "   " })],
+      user_metadata: {},
+    });
+    expect(readGithubIdentity(blank)).toBeNull();
+  });
+
+  it("survives a user with no identities at all", () => {
+    expect(readGithubIdentity(null)).toBeNull();
+    expect(readGithubIdentity(user({ identities: undefined }))).toBeNull();
+  });
+});
+
+describe("syncGithubMirrors", () => {
+  // The original bug: both writes were issued without `await`, so neither ever
+  // reached the database while the page showed the handle as repaired.
+  it("actually issues the writes when both mirrors are empty", async () => {
+    const { client, calls } = fakeClient();
+    const identity = await syncGithubMirrors(client, "u1", user(), {
+      githubUsername: null,
+      githubId: null,
+      socialGithub: null,
+    });
+
+    expect(identity).toEqual({ username: "octocat", id: 583231 });
+    expect(calls).toEqual([
+      {
+        table: "users",
+        op: "update",
+        payload: { github_username: "octocat", github_id: 583231 },
+      },
+      {
+        table: "social_links",
+        op: "upsert",
+        payload: { user_id: "u1", github: "octocat" },
+      },
+    ]);
+  });
+
+  it("writes nothing when no GitHub identity is attached", async () => {
+    const { client, calls } = fakeClient();
+    const unlinked = user({
+      identities: [identity("google", {})],
+      user_metadata: { user_name: "octocat" },
+    });
+
+    expect(
+      await syncGithubMirrors(client, "u1", unlinked, {
+        githubUsername: null,
+        socialGithub: null,
+      }),
+    ).toBeNull();
+    expect(calls).toEqual([]);
+  });
+
+  it("fills only the gaps, leaving a mirror that is already set alone", async () => {
+    const { client, calls } = fakeClient();
+    await syncGithubMirrors(client, "u1", user(), {
+      githubUsername: "octocat",
+      githubId: 583231,
+      socialGithub: "octocat",
+    });
+    expect(calls).toEqual([]);
+  });
+
+  // github-sync's rename-versus-reclaim guard depends on the stored id, and the
+  // unique partial index would reject a conflicting one.
+  it("never overwrites a github_id that is already canonicalised", async () => {
+    const { client, calls } = fakeClient();
+    await syncGithubMirrors(client, "u1", user(), {
+      githubUsername: null,
+      githubId: 111,
+      socialGithub: "octocat",
+    });
+    expect(calls).toEqual([
+      {
+        table: "users",
+        op: "update",
+        payload: { github_username: "octocat" },
+      },
+    ]);
+  });
+
+  it("backfills only social_links when users is already correct", async () => {
+    const { client, calls } = fakeClient();
+    await syncGithubMirrors(client, "u1", user(), {
+      githubUsername: "octocat",
+      githubId: 583231,
+      socialGithub: null,
+    });
+    expect(calls).toEqual([
+      {
+        table: "social_links",
+        op: "upsert",
+        payload: { user_id: "u1", github: "octocat" },
+      },
+    ]);
+  });
+
+  it("reports a failed write instead of swallowing it", async () => {
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { client } = fakeClient({ message: "permission denied" });
+
+    const identity = await syncGithubMirrors(client, "u1", user(), {
+      githubUsername: null,
+      githubId: null,
+      socialGithub: null,
+    });
+
+    // Still returned, so the page renders with the right handle and retries.
+    expect(identity?.username).toBe("octocat");
+    expect(logged).toHaveBeenCalledTimes(2);
+    expect(logged.mock.calls.map((c) => c[0])).toEqual([
+      "github mirror: users update failed",
+      "github mirror: social_links upsert failed",
+    ]);
+  });
+});

--- a/src/lib/__tests__/github-identity.test.ts
+++ b/src/lib/__tests__/github-identity.test.ts
@@ -206,6 +206,21 @@ describe("syncGithubMirrors", () => {
     ]);
   });
 
+  // A row with a handle but no stable id sends github-sync down its username
+  // path, which resolves whoever owns that handle now. The id must still be
+  // filled from the live identity even though every other mirror looks correct.
+  it("still backfills a missing github_id when the handle is already set", async () => {
+    const { client, calls } = fakeClient();
+    await syncGithubMirrors(client, "u1", user(), {
+      githubUsername: "octocat",
+      githubId: null,
+      socialGithub: "octocat",
+    });
+    expect(calls).toEqual([
+      { table: "users", op: "update", payload: { github_id: 583231 } },
+    ]);
+  });
+
   it("backfills only social_links when users is already correct", async () => {
     const { client, calls } = fakeClient();
     await syncGithubMirrors(client, "u1", user(), {

--- a/src/lib/github-identity.ts
+++ b/src/lib/github-identity.ts
@@ -1,0 +1,126 @@
+// The one place that turns a Supabase auth identity into the GitHub handle the
+// rest of the app trusts.
+//
+// This logic used to live in four copies — /auth/callback, profile-setup,
+// dashboard and settings — and they had drifted into two different bugs:
+//
+//   * dashboard and settings fired their repair writes without awaiting them.
+//     A PostgREST builder is lazy (the fetch happens inside `then()`), so an
+//     un-awaited query never leaves the browser. Both pages patched their local
+//     copy on the next line, so the screen looked repaired while the database
+//     was never touched — the failure was invisible by construction.
+//   * dashboard and profile-setup derived the handle from `user_metadata`
+//     without checking that a GitHub identity was still attached. That metadata
+//     survives `unlinkIdentity`, so a builder who disconnected GitHub had the
+//     handle written straight back on their next page load.
+//
+// Keeping both rules in one function is the point: either one alone is wrong.
+
+import type { SupabaseClient, User } from "@supabase/supabase-js";
+
+export type GithubIdentity = {
+  username: string;
+  /**
+   * GitHub's stable numeric id, when the provider sent one. github-sync uses it
+   * to tell a legitimate rename apart from someone reclaiming a freed handle,
+   * so a missing value silently disables that guard.
+   */
+  id: number | null;
+};
+
+/** What the caller already has in the database, so we only write what is missing. */
+export type GithubMirrorState = {
+  githubUsername?: string | null;
+  githubId?: number | null;
+  socialGithub?: string | null;
+};
+
+// The pages hold clients typed against generated Database types that disagree
+// with each other, so this takes the loosest shape that still names the calls.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type MirrorClient = Pick<SupabaseClient<any, any, any>, "from">;
+
+function asHandle(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+/**
+ * The GitHub handle this account has actually proved, or null.
+ *
+ * Returns null unless a GitHub identity is currently attached, whatever
+ * `user_metadata` still remembers. `user_metadata` is only consulted as a
+ * fallback *for the handle itself*, because older identities predate Supabase
+ * copying `user_name` into `identity_data`.
+ */
+export function readGithubIdentity(
+  user: User | null | undefined,
+): GithubIdentity | null {
+  const identity = user?.identities?.find((i) => i.provider === "github");
+  if (!identity) return null;
+
+  const data = (identity.identity_data ?? {}) as Record<string, unknown>;
+  const metadata = (user?.user_metadata ?? {}) as Record<string, unknown>;
+  const username =
+    asHandle(data.user_name) ??
+    asHandle(data.preferred_username) ??
+    asHandle(metadata.user_name) ??
+    asHandle(metadata.preferred_username);
+  if (!username) return null;
+
+  // Lives in identity_data.sub (OIDC-style subject id, string-encoded).
+  const raw = data.sub ?? data.provider_id ?? null;
+  const parsed =
+    raw != null && /^\d+$/.test(String(raw)) ? Number(raw) : Number.NaN;
+
+  return { username, id: Number.isFinite(parsed) ? parsed : null };
+}
+
+/**
+ * Repair `users.github_username` / `users.github_id` / `social_links.github`
+ * from the live identity, and report the handle now in force.
+ *
+ * Only fills gaps. Reconciling a handle that changed on GitHub's side is
+ * github-sync's job — it holds the rename-versus-reclaim guard this does not.
+ *
+ * A failed write is logged rather than thrown: the caller's page is still
+ * usable with the returned handle, and the next load retries. It must never be
+ * swallowed silently, which is how the original bug survived.
+ */
+export async function syncGithubMirrors(
+  sb: MirrorClient,
+  userId: string,
+  user: User | null | undefined,
+  current: GithubMirrorState,
+): Promise<GithubIdentity | null> {
+  const identity = readGithubIdentity(user);
+  if (!identity) return null;
+
+  const userUpdates: Record<string, string | number> = {};
+  if (!current.githubUsername) userUpdates.github_username = identity.username;
+  // Backfilled once and never overwritten: a row that already carries an id has
+  // been canonicalised, and the unique partial index would reject a conflict.
+  if (current.githubId == null && identity.id !== null) {
+    userUpdates.github_id = identity.id;
+  }
+
+  if (Object.keys(userUpdates).length > 0) {
+    const { error } = await sb.from("users").update(userUpdates).eq("id", userId);
+    if (error) {
+      console.error("github mirror: users update failed", error.message);
+    }
+  }
+
+  if (!current.socialGithub) {
+    const { error } = await sb
+      .from("social_links")
+      .upsert(
+        { user_id: userId, github: identity.username },
+        { onConflict: "user_id" },
+      );
+    if (error) {
+      console.error("github mirror: social_links upsert failed", error.message);
+    }
+  }
+
+  return identity;
+}


### PR DESCRIPTION
Two funnel leaks, both measured on prod. 164 of 277 accounts (59%) have a linked GitHub, and the split is entirely by signup provider:

| Signed up with | Accounts | GitHub linked | Added a project |
|---|---|---|---|
| Google | 133 (48% of all) | **47%** | 20% |
| GitHub | 101 | **85%** | 47% |
| Email | 43 | **37%** | 14% |

## 1. The self-heal never ran

`dashboard/page.tsx` and `settings/page.tsx` both fired their repair writes without awaiting them:

```js
sb.from("users").update({ github_username: gh }).eq("id", id);
```

A PostgREST builder is **lazy** — `_fetch()` is called inside `then()` ([`PostgrestBuilder.ts:143`](https://github.com/supabase/postgrest-js/blob/master/src/PostgrestBuilder.ts)) — so a query nobody awaits never leaves the browser. Both pages patched their local copy on the very next line, so the screen looked repaired while the database was never touched. The failure was invisible by construction, which is why it survived.

Four accounts on prod carry a live GitHub identity in `auth.identities` with `users.github_username` NULL. `github-sync` reads that column, so all four sit at streak 0, vibe_score 10, 0 contributions — their `last_sign_in_at` is the exact minute they linked GitHub. One (`robin`) has an X handle, which means the dashboard never bounces them to `profile-setup?step=2`, the one copy of this code that did await its writes. Nothing can ever repair them.

## 2. Fixing that alone would have shipped a second bug

`dashboard` and `profile-setup` derived the handle from `user_metadata` **without** checking that a GitHub identity was still attached — unlike `settings` and `/auth/callback`, which gate correctly. `user_metadata` outlives `unlinkIdentity`, so a builder who disconnected GitHub would have had the handle written straight back on their next page load. It's harmless today only because the write never happens. Un-await-ing the one bug would have activated the other.

Both rules now live in `syncGithubMirrors`, replacing four divergent copies. Either rule alone is wrong, which is the argument for one implementation.

- Fills gaps only. Reconciling a handle that changed on GitHub's side stays `github-sync`'s job — it holds the rename-versus-reclaim guard this doesn't.
- `github_id` is backfilled once and never overwritten (the unique partial index would reject a conflict). Required widening `DASHBOARD_USER_FIELDS` by one column, which wasn't selecting it.
- Failed writes are logged, not swallowed.

The tests model PostgREST's laziness deliberately: the fake client records on `then`, not on the method call, so **dropping the `await` again fails them**.

## 3. "Recommended" was the wrong word

Profile setup hard-blocks on `if (!verifiedGithub)`, so GitHub is mandatory — but signup called it *"Recommended: auto-verifies your GitHub and syncs your streak"*. A Google signup only discovered it was required two steps in, after committing, and fewer than half ever came back. The page now states it before either choice, and flags it under the Google button too.

## Verification

- `eslint src` and `npx tsc --noEmit` clean
- 703 tests pass (51 files), 12 new for the helper
- Signup copy verified rendering in a browser against local dev

## Not included

The 4 stuck accounts still need a one-time backfill from `auth.identities` — that's a prod data write, so I've left it for @unknownking07 to approve separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub verification is now required before profiles go live, supporting verified commit-based vibe scores.
  * Added clearer messaging that GitHub access is read-only and the app will not modify code or accounts.
  * Google sign-up users are now informed that they must connect GitHub before completing their profile.

* **Improvements**
  * GitHub identity details are synchronized more consistently across profile setup, dashboard, and settings.
  * Existing verified GitHub information is preserved while missing details are filled in when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->