### PR TITLE
feat(homepage): make every builder row on the proof wall open their profile

### DIFF
--- a/src/components/homepage/proof-wall-hero.tsx
+++ b/src/components/homepage/proof-wall-hero.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { Info } from "@phosphor-icons/react/dist/ssr";
 import type { ProofWallData } from "@/lib/supabase/server-queries";
 import { ProofWallStats } from "@/components/homepage/proof-wall-stats";
 
@@ -55,7 +56,7 @@ export function ProofWallHero({
         </h1>
         <p className="text-sm sm:text-base text-[var(--text-secondary)] font-medium leading-relaxed lg:pb-2">
           Every square below is a day a builder shipped, read straight from
-          GitHub. Hover any square for the builder, the day, and the commits — click the row to open their profile.
+          GitHub. Hover any square for the builder, the day, and the commits.
           This is what you build here. It&apos;s also what you hire on.
         </p>
       </div>
@@ -113,6 +114,16 @@ export function ProofWallHero({
             );
           })}
         </div>
+        {/* Sits under the wall rather than in the explainer copy above it,
+            because that is where the affordance is. Always visible, not behind
+            a hover: a hint you have to discover does not fix discoverability.
+            It names the row as the unit on purpose — the wall reads as loose
+            dots, so "click a dot" is the wrong mental model for what is really
+            one builder per row. */}
+        <p className="mt-3 flex items-center justify-end gap-1.5 text-[11px] font-medium text-[var(--text-muted)]">
+          <Info size={13} weight="fill" aria-hidden="true" className="shrink-0" />
+          Each row is one builder. Click anywhere on it to open their profile.
+        </p>
         <p className="sr-only">
           Activity wall: the last {days.length} days of verified GitHub shipping
           activity from the {rows.length} most active builders on VibeTalent.

--- a/src/components/homepage/proof-wall-hero.tsx
+++ b/src/components/homepage/proof-wall-hero.tsx
@@ -55,7 +55,7 @@ export function ProofWallHero({
         </h1>
         <p className="text-sm sm:text-base text-[var(--text-secondary)] font-medium leading-relaxed lg:pb-2">
           Every square below is a day a builder shipped, read straight from
-          GitHub. Hover any square for the builder, the day, and the commits.
+          GitHub. Hover any square for the builder, the day, and the commits — click the row to open their profile.
           This is what you build here. It&apos;s also what you hire on.
         </p>
       </div>
@@ -72,30 +72,51 @@ export function ProofWallHero({
           borderBottom: "1px solid var(--border-subtle)",
         }}
       >
-        <div className="flex justify-end gap-[3px] overflow-hidden" aria-hidden>
-          {days.map((day) => (
-            <div key={day} className="flex flex-col gap-[3px] shrink-0">
-              {rows.map((row) => {
-                const commits = row.cells[day];
-                return (
-                  <div
-                    key={row.username}
-                    className="w-[11px] h-[11px] sm:w-[14px] sm:h-[14px] rounded-[2px]"
-                    style={{ backgroundColor: shadeFor(commits) }}
-                    title={
-                      commits
-                        ? `@${row.username} · ${prettyDate(day)} · ${commits} ${commits === 1 ? "commit" : "commits"}`
-                        : undefined
-                    }
-                  />
-                );
-              })}
-            </div>
-          ))}
+        {/* One link per builder, not per square. The wall reads as a grid of
+            days but every square in a row belongs to the same person, so 560
+            anchors would all point at the same 8 places — and Next would
+            prefetch each one. A row-level link keeps the identical click
+            target, gives a screen reader 8 named destinations instead of a
+            wall of unlabelled cells, and is why the grid is built row-first
+            here rather than column-first.
+
+            Not aria-hidden any more, which it was while it was decorative:
+            hiding focusable links from assistive tech makes them reachable by
+            keyboard but invisible to the user driving it. */}
+        <div className="flex flex-col gap-[3px] overflow-hidden">
+          {rows.map((row) => {
+            const activeDays = days.filter((day) => row.cells[day]).length;
+            return (
+              <Link
+                key={row.username}
+                href={`/profile/${row.username}`}
+                prefetch={false}
+                aria-label={`@${row.username} — shipped on ${activeDays} of the last ${days.length} days. View profile.`}
+                className="flex justify-end gap-[3px] rounded-[3px] transition-opacity hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)]"
+              >
+                {days.map((day) => {
+                  const commits = row.cells[day];
+                  return (
+                    <div
+                      key={day}
+                      className="w-[11px] h-[11px] sm:w-[14px] sm:h-[14px] shrink-0 rounded-[2px]"
+                      style={{ backgroundColor: shadeFor(commits) }}
+                      title={
+                        commits
+                          ? `@${row.username} · ${prettyDate(day)} · ${commits} ${commits === 1 ? "commit" : "commits"}`
+                          : undefined
+                      }
+                    />
+                  );
+                })}
+              </Link>
+            );
+          })}
         </div>
         <p className="sr-only">
           Activity wall: the last {days.length} days of verified GitHub shipping
           activity from the {rows.length} most active builders on VibeTalent.
+          Each row links to that builder&apos;s profile.
         </p>
       </div>
 


### PR DESCRIPTION
The proof wall already named the builder on hover — `@aaron · Jul 15 · 52 commits` — and then gave you nowhere to go with that. Every square is a real person shipping, so the obvious next move is to look at them.

## Linked per row, not per square

The wall reads as a grid of days, but **every square in a row belongs to the same builder**. 560 per-square anchors would all point at the same 8 destinations, and Next would prefetch each one. A row-level link:

- keeps an identical click target (the whole row was always one person)
- ships 8 anchors instead of 560, with `prefetch={false}`
- gives a screen reader 8 named destinations instead of a wall of unlabelled cells

That's why the grid is now built **row-first**. It was column-first (one flex column per day), which scattered a builder's squares across 70 separate parents and made a single link around them impossible. Same gaps, same `justify-end`, same fractional sizing — the rendering is unchanged.

## Accessibility

Dropped `aria-hidden` from the wall. It was correct while the wall was decorative, but leaving it on top of focusable links makes them reachable by keyboard and invisible to the person driving that keyboard. Each row now carries its own label — `@aaron — shipped on 69 of the last 70 days. View profile.` — and the `sr-only` summary says the rows are links. Added a visible `focus-visible` outline and a hover fade so the affordance is discoverable by mouse too.

Per-square hover titles are untouched.

## Verification

Driven in a browser against local dev:

- 8 row links, 70 squares each, hrefs `/profile/karan`, `/profile/aaron`, … `/profile/ugxships`
- clicking the exact square from the report (`@aaron · Jul 15 · 52 commits`) navigates to `/profile/aaron`
- per-square tooltips intact (`@karan · Jul 5 · 35 commits`)
- wall renders pixel-identical to before at 1280px
- `eslint src` + `npx tsc --noEmit` clean, 703 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)