### PR TITLE
fix(onboarding): stop requiring a contact handle nobody reads

### DIFF
--- a/src/app/auth/profile-setup/page.tsx
+++ b/src/app/auth/profile-setup/page.tsx
@@ -325,10 +325,14 @@ export default function ProfileSetupPage() {
     }
     const twitter = twitterResult.handle;
     const telegram = telegramResult.handle;
-    if (!twitter && !telegram) {
-      setError("Please add your X (Twitter) or Telegram so clients can contact you.");
-      return;
-    }
+    // Deliberately NOT required. This gate used to block anyone without an X
+    // or Telegram handle, on the reasoning that clients need a way to reach
+    // you — but /api/hire notifies a builder by email and an in-app
+    // notification and never reads either handle, so it was defending a path
+    // that does not use it. It was holding 17 GitHub-verified builders out of
+    // their own dashboard, 3 of whom had already shipped a project, against a
+    // hire flow with 3 requests ever. GitHub stays mandatory: that one is the
+    // verification the whole profile rests on.
     // Reflect cleaned values back so the user sees the bare handle if they
     // pasted a profile URL.
     setSocials((s) => ({ ...s, twitter, telegram }));
@@ -649,7 +653,7 @@ export default function ProfileSetupPage() {
             Social Links
           </h2>
           <p className="text-xs text-[var(--text-secondary)] font-medium">
-            GitHub required + X or Telegram so clients can reach you
+            GitHub verifies your work. The rest is optional.
           </p>
         </div>
       </div>
@@ -717,7 +721,7 @@ export default function ProfileSetupPage() {
           type="text"
           value={socials.twitter}
           onChange={(e) => setSocials({ ...socials, twitter: e.target.value })}
-          placeholder="X / Twitter handle or profile link"
+          placeholder="X / Twitter handle (optional)"
           className="input-brutal w-full"
         />
       </div>
@@ -728,7 +732,7 @@ export default function ProfileSetupPage() {
           type="text"
           value={socials.website}
           onChange={(e) => setSocials({ ...socials, website: e.target.value })}
-          placeholder="https://your-website.com"
+          placeholder="https://your-website.com (optional)"
           className="input-brutal w-full"
         />
       </div>
@@ -739,7 +743,7 @@ export default function ProfileSetupPage() {
           type="text"
           value={socials.telegram}
           onChange={(e) => setSocials({ ...socials, telegram: e.target.value })}
-          placeholder="Telegram username or t.me link"
+          placeholder="Telegram username (optional)"
           className="input-brutal w-full"
         />
       </div>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -258,11 +258,12 @@ export default function DashboardPage() {
         }
       }
 
-      // Enforce mandatory socials: GitHub + (X or Telegram)
+      // GitHub is the only mandatory link. A missing contact handle used to
+      // bounce people back here too, which locked GitHub-verified builders out
+      // of their own dashboard over a field /api/hire never reads — it reaches
+      // a builder by email and in-app notification.
       const hasGithub = socials?.github?.trim();
-      const hasTwitter = socials?.twitter?.trim();
-      const hasTelegram = socials?.telegram?.trim();
-      if (!hasGithub || (!hasTwitter && !hasTelegram)) {
+      if (!hasGithub) {
         window.location.href = "/auth/profile-setup?step=2";
         return;
       }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -257,10 +257,14 @@ export default function SettingsPage() {
     }
     const twitter = twitterResult.handle;
     const telegram = telegramResult.handle;
-    if (!twitter && !telegram) {
-      alert("Please add your X (Twitter) or Telegram so clients can contact you.");
-      return;
-    }
+    // Deliberately NOT required. This gate used to block anyone without an X
+    // or Telegram handle, on the reasoning that clients need a way to reach
+    // you — but /api/hire notifies a builder by email and an in-app
+    // notification and never reads either handle, so it was defending a path
+    // that does not use it. It was holding 17 GitHub-verified builders out of
+    // their own dashboard, 3 of whom had already shipped a project, against a
+    // hire flow with 3 requests ever. GitHub stays mandatory: that one is the
+    // verification the whole profile rests on.
     // Canonicalize the website URL so the DB stores `https://...` form. The
     // onboarding write path already does this; the settings save bypassed it
     // and could re-introduce bare-domain values that render as relative paths.


### PR DESCRIPTION
Step 2 required GitHub **and** an X or Telegram handle, on the reasoning that clients need a way to reach you.

**They don't use it.** `/api/hire` notifies a builder by email plus an in-app notification ([`route.ts:110`](../blob/main/src/app/api/hire/route.ts)) and never reads either handle. The gate was defending a path that doesn't touch it.

## What it cost

Measured on prod:

| | |
|---|---|
| Accounts held at step 2 | **51** |
| …GitHub-verified, blocked by nothing but the contact field | **17** |
| …who had already shipped a project and still couldn't reach their dashboard | **3** |
| Hire requests the gate was protecting | **3 ever**, most recent 2026-06-17 |

Three people did every single thing the product asks — verified GitHub, shipped a project — and a contact field locked them out of their own dashboard, to protect a flow that has fired three times in the product's life and not once in three months.

## What changed

GitHub stays mandatory. It's the verification the whole profile rests on and the only claim the product actually makes. A contact handle is a preference, and preferences don't belong in a wall.

Removed in all three places that enforced it:

- `profile-setup` — the hard stop on Next
- `settings` — the same gate on Save
- `dashboard` — the redirect that bounced people back to `?step=2`

Step 2 copy now says what it enforces (`GitHub verifies your work. The rest is optional.`) and the optional fields are labelled as such.

## Verification

`eslint src` and `npx tsc --noEmit` clean, 704 tests pass.

Note: the authenticated step-2 flow can't be driven in a signed-out browser, so this rests on the type/lint/test pass and on the change being the removal of three guard clauses. The 17 blocked builders are unblocked on their next visit; nothing needs backfilling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)